### PR TITLE
fix standalone block statement scoping

### DIFF
--- a/src/__tests__/__snapshots__/block_scoping.ts.snap
+++ b/src/__tests__/__snapshots__/block_scoping.ts.snap
@@ -38,6 +38,13 @@ Object {
 }
 `;
 
+exports[`standalone block statements 1`] = `
+Object {
+  "status": "finished",
+  "value": true,
+}
+`;
+
 exports[`while loops use block scoping instead of function scoping 1`] = `
 Object {
   "status": "finished",

--- a/src/__tests__/block_scoping.ts
+++ b/src/__tests__/block_scoping.ts
@@ -3,6 +3,27 @@ import { parseError, runInContext } from "../index";
 import { Finished } from "../types";
 
 // This is bad practice. Don't do this!
+test("standalone block statements", () => {
+  const code = `
+    function test(){
+      const x = true;
+      {
+          const x = false;
+      }
+      return x;
+    }
+    test();
+  `;
+  const context = mockContext();
+  const promise = runInContext(code, context, { scheduler: "preemptive" });
+  return promise.then(obj => {
+    expect(obj).toMatchSnapshot();
+    expect(obj.status).toBe("finished");
+    expect((obj as Finished).value).toBe(true);
+  });
+});
+
+// This is bad practice. Don't do this!
 test("const uses block scoping instead of function scoping", () => {
   const code = `
     function test(){


### PR DESCRIPTION
Fixed block statement scoping (so standalone block statements are now correctly scoped).

A downside now is that variables declared in loop blocks can now shadow loop variables, same as in ES6, but we should discourage this behaviour.
```
  function test(){
      for (let x = 0; x < 2; x = x + 1) {
        let x = 1;
        print(x);
      }
      return false;
  }
```