### PR TITLE
Fix undefined error that causes editor to crash on refactoring

### DIFF
--- a/src/scope-refactoring.ts
+++ b/src/scope-refactoring.ts
@@ -38,10 +38,12 @@ export function scopeVariables(
     enclosingLoc: enclosingLoc === undefined ? program.loc : enclosingLoc,
     children: []
   }
-  const definitionStatements = getDeclarationStatements(program.body) as (
-    | es.VariableDeclaration
-    | es.FunctionDeclaration
-  )[]
+
+  if (program.body == null) {
+    return block
+  }
+
+  const definitionStatements = getDefinitionStatements(program.body)
   const blockStatements = getBlockStatements(program.body)
   const forStatements = getForStatements(program.body)
   const ifStatements = getIfStatements(program.body)
@@ -330,13 +332,13 @@ function getBlockStatements(nodes: (es.Statement | es.ModuleDeclaration)[]): es.
   return nodes.filter(statement => statement.type === 'BlockStatement') as es.BlockStatement[]
 }
 
-function getDeclarationStatements(
+function getDefinitionStatements(
   nodes: (es.Statement | es.ModuleDeclaration)[]
-): (es.Statement | es.ModuleDeclaration)[] {
+): (es.FunctionDeclaration | es.VariableDeclaration)[] {
   return nodes.filter(
     statement =>
       statement.type === 'FunctionDeclaration' || statement.type === 'VariableDeclaration'
-  )
+  ) as (es.FunctionDeclaration | es.VariableDeclaration)[]
 }
 
 function getIfStatements(nodes: (es.Statement | es.ModuleDeclaration)[]): es.IfStatement[] {


### PR DESCRIPTION
Fixes https://github.com/source-academy/cadet-frontend/issues/1039

Loose parsing gives us a tree which may not exactly fit acorn specifications. 
Therefore, we add an additional null/undefined check in `scopeVariables`

I've tested with a few other non valid programs and it does not seem to crash anymore with this check. 