### PR TITLE
Fix navigation issue

### DIFF
--- a/src/finder.ts
+++ b/src/finder.ts
@@ -77,7 +77,9 @@ export function findDeclarationNode(program: Node, identifier: Identifier): Node
         }
       },
       VariableDeclarator(node: VariableDeclarator, state: any, callback: WalkerCallback<any>) {
-        if ((node.id as Identifier).name === identifier.name) {
+        if ((node.id as Identifier === identifier) ||
+          ((node.id as Identifier).name === identifier.name &&
+            occursBefore(node.loc as any, identifier.loc as any))) {
           declarations.push(node.id)
         }
       }
@@ -88,6 +90,17 @@ export function findDeclarationNode(program: Node, identifier: Identifier): Node
   }
 
   return undefined
+}
+
+
+function occursBefore(loc1: SourceLocation, loc2: SourceLocation): boolean {
+  if (loc1.start.line > loc2.start.line) {
+    return false
+  } else if (loc1.start.line < loc2.start.line) {
+    return true
+  } else {
+    return (loc1.start.column - loc2.start.column) < 0
+  }
 }
 
 function containsNode(nodeOuter: Node, nodeInner: Node): boolean {

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -77,9 +77,11 @@ export function findDeclarationNode(program: Node, identifier: Identifier): Node
         }
       },
       VariableDeclarator(node: VariableDeclarator, state: any, callback: WalkerCallback<any>) {
-        if ((node.id as Identifier === identifier) ||
+        if (
+          (node.id as Identifier) === identifier ||
           ((node.id as Identifier).name === identifier.name &&
-            occursBefore(node.loc as any, identifier.loc as any))) {
+            occursBefore(node.loc as any, identifier.loc as any))
+        ) {
           declarations.push(node.id)
         }
       }
@@ -92,14 +94,13 @@ export function findDeclarationNode(program: Node, identifier: Identifier): Node
   return undefined
 }
 
-
 function occursBefore(loc1: SourceLocation, loc2: SourceLocation): boolean {
   if (loc1.start.line > loc2.start.line) {
     return false
   } else if (loc1.start.line < loc2.start.line) {
     return true
   } else {
-    return (loc1.start.column - loc2.start.column) < 0
+    return loc1.start.column - loc2.start.column < 0
   }
 }
 


### PR DESCRIPTION
In the following code, on pressing Cmd+B at the x in the line `const z = x + 2;`, the cursor was moved to the next line, instead of the x in the first line.

```
{
    const x = 1;
    {
        const z = x + 2;
        const x = 2;
        function f(y) {
            return x + y;
        }
    }
}
```

Solution: Added a check to make sure the found declaration of the occurrence does not occur after the occurrence in the code, since Source does not allow this anyway.