### PR TITLE
Fix formatting of potential infinite recursion error messages

### DIFF
--- a/src/__tests__/native.ts
+++ b/src/__tests__/native.ts
@@ -2,6 +2,28 @@ import { stripIndent } from 'common-tags'
 import { parseError, runInContext } from '../index'
 import { mockContext } from '../mocks/context'
 
+test('Proper stringify-ing of arguments during potentially infinite iterative function calls', () => {
+  const code = stripIndent`
+    function f(x) {
+      return f(x);
+    }
+    const array = [1, 2, 3];
+    f(list(1, 2, f, () => 1, array));
+  `
+  const context = mockContext(4)
+  const promise = runInContext(code, context, { scheduler: 'preemptive', isNativeRunnable: true })
+  return promise.then(obj => {
+    const errors = parseError(context.errors)
+    expect(errors).toMatch(stripIndent`
+    Line 2: Potential infinite recursion detected: f([ 1,
+    [ 2,
+    [ function f(x) {
+        return f(x);
+      },
+    [() => 1, [[1, 2, 3], null]] ] ] ]) ...`)
+  })
+})
+
 test('test increasing time limit for functions', () => {
   const code = stripIndent`
     function f(a, b) {
@@ -16,7 +38,7 @@ test('test increasing time limit for functions', () => {
     const errors = parseError(context.errors)
     const timeTaken = Date.now() - start
     expect(errors).toMatch('Line 2: Potential infinite recursion detected')
-    expect(errors).toMatch(/f\(\d+,\d+\) \.\.\. f\(\d+,\d+\) \.\.\. f\(\d+,\d+\)/)
+    expect(errors).toMatch(/f\(\d+, \d+\) \.\.\. f\(\d+, \d+\) \.\.\. f\(\d+, \d+\)/)
     expect(timeTaken).toBeLessThan(2000)
     expect(timeTaken).toBeGreaterThanOrEqual(1000)
     const longerContext = mockContext()
@@ -28,7 +50,7 @@ test('test increasing time limit for functions', () => {
       const longerErrors = parseError(longerContext.errors)
       const longerTimeTaken = Date.now() - start
       expect(longerErrors).toMatch('Line 2: Potential infinite recursion detected')
-      expect(errors).toMatch(/f\(\d+,\d+\) \.\.\. f\(\d+,\d+\) \.\.\. f\(\d+,\d+\)/)
+      expect(errors).toMatch(/f\(\d+, \d+\) \.\.\. f\(\d+, \d+\) \.\.\. f\(\d+, \d+\)/)
       expect(longerTimeTaken).toBeLessThan(20000)
       expect(longerTimeTaken).toBeGreaterThanOrEqual(10000)
     })
@@ -52,7 +74,7 @@ test('test increasing time limit for mutual recursion', () => {
     const errors = parseError(context.errors)
     const timeTaken = Date.now() - start
     expect(errors).toMatch(/Line [52]: Potential infinite recursion detected/)
-    expect(errors).toMatch(/f\(\d+,\d+\) \.\.\. g\(\d+,\d+\)/)
+    expect(errors).toMatch(/f\(\d+, \d+\) \.\.\. g\(\d+, \d+\)/)
     expect(timeTaken).toBeLessThan(2000)
     expect(timeTaken).toBeGreaterThanOrEqual(1000)
     const longerContext = mockContext()
@@ -64,7 +86,7 @@ test('test increasing time limit for mutual recursion', () => {
       const longerErrors = parseError(longerContext.errors)
       const longerTimeTaken = Date.now() - start
       expect(longerErrors).toMatch(/Line [52]: Potential infinite recursion detected/)
-      expect(longerErrors).toMatch(/f\(\d+,\d+\) \.\.\. g\(\d+,\d+\)/)
+      expect(longerErrors).toMatch(/f\(\d+, \d+\) \.\.\. g\(\d+, \d+\)/)
       expect(longerTimeTaken).toBeLessThan(20000)
       expect(longerTimeTaken).toBeGreaterThanOrEqual(10000)
     })

--- a/src/native-errors.ts
+++ b/src/native-errors.ts
@@ -2,6 +2,7 @@
 import { stripIndent } from 'common-tags'
 import * as es from 'estree'
 import { JSSLANG_PROPERTIES } from './constants'
+import { stringify } from './interop'
 import { RuntimeSourceError } from './interpreter-errors'
 import { ErrorSeverity, ErrorType } from './types'
 
@@ -42,7 +43,8 @@ export class PotentialInfiniteRecursionError extends RuntimeSourceError {
 
   public explain() {
     const formattedCalls = this.calls.map(
-      ([executedName, executedArguments]) => `${executedName}(${executedArguments})`
+      ([executedName, executedArguments]) =>
+        `${executedName}(${executedArguments.map(arg => stringify(arg)).join(', ')})`
     )
     return stripIndent`Potential infinite recursion detected: ${formattedCalls.join(' ... ')}.
       ${getWarningMessage()}`


### PR DESCRIPTION
Fixes #223. We use the default stringify method to pretty-print the arguments.