### PR TITLE
Only function DECLARATIONS need to come first in function bodies

### DIFF
--- a/doc/source_return.tex
+++ b/doc/source_return.tex
@@ -8,6 +8,6 @@ $\textbf{\texttt{return}}$ and $\textit{expression}$ in return statements.
   $(\ \textit{name}\ | \ \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\ )$
                                                and
 $\texttt{\textbf{=>}}$ in function definition expressions.
-\item Local functions within an outer function
+\item Local function declarations within an outer function
   must precede all other statements in body of the outer function.
 \end{itemize}


### PR DESCRIPTION
small clarification, regarding the restriction on placing local function declarations