### PR TITLE
Fix yarn build throwing type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-toolchain/*.js
-toolchain/*/*.js
+*.js
 *.map
-lib/
+dist/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "An open-source interpreter for The Source",
   "dependencies": {
-    "acorn": "^5.1.2",
+    "acorn": "^5.7.1",
     "astring": "^1.2.0",
     "babel-cli": "^6.26.0",
     "commander": "^2.14.1",
@@ -15,7 +15,7 @@
     "slang": "slang.js"
   },
   "scripts": {
-    "build": "tsc; babel toolchain -d lib",
+    "build": "tsc",
     "test": "jest"
   },
   "repository": {
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/source-academy/js-slang",
   "devDependencies": {
-    "@types/acorn": "^4.0.2",
+    "@types/acorn": "^4.0.3",
     "@types/common-tags": "^1.4.0",
-    "@types/estree": "0.0.37",
+    "@types/estree": "0.0.39",
     "@types/invariant": "^2.2.29",
     "@types/jest": "^23.1.4",
     "@types/node": "^9.4.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "./dist",
     "module": "esnext",
     "target": "es2016",
     "lib": [
@@ -12,8 +13,8 @@
     "allowJs": false,
     "removeComments": false,
     "allowSyntheticDefaultImports": true,
-    "jsx": "react",
     "moduleResolution": "node",
+    "rootDir": "toolchain",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/acorn@^4.0.2":
+"@types/acorn@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.3.tgz#d1f3e738dde52536f9aad3d3380d14e448820afd"
   dependencies:
@@ -26,13 +26,9 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.4.0.tgz#28c1be61e352dde38936018984e2885caef087c1"
 
-"@types/estree@*":
+"@types/estree@*", "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-
-"@types/estree@0.0.37":
-  version "0.0.37"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.37.tgz#48949c1516d46139c1e521195f9e12993b69d751"
 
 "@types/invariant@^2.2.29":
   version "2.2.29"
@@ -60,7 +56,7 @@ acorn-globals@^4.1.0:
   dependencies:
     acorn "^5.0.0"
 
-acorn@^5.0.0, acorn@^5.1.2, acorn@^5.3.0:
+acorn@^5.0.0, acorn@^5.3.0, acorn@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 


### PR DESCRIPTION
Had to upgrade the version for @types/estree. Also upgraded some other dependencies, and changed build behaviour to point to dist/.