### PR TITLE
Store external symbols

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -47,7 +47,7 @@ const defineSymbol = (context: Context, name: string, value: Value) => {
   globalFrame.environment[name] = value
 }
 
-export const importExternals = (context: Context, externals: string[]) => {
+export const importExternalSymbols = (context: Context, externals: string[]) => {
   ensureGlobalEnvironmentExist(context)
 
   externals.forEach(symbol => {
@@ -159,7 +159,7 @@ const createContext = <T>(chapter = 1, externals: string[] = [], externalContext
   const context = createEmptyContext(chapter, externalContext)
 
   importBuiltins(context, externalBuiltIns)
-  importExternals(context, externals)
+  importExternalSymbols(context, externals)
 
   return context
 }

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -18,8 +18,9 @@ const createEmptyRuntime = () => ({
   nodes: []
 })
 
-export const createEmptyContext = <T>(chapter: number, externalContext?: T): Context<T> => ({
+export const createEmptyContext = <T>(chapter: number, externalSymbols: string[], externalContext?: T): Context<T> => ({
   chapter,
+  externalSymbols,
   errors: [],
   externalContext,
   cfg: createEmptyCFG(),
@@ -156,7 +157,7 @@ const defaultBuiltIns: CustomBuiltIns = {
 
 const createContext = <T>(chapter = 1, externalSymbols: string[] = [], externalContext?: T, 
   externalBuiltIns: CustomBuiltIns = defaultBuiltIns) => {
-  const context = createEmptyContext(chapter, externalContext)
+  const context = createEmptyContext(chapter, externalSymbols, externalContext)
 
   importBuiltins(context, externalBuiltIns)
   importExternalSymbols(context, externalSymbols)

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -47,10 +47,10 @@ const defineSymbol = (context: Context, name: string, value: Value) => {
   globalFrame.environment[name] = value
 }
 
-export const importExternalSymbols = (context: Context, externals: string[]) => {
+export const importExternalSymbols = (context: Context, externalSymbols: string[]) => {
   ensureGlobalEnvironmentExist(context)
 
-  externals.forEach(symbol => {
+  externalSymbols.forEach(symbol => {
     defineSymbol(context, symbol, GLOBAL[symbol])
   })
 }
@@ -154,12 +154,12 @@ const defaultBuiltIns: CustomBuiltIns = {
     throw new Error('List visualizer is not enabled')}
 }
 
-const createContext = <T>(chapter = 1, externals: string[] = [], externalContext?: T, 
+const createContext = <T>(chapter = 1, externalSymbols: string[] = [], externalContext?: T, 
   externalBuiltIns: CustomBuiltIns = defaultBuiltIns) => {
   const context = createEmptyContext(chapter, externalContext)
 
   importBuiltins(context, externalBuiltIns)
-  importExternalSymbols(context, externals)
+  importExternalSymbols(context, externalSymbols)
 
   return context
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,9 @@ export interface Context<T = any> {
   /** The source version used */
   chapter: number
 
+  /** The external symbols that exist in the Context. */
+  externalSymbols: string[]
+
   /** All the errors gathered */
   errors: SourceError[]
 


### PR DESCRIPTION
### Features
- Renamed `externals` -> `externalSymbols`
- Stored `externalSymbols` just as we store `chapter`. This ensures accountability (one could check what external symbols were introduced) and allows a cleaner reset of the context by providing access to the `externalSymbols`