### PR TITLE
Refactor for statement check into rules

### DIFF
--- a/src/__tests__/__snapshots__/disallowed_syntax.ts.snap
+++ b/src/__tests__/__snapshots__/disallowed_syntax.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Cannot leave blank expressions in for loops 1`] = `"Line 2: For statement cannot have empty init expression."`;
+exports[`Cannot leave blank expressions in for loops 1`] = `"Line 2: Missing init expression in for statement."`;
 
-exports[`Cannot leave blank expressions in for loops 2`] = `"Line 2: For statement cannot have empty test expression."`;
+exports[`Cannot leave blank expressions in for loops 2`] = `"Line 2: Missing test expression in for statement."`;
 
-exports[`Cannot leave blank expressions in for loops 3`] = `"Line 2: For statement cannot have empty update expression."`;
+exports[`Cannot leave blank expressions in for loops 3`] = `"Line 2: Missing update expression in for statement."`;
 
-exports[`Cannot leave blank expressions in for loops 4`] = `"Line 2: For statement cannot have empty init,test,update expressions."`;
+exports[`Cannot leave blank expressions in for loops 4`] = `"Line 2: Missing init, test, update expressions in for statement."`;
 
 exports[`Cannot use update expressions 1`] = `"Line 3: Update expressions are not allowed"`;

--- a/src/interpreter-errors.ts
+++ b/src/interpreter-errors.ts
@@ -166,23 +166,3 @@ export class ConstAssignment implements SourceError {
     return 'TODO'
   }
 }
-
-export class EmptyForExpression implements SourceError {
-  public type = ErrorType.RUNTIME
-  public severity = ErrorSeverity.ERROR
-  public location: es.SourceLocation
-
-  constructor(node: es.Node, private missing: string[]) {
-    this.location = node.loc!
-  }
-
-  public explain() {
-    const exp = this.missing.length > 1 ? 'expressions': 'expression'
-    return `For statement cannot have empty ${this.missing.join(',')} ${exp}.`
-  }
-
-  public elaborate() {
-    return 'TODO'
-  }
-
-}

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -321,15 +321,6 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return new BreakValue()
   },
   ForStatement: function*(node: es.ForStatement, context: Context) {
-    // Check that all 3 expressions are not empty in a for loop
-    const missing_parts = ["init", "test", "update"].filter(
-      part => node[part] === null
-    );
-    if (missing_parts.length > 0) {
-      const error = new errors.EmptyForExpression(node, missing_parts);
-      handleError(context, error);
-    }
-
     // Create a new block scope for the loop variables
     const loopFrame = createBlockFrame(context, "forLoopFrame")
     pushFrame(context, loopFrame)

--- a/src/rules/forStatementMustHaveAllParts.ts
+++ b/src/rules/forStatementMustHaveAllParts.ts
@@ -1,0 +1,44 @@
+import { stripIndent } from 'common-tags'
+import * as es from 'estree'
+
+import { ErrorSeverity, ErrorType, Rule, SourceError } from '../types'
+
+export class ForStatmentMustHaveAllParts implements SourceError {
+  public type = ErrorType.SYNTAX
+  public severity = ErrorSeverity.ERROR
+
+  constructor(public node: es.ForStatement, private missingParts :string[]) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Missing ${this.missingParts.join(', ')} expression${this.missingParts.length === 1 ? '' : 's'} in for statement.`
+  }
+
+  public elaborate() {
+    return stripIndent`
+      This for statement requires all three parts (initialiser, test, update) to be present.
+    `
+  }
+}
+
+const forStatementMustHaveAllParts: Rule<es.ForStatement> = {
+  name: 'for-statement-must-have-all-parts',
+
+  checkers: {
+    ForStatement(node: es.ForStatement) {
+      const missingParts = ["init", "test", "update"].filter(
+        part => node[part] === null
+      );
+      if (missingParts.length > 0) {
+        return [new ForStatmentMustHaveAllParts(node, missingParts)]
+      } else {
+        return []
+      }
+    }
+  }
+}
+
+export default forStatementMustHaveAllParts

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -14,6 +14,7 @@ import noNonEmptyList from './noNonEmptyList'
 import noUnspecifiedLiteral from './noUnspecifiedLiteral'
 import noUnspecifiedOperator from './noUnspecifiedOperator'
 import singleVariableDeclaration from './singleVariableDeclaration'
+import forStatementMustHaveAllParts from './forStatementMustHaveAllParts'
 
 const rules: Array<Rule<es.Node>> = [
   bracesAroundIfElse,
@@ -27,7 +28,8 @@ const rules: Array<Rule<es.Node>> = [
   noDeclareReserved,
   noDeclareMutable,
   noUnspecifiedLiteral,
-  noUnspecifiedOperator
+  noUnspecifiedOperator,
+  forStatementMustHaveAllParts
 ]
 
 export default rules


### PR DESCRIPTION
The for statement requiring all 3 parts should be refactored out of the interpreter and into rules, avoiding duplication of such a check for the metacircular interpreter once it uses the same parser as the Source interpreter.