### PR TITLE
Disable UpdateExpression from Chapter 3

### DIFF
--- a/src/syntaxTypes.ts
+++ b/src/syntaxTypes.ts
@@ -29,9 +29,9 @@ const syntaxTypes: { [nodeName: string]: number } = {
   ObjectExpression: 3,
   MemberExpression: 3,
   Property: 3,
-  UpdateExpression: 3,
 
   // Week 5
+  UpdateExpression: 5,
   EmptyStatement: 5,
   // previously Week 10
   NewExpression: 10,


### PR DESCRIPTION
This is not a specified operator in the documentation, and should not be allowed. In addition, there is no support in the interpreter for handling this expression, so enabling this type of expression would require 
1. A change in the language specifications
2. Implementation of a handler for this expression