### PR TITLE
Fix null and RegExp literal values being allowed

### DIFF
--- a/src/interop.ts
+++ b/src/interop.ts
@@ -77,6 +77,8 @@ export const toString = (value: Value, length = 0): string => {
     } else {
       return stripBody(value.toString())
     }
+  } else if (value === null) {
+    return 'null'
   } else {
     return value.toString()
   }

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -11,6 +11,7 @@ import noIfWithoutElse from './noIfWithoutElse'
 import noImplicitDeclareUndefined from './noImplicitDeclareUndefined'
 import noImplicitReturnUndefined from './noImplicitReturnUndefined'
 import noNonEmptyList from './noNonEmptyList'
+import noUnspecifiedLiteral from './noUnspecifiedLiteral'
 import noUnspecifiedOperator from './noUnspecifiedOperator'
 import singleVariableDeclaration from './singleVariableDeclaration'
 
@@ -25,6 +26,7 @@ const rules: Array<Rule<es.Node>> = [
   noBlockArrowFunction,
   noDeclareReserved,
   noDeclareMutable,
+  noUnspecifiedLiteral,
   noUnspecifiedOperator
 ]
 

--- a/src/rules/noUnspecifiedLiteral.ts
+++ b/src/rules/noUnspecifiedLiteral.ts
@@ -1,0 +1,48 @@
+import * as es from 'estree'
+
+import { ErrorSeverity, ErrorType, Rule, SourceError } from '../types'
+
+const specifiedLiterals = ['boolean', 'string', 'number']
+
+export class NoUnspecifiedLiteral implements SourceError {
+  public type = ErrorType.SYNTAX
+  public severity = ErrorSeverity.ERROR
+
+  constructor(public node: es.Literal) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    /** 
+     * A check is used for RegExp to ensure that only null and RegExp are caught.
+     * Any other unspecified literal value should not be caught.
+     */
+    const literal = this.node.value === null ? 'null' 
+      : this.node.value instanceof RegExp ? 'RegExp'
+      : ''
+    return (
+      `A literal '${literal}' value is not allowed. Only string, boolean, and number literal values are allowed.`
+    )
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}
+
+const noUnspecifiedLiteral: Rule<es.Literal> = {
+  name: 'no-unspecified-literal',
+  checkers: {
+    Literal(node: es.Literal) {
+      if (!specifiedLiterals.includes(typeof node.value)) {
+        return [new NoUnspecifiedLiteral(node)]
+      } else {
+        return []
+      }
+    }
+  }
+}
+
+export default noUnspecifiedLiteral

--- a/src/rules/noUnspecifiedLiteral.ts
+++ b/src/rules/noUnspecifiedLiteral.ts
@@ -23,7 +23,7 @@ export class NoUnspecifiedLiteral implements SourceError {
       : this.node.value instanceof RegExp ? 'RegExp'
       : ''
     return (
-      `A literal '${literal}' value is not allowed. Only string, boolean, and number literal values are allowed.`
+      `'${literal}' literals are not allowed`
     )
   }
 


### PR DESCRIPTION
### Features
- Added a rule that only allows specified literal values (string, number, boolean)

### Issues fixed
- Fixes #20 
- Fixes #30 