### PR TITLE
Bump version to v0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-slang",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Javascript-based interpreter for slang, written in Typescript",
   "author": {
     "name": "Source Academy",


### PR DESCRIPTION
- `yarn build` was not run properly, causing `parser.js` to be missing on pubish. 
- The file has been added, and this version is to push the change of adding the file back.