### PR TITLE
Expand generator shorthand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-slang",
-  "version": "0.2.1-alpha.2",
+  "version": "0.2.2",
   "description": "Javascript-based interpreter for slang, written in Typescript",
   "author": {
     "name": "Source Academy",

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -253,18 +253,19 @@ function* evaluateBlockSatement(context: Context, node: es.BlockStatement) {
  * They do not minify well, raising uncaught syntax errors in production.
  * See: https://github.com/webpack/webpack/issues/7566
  */
+// tslint:disable:object-literal-shorthand
+// prettier-ignore
 export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   /** Simple Values */
-
-  *Literal(node: es.Literal, context: Context) {
+  Literal: function*(node: es.Literal, context: Context) {
     return node.value
   },
 
-  *ThisExpression(node: es.ThisExpression, context: Context) {
+  ThisExpression: function*(node: es.ThisExpression, context: Context) {
     return context.runtime.environments[0].thisContext
   },
 
-  *ArrayExpression(node: es.ArrayExpression, context: Context) {
+  ArrayExpression: function*(node: es.ArrayExpression, context: Context) {
     const res = []
     for (const n of node.elements) {
       res.push(yield* evaluate(n, context))
@@ -272,24 +273,24 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return res
   },
 
-  *DebuggerStatement(node: es.DebuggerStatement, context: Context) {
+  DebuggerStatement: function*(node: es.DebuggerStatement, context: Context) {
     context.runtime.break = true
     yield
   },
 
-  *FunctionExpression(node: es.FunctionExpression, context: Context) {
+  FunctionExpression: function*(node: es.FunctionExpression, context: Context) {
     return new Closure(node, currentEnvironment(context), context)
   },
 
-  *ArrowFunctionExpression(node: es.ArrowFunctionExpression, context: Context) {
+  ArrowFunctionExpression: function*(node: es.ArrowFunctionExpression, context: Context) {
     return Closure.makeFromArrowFunction(node, currentEnvironment(context), context)
   },
 
-  *Identifier(node: es.Identifier, context: Context) {
+  Identifier: function*(node: es.Identifier, context: Context) {
     return getVariable(context, node.name)
   },
 
-  *CallExpression(node: es.CallExpression, context: Context) {
+  CallExpression: function*(node: es.CallExpression, context: Context) {
     const callee = yield* evaluate(node.callee, context)
     const args = yield* getArgs(context, node)
     let thisContext
@@ -300,7 +301,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return result
   },
 
-  *NewExpression(node: es.NewExpression, context: Context) {
+  NewExpression: function*(node: es.NewExpression, context: Context) {
     const callee = yield* evaluate(node.callee, context)
     const args = []
     for (const arg of node.arguments) {
@@ -317,7 +318,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return obj
   },
 
-  *UnaryExpression(node: es.UnaryExpression, context: Context) {
+  UnaryExpression: function*(node: es.UnaryExpression, context: Context) {
     const value = yield* evaluate(node.argument, context)
 
     const error = rttc.checkUnaryExpression(node, node.operator, value)
@@ -327,7 +328,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return evaluateUnaryExpression(node.operator, value)
   },
 
-  *BinaryExpression(node: es.BinaryExpression, context: Context) {
+  BinaryExpression: function*(node: es.BinaryExpression, context: Context) {
     const left = yield* evaluate(node.left, context)
     const right = yield* evaluate(node.right, context)
 
@@ -338,15 +339,15 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return evaluateBinaryExpression(node.operator, left, right)
   },
 
-  *ConditionalExpression(node: es.ConditionalExpression, context: Context) {
+  ConditionalExpression: function*(node: es.ConditionalExpression, context: Context) {
     return yield* this.IfStatement(node, context)
   },
 
-  *LogicalExpression(node: es.LogicalExpression, context: Context) {
+  LogicalExpression: function*(node: es.LogicalExpression, context: Context) {
     return yield* this.ConditionalExpression(transformLogicalExpression(node), context)
   },
 
-  *VariableDeclaration(node: es.VariableDeclaration, context: Context) {
+  VariableDeclaration: function*(node: es.VariableDeclaration, context: Context) {
     const declaration = node.declarations[0]
     const constant = node.kind === 'const'
     const id = declaration.id as es.Identifier
@@ -355,15 +356,15 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return undefined
   },
 
-  *ContinueStatement(node: es.ContinueStatement, context: Context) {
+  ContinueStatement: function*(node: es.ContinueStatement, context: Context) {
     return new ContinueValue()
   },
 
-  *BreakStatement(node: es.BreakStatement, context: Context) {
+  BreakStatement: function*(node: es.BreakStatement, context: Context) {
     return new BreakValue()
   },
 
-  *ForStatement(node: es.ForStatement, context: Context) {
+  ForStatement: function*(node: es.ForStatement, context: Context) {
     // Create a new block scope for the loop variables
     const loopEnvironment = createBlockEnvironment(context, 'forLoopEnvironment')
     pushEnvironment(context, loopEnvironment)
@@ -415,7 +416,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return value
   },
 
-  *MemberExpression(node: es.MemberExpression, context: Context) {
+  MemberExpression: function*(node: es.MemberExpression, context: Context) {
     let obj = yield* evaluate(node.object, context)
     if (obj instanceof Closure) {
       obj = obj.fun
@@ -447,7 +448,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     }
   },
 
-  *AssignmentExpression(node: es.AssignmentExpression, context: Context) {
+  AssignmentExpression: function*(node: es.AssignmentExpression, context: Context) {
     if (node.left.type === 'MemberExpression') {
       const left = node.left
       const obj = yield* evaluate(left.object, context)
@@ -478,7 +479,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return value
   },
 
-  *FunctionDeclaration(node: es.FunctionDeclaration, context: Context) {
+  FunctionDeclaration: function*(node: es.FunctionDeclaration, context: Context) {
     const id = node.id as es.Identifier
     // tslint:disable-next-line:no-any
     const closure = new Closure(node, currentEnvironment(context), context)
@@ -486,22 +487,22 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return undefined
   },
 
-  *IfStatement(node: es.IfStatement | es.ConditionalExpression, context: Context) {
+  IfStatement: function*(node: es.IfStatement | es.ConditionalExpression, context: Context) {
     return yield* evaluate(yield* reduceIf(node, context), context)
   },
 
-  *ExpressionStatement(node: es.ExpressionStatement, context: Context) {
+  ExpressionStatement: function*(node: es.ExpressionStatement, context: Context) {
     return yield* evaluate(node.expression, context)
   },
 
-  *ReturnStatement(node: es.ReturnStatement, context: Context) {
+  ReturnStatement: function*(node: es.ReturnStatement, context: Context) {
     let returnExpression = node.argument!
 
     // If we have a conditional expression, reduce it until we get something else
     while (
       returnExpression.type === 'LogicalExpression' ||
       returnExpression.type === 'ConditionalExpression'
-    ) {
+      ) {
       if (returnExpression.type === 'LogicalExpression') {
         returnExpression = transformLogicalExpression(returnExpression)
       }
@@ -518,15 +519,15 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     }
   },
 
-  *WhileStatement(node: es.WhileStatement, context: Context) {
+  WhileStatement: function*(node: es.WhileStatement, context: Context) {
     let value: any // tslint:disable-line
     while (
       // tslint:disable-next-line
-      (yield* evaluate(node.test, context)) &&
-      !(value instanceof ReturnValue) &&
-      !(value instanceof BreakValue) &&
-      !(value instanceof TailCallReturnValue)
-    ) {
+    (yield* evaluate(node.test, context)) &&
+    !(value instanceof ReturnValue) &&
+    !(value instanceof BreakValue) &&
+    !(value instanceof TailCallReturnValue)
+      ) {
       value = yield* evaluate(node.body, context)
     }
     if (value instanceof BreakValue) {
@@ -535,7 +536,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return value
   },
 
-  *ObjectExpression(node: es.ObjectExpression, context: Context) {
+  ObjectExpression: function*(node: es.ObjectExpression, context: Context) {
     const obj = {}
     for (const prop of node.properties) {
       let key
@@ -549,7 +550,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return obj
   },
 
-  *BlockStatement(node: es.BlockStatement, context: Context) {
+  BlockStatement: function*(node: es.BlockStatement, context: Context) {
     let result: Value
 
     // Create a new environment (block scoping)
@@ -560,7 +561,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return result
   },
 
-  *Program(node: es.BlockStatement, context: Context) {
+  Program: function*(node: es.BlockStatement, context: Context) {
     hoistFunctionsAndVariableDeclarationsIdentifiers(context, node)
     let result: Value
     for (const statement of node.body) {
@@ -572,6 +573,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return result
   }
 }
+// tslint:disable:object-literal-shorthand
 
 export function* evaluate(node: es.Node, context: Context) {
   yield* visit(context, node)


### PR DESCRIPTION
The object literal shorthand causes some error during the minification process.

Let's expand all these out and disable the relevant prettier and ts-lint rules to fix this.