### PR TITLE
Add no-repl mode to js-slang executable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ You can set additional options:
 
 .. code-block::
 
-  Usage: js-slang [PROGRAM] [OPTION]
+  Usage: js-slang [PROGRAM_STRING] [OPTION]
 
     -c, --chapter=CHAPTER set the Source chapter number (i.e., 1-4) (default: 1)
     -s, --use-subst       use substitution

--- a/README.rst
+++ b/README.rst
@@ -22,23 +22,33 @@ To build,
   $ yarn
   $ yarn build
 
+To add "js-slang" to your PATH, build it as per the above instructions, then run
+
+.. code-block::
+
+  $ cd dist
+  $ npm link
+
+If you do not wish to add "js-slang" to your PATH, replace "js-slang" with "node dist/repl/repl.js" in the following examples.
+
 To try out *Source* in a REPL, run
 
 .. code-block::
 
-  $ node dist/repl/repl.js -c [chapter] # default: 1
+  $ js-slang -c [chapter] # default: 1
 
-You can set additional options for the REPL:
+You can set additional options:
 
 .. code-block::
 
-  Usage: node repl.js [FILENAME] [OPTION]
+  Usage: js-slang [PROGRAM] [OPTION]
 
-    -c, --chapter=CHAPTER set the Source chapter number (i.e., 1-4)
+    -c, --chapter=CHAPTER set the Source chapter number (i.e., 1-4) (default: 1)
     -s, --use-subst       use substitution
     -h, --help            display this help
     -n, --native          use the native execution method
     -l, --lazy            use lazy evaluation
+    -e, --eval            don't show REPL, only display output of evaluation
 
 Documentation
 -------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,10 +51,12 @@ const DEFAULT_OPTIONS: IOptions = {
 }
 
 // needed to work on browsers
-// @ts-ignore
-SourceMapConsumer.initialize({
-  'lib/mappings.wasm': 'https://unpkg.com/source-map@0.7.3/lib/mappings.wasm'
-})
+if (typeof window !== 'undefined') {
+  // @ts-ignore
+  SourceMapConsumer.initialize({
+    'lib/mappings.wasm': 'https://unpkg.com/source-map@0.7.3/lib/mappings.wasm'
+  })
+}
 
 // deals with parsing error objects and converting them to strings (for repl at least)
 

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -68,7 +68,7 @@ function main() {
       ['e', 'eval', "don't show REPL, only display output of evaluation"]
     ])
     .bindHelp()
-    .setHelp('Usage: node repl.js [PROGRAM_STRING] [OPTION]\n\n[[OPTIONS]]')
+    .setHelp('Usage: js-slang [PROGRAM_STRING] [OPTION]\n\n[[OPTIONS]]')
     .parseSystem()
 
   const executionMethod = opt.options.native === true ? 'native' : 'interpreter'

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -68,7 +68,7 @@ function main() {
       ['e', 'eval', "don't show REPL, only display output of evaluation"]
     ])
     .bindHelp()
-    .setHelp('Usage: node repl.js [PROGRAM] [OPTION]\n\n[[OPTIONS]]')
+    .setHelp('Usage: node repl.js [PROGRAM_STRING] [OPTION]\n\n[[OPTIONS]]')
     .parseSystem()
 
   const executionMethod = opt.options.native === true ? 'native' : 'interpreter'

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -1,6 +1,6 @@
-import fs = require('fs')
-import repl = require('repl') // 'repl' here refers to the module named 'repl' in index.d.ts
-import util = require('util')
+#!/usr/bin/env node
+import { start } from 'repl' // 'repl' here refers to the module named 'repl' in index.d.ts
+import { inspect } from 'util'
 import { createContext, IOptions, parseError, runInContext } from '../index'
 import { EvaluationMethod, ExecutionMethod } from '../types'
 import Closure from '../interpreter/closure'
@@ -10,6 +10,7 @@ function startRepl(
   executionMethod: ExecutionMethod = 'interpreter',
   evaluationMethod: EvaluationMethod = 'strict',
   useSubst: boolean = false,
+  useRepl: boolean,
   prelude = ''
 ) {
   // use defaults for everything
@@ -23,7 +24,10 @@ function startRepl(
   runInContext(prelude, context, options).then(preludeResult => {
     if (preludeResult.status === 'finished') {
       console.dir(preludeResult.value, { depth: null })
-      repl.start(
+      if (!useRepl) {
+        return
+      }
+      start(
         // the object being passed as argument fits the interface ReplOptions in the repl module.
         {
           eval: (cmd, unusedContext, unusedFilename, callback) => {
@@ -40,7 +44,7 @@ function startRepl(
           writer: output => {
             return output instanceof Closure || typeof output === 'function'
               ? output.toString()
-              : util.inspect(output, {
+              : inspect(output, {
                   depth: 1000,
                   colors: true
                 })
@@ -56,31 +60,24 @@ function startRepl(
 function main() {
   const opt = require('node-getopt')
     .create([
-      ['c', 'chapter=CHAPTER', 'set the Source chapter number (i.e., 1-4)'],
+      ['c', 'chapter=CHAPTER', 'set the Source chapter number (i.e., 1-4)', '1'],
       ['s', 'use-subst', 'use substitution'],
       ['h', 'help', 'display this help'],
       ['n', 'native', 'use the native execution method'],
-      ['l', 'lazy', 'use lazy evaluation']
+      ['l', 'lazy', 'use lazy evaluation'],
+      ['e', 'eval', "don't show REPL, only display output of evaluation"]
     ])
     .bindHelp()
-    .setHelp('Usage: node repl.js [FILENAME] [OPTION]\n\n[[OPTIONS]]')
+    .setHelp('Usage: node repl.js [PROGRAM] [OPTION]\n\n[[OPTIONS]]')
     .parseSystem()
 
   const executionMethod = opt.options.native === true ? 'native' : 'interpreter'
   const evaluationMethod = opt.options.lazy === true ? 'lazy' : 'strict'
-  const chapter = opt.options.chapter !== undefined ? parseInt(opt.options.chapter, 10) : 1
+  const chapter = parseInt(opt.options.chapter, 10)
   const useSubst = opt.options.s
-
-  if (opt.argv.length > 0) {
-    fs.readFile(opt.argv[0], 'utf8', (err, data) => {
-      if (err) {
-        throw err
-      }
-      startRepl(chapter, executionMethod, evaluationMethod, useSubst, data)
-    })
-  } else {
-    startRepl(chapter, executionMethod, evaluationMethod, useSubst, '')
-  }
+  const useRepl = !opt.options.e
+  const prelude = opt.argv[0] ?? ''
+  startRepl(chapter, executionMethod, evaluationMethod, useSubst, useRepl, prelude)
 }
 
 main()


### PR DESCRIPTION
Go here to read the new README https://github.com/source-academy/js-slang/blob/880d77e0d6f7f7aec9b895773dc89a9271fd7188/README.rst

Ability to read in a file path is gone to keep things simple. If you want to pass in a file, do

```
js-slang $(cat path/to/file.js)
```

instead.

A new `eval` option is added to facilitate testing, where the REPL is not shown.

![image](https://user-images.githubusercontent.com/3646725/77823407-ee185980-7135-11ea-9e0a-dbbb84f44402.png)




To get rid of the `SourceConsumer....` logs, I added a check to check if it's in the browser first.