### PR TITLE
Move @types/acorn and @types/estree to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "url": "https://github.com/source-academy/"
   },
   "dependencies": {
+    "@types/acorn": "^4.0.3",
+    "@types/estree": "0.0.39",
     "acorn": "^5.7.1",
     "astring": "^1.2.0",
     "commander": "^2.14.1",
@@ -32,9 +34,7 @@
   },
   "homepage": "https://github.com/source-academy/js-slang",
   "devDependencies": {
-    "@types/acorn": "^4.0.3",
     "@types/common-tags": "^1.4.0",
-    "@types/estree": "0.0.39",
     "@types/invariant": "^2.2.29",
     "@types/jest": "^23.1.4",
     "@types/node": "^9.4.7",


### PR DESCRIPTION
Fixes the following errors when `js-slang` is used as a node module in some other typescript project.

```
node_modules/js-slang/dist/types.d.ts(1,23): error TS2688: Cannot find type definition file for 'acorn'.
node_modules/js-slang/dist/types.d.ts(2,32): error TS7016: Could not find a declaration file for module 'acorn'. '/home/ning/github/grader/node_modules/acorn/dist/acorn.js' implicitly has an 'any' type.
  Try `npm install @types/acorn` if it exists or add a new declaration (.d.ts) file containing `declare module 'acorn';`
node_modules/js-slang/dist/types.d.ts(3,21): error TS2307: Cannot find module 'estree'.
```