### PR TITLE
Add curried function for display

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -118,13 +118,8 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
     defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext, externalBuiltIns.display))
     // previously week 5
     defineSymbol(context, 'assoc', list.assoc)
-    if (window.hasOwnProperty('ListVisualizer')) {
-      defineSymbol(context, 'draw', (window as any).ListVisualizer.draw)
-    } else {
-      defineSymbol(context, 'draw', () => {
-        throw new Error('List visualizer is not enabled')
-      })
-    }
+    defineSymbol(context, 'draw', 
+      (list: any) => externalBuiltIns.visualiseList(list, context.externalContext))
     // previously week 6
     defineSymbol(context, 'is_number', misc.is_number)
     // previously week 8

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -141,7 +141,9 @@ const defaultBuiltIns: CustomBuiltIns = {
   // See issue #5
   prompt: (v: Value, e: any) => toString(v),
   // See issue #11
-  alert: misc.display
+  alert: misc.display,
+  visualiseList: (list: any) => {
+    throw new Error('List visualizer is not enabled')}
 }
 
 const createContext = <T>(chapter = 1, externals = [], externalContext?: T, 

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -55,16 +55,31 @@ export const importExternals = (context: Context, externals: string[]) => {
   })
 }
 
+/**
+ * Imports builtins from standard and external libraries.
+ *
+ * For externalBuiltIns that need to be curried, the __SOURCE__
+ * property must be defined in the currying function.
+ */
 export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIns) => {
   ensureGlobalEnvironmentExist(context)
 
+  /* Defining the __SOURCE__ property in the curried functions. */
+  let display = (v: Value) => externalBuiltIns.display(v, context.externalContext)
+  display.__SOURCE__ = externalBuiltIns.display.__SOURCE__
+  let prompt = (v: Value) => externalBuiltIns.prompt(v, context.externalContext)
+  prompt.__SOURCE__ = externalBuiltIns.prompt.__SOURCE__
+  let alert = (v: Value) => externalBuiltIns.alert(v, context.externalContext)
+  alert.__SOURCE__ = externalBuiltIns.alert.__SOURCE__
+  let visualiseList = (list: any) => externalBuiltIns.visualiseList(list, context.externalContext)
+  visualiseList.__SOURCE__ = externalBuiltIns.visualiseList.__SOURCE__
+ 
+
   if (context.chapter >= 1) {
     defineSymbol(context, 'runtime', misc.runtime)
-    defineSymbol(context, 'display', 
-      (v: Value) => externalBuiltIns.display(v, context.externalContext))
+    defineSymbol(context, 'display', display)
     defineSymbol(context, 'error', misc.error_message)
-    defineSymbol(context, 'prompt', 
-      (v: Value) => externalBuiltIns.prompt(v, context.externalContext))
+    defineSymbol(context, 'prompt', prompt)
     defineSymbol(context, 'parse_int', misc.parse_int)
     defineSymbol(context, 'undefined', undefined)
     defineSymbol(context, 'NaN', NaN)
@@ -111,15 +126,13 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 
   if (context.chapter >= Infinity) {
     // previously week 4
-    defineSymbol(context, 'alert', 
-      (v: Value) => externalBuiltIns.alert(v, context.externalContext))
+    defineSymbol(context, 'alert', alert)
     defineSymbol(context, 'math_floor', Math.floor)
     // tslint:disable-next-line:ban-types
     defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext, externalBuiltIns.display))
     // previously week 5
     defineSymbol(context, 'assoc', list.assoc)
-    defineSymbol(context, 'draw', 
-      (list: any) => externalBuiltIns.visualiseList(list, context.externalContext))
+    defineSymbol(context, 'draw', visualiseList)
     // previously week 6
     defineSymbol(context, 'is_number', misc.is_number)
     // previously week 8

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -60,9 +60,11 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 
   if (context.chapter >= 1) {
     defineSymbol(context, 'runtime', misc.runtime)
-    defineSymbol(context, 'display', (v: Value) => externalBuiltIns.display(v, context.externalContext))
+    defineSymbol(context, 'display', 
+      (v: Value) => externalBuiltIns.display(v, context.externalContext))
     defineSymbol(context, 'error', misc.error_message)
-    defineSymbol(context, 'prompt', externalBuiltIns.prompt)
+    defineSymbol(context, 'prompt', 
+      (v: Value) => externalBuiltIns.prompt(v, context.externalContext))
     defineSymbol(context, 'parse_int', misc.parse_int)
     defineSymbol(context, 'undefined', undefined)
     defineSymbol(context, 'NaN', NaN)
@@ -109,7 +111,8 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 
   if (context.chapter >= Infinity) {
     // previously week 4
-    defineSymbol(context, 'alert', alert)
+    defineSymbol(context, 'alert', 
+      (v: Value) => externalBuiltIns.alert(v, context.externalContext))
     defineSymbol(context, 'math_floor', Math.floor)
     // tslint:disable-next-line:ban-types
     defineSymbol(context, 'timed', (f: Function) => misc.timed(context, f, context.externalContext, externalBuiltIns.display))
@@ -136,7 +139,9 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 const defaultBuiltIns: CustomBuiltIns = {
   display: misc.display,
   // See issue #5
-  prompt: (v: Value) => toString(v)
+  prompt: (v: Value, e: any) => toString(v),
+  // See issue #11
+  alert: misc.display
 }
 
 const createContext = <T>(chapter = 1, externals = [], externalContext?: T, 

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -60,7 +60,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 
   if (context.chapter >= 1) {
     defineSymbol(context, 'runtime', misc.runtime)
-    defineSymbol(context, 'display', externalBuiltIns.display)
+    defineSymbol(context, 'display', (v: Value) => externalBuiltIns.display(v, context.externalContext))
     defineSymbol(context, 'error', misc.error_message)
     defineSymbol(context, 'prompt', externalBuiltIns.prompt)
     defineSymbol(context, 'parse_int', misc.parse_int)

--- a/src/stdlib/list.ts
+++ b/src/stdlib/list.ts
@@ -14,7 +14,7 @@ declare global {
 // Author: Martin Henz
 // Translated to TypeScript by Evan Sebastian
 
-type List = Value[]
+export type List = Value[]
 
 // array test works differently for Rhino and
 // the Firefox environment (especially Web Console)

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,8 @@ import { closureToJS } from './interop'
  */
 export interface CustomBuiltIns {
   display: (value: Value, externalContext: any) => void,
-  prompt: (value: Value) => string | null
+  prompt: (value: value) => string | null,
+  alert: (value: value) => null
 }
 
 export enum ErrorType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface CustomBuiltIns {
   prompt: (value: Value, externalContext: any) => string | null,
   alert: (value: Value, externalContext: any) => void,
   /* Used for list visualisation. See #12 */
-  visualiseList: (list: any, externalContext: any) => null
+  visualiseList: (list: any, externalContext: any) => void
 }
 
 export enum ErrorType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,7 +203,7 @@ export interface Finished {
   value: Value
 }
 
-interface Suspended {
+export interface Suspended {
   status: 'suspended'
   it: IterableIterator<Value>
   scheduler: Scheduler

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ import { closureToJS } from './interop'
  */
 export interface CustomBuiltIns {
   display: (value: Value, externalContext: any) => void,
-  prompt: (value: value, externalContext: any) => string | null,
-  alert: (value: value, externalContext: any) => void,
+  prompt: (value: Value, externalContext: any) => string | null,
+  alert: (value: Value, externalContext: any) => void,
   /* Used for list visualisation. See #12 */
   visualiseList: (list: any, externalContext: any) => null
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,10 @@ import { closureToJS } from './interop'
  */
 export interface CustomBuiltIns {
   display: (value: Value, externalContext: any) => void,
-  prompt: (value: value) => string | null,
-  alert: (value: value) => null
+  prompt: (value: value, externalContext: any) => string | null,
+  alert: (value: value, externalContext: any) => null,
+  /* Used for list visualisation. See #12 */
+  visualiseList: (list: any, externalContext: any) => null
 }
 
 export enum ErrorType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ import { closureToJS } from './interop'
 export interface CustomBuiltIns {
   display: (value: Value, externalContext: any) => void,
   prompt: (value: value, externalContext: any) => string | null,
-  alert: (value: value, externalContext: any) => null,
+  alert: (value: value, externalContext: any) => void,
   /* Used for list visualisation. See #12 */
   visualiseList: (list: any, externalContext: any) => null
 }


### PR DESCRIPTION
Must have accidentally changed it when incorporating externalBuiltIns.

### Features
- Fixed display
- Added externalContext parameter for all externalBuiltIns
- Added alert, visualiseList function
- Fix typescript errors on exporting a function, but not exporting a related type that it uses