### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-slang",
-  "version": "0.1.19",
+  "version": "0.2.0-alpha",
   "description": "Javascript-based interpreter for slang, written in Typescript",
   "author": {
     "name": "Source Academy",


### PR DESCRIPTION
We should start versioning these so we can test our changes not just on `jest` but also on `cadet-frontend`. I propose we stay on `0.1.20-alpha-x.y.z` until we're ready for next semester, which is when we should bump to `0.1.20`