### PR TITLE
Prevent 'never' type inference for externals

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -154,7 +154,7 @@ const defaultBuiltIns: CustomBuiltIns = {
     throw new Error('List visualizer is not enabled')}
 }
 
-const createContext = <T>(chapter = 1, externals = [], externalContext?: T, 
+const createContext = <T>(chapter = 1, externals: string[] = [], externalContext?: T, 
   externalBuiltIns: CustomBuiltIns = defaultBuiltIns) => {
   const context = createEmptyContext(chapter, externalContext)
 


### PR DESCRIPTION
### Features
- Due to the way typescript infers types, the default argument, `[]`, was being inferred as `never[]`. This is the compiled `createContext.d.ts`:
```
declare const createContext: <T>(chapter?: number, externals?: never[], ...
```
- Added an explicit type to allow strings