### PR TITLE
fix syntax highlight issue with firefox

### DIFF
--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -286,8 +286,7 @@ export function HighlightRulesSelector(id: number) {
           },
           {
             token: ['variable.language'],
-            regex: /\.{3}|--+|[$%&*+\-~\/^]=+|==[^=]|!=[^=]|\+\++|\^|(?<!&)&(?!&)|(?<!\|)\|(?!\|)/,
-            next: 'start'
+            regex: /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|[^&]*&[^&]|[^\|]*\|[^\|]/
           },
           {
             token: keywordMapper,
@@ -304,7 +303,7 @@ export function HighlightRulesSelector(id: number) {
           },
           {
             token: 'keyword.operator',
-            regex: /\.{3}|===|=|!==|<+=?|>+=?|!|&&|\|\||[%*+-\/]/,
+            regex: /===|=|!==|<+=?|>+=?|!|&&|\|\||[%*+-\/]/,
             next: 'start'
           },
           {


### PR DESCRIPTION
see #472 
the previous version includes lookup syntax which is not supported by certain browsers such as firefox. The current version fixed the issue.