### PR TITLE
Scope highlighting

### DIFF
--- a/src/__tests__/__snapshots__/index.ts.snap
+++ b/src/__tests__/__snapshots__/index.ts.snap
@@ -634,6 +634,41 @@ Array [
 ]
 `;
 
+exports[`Find scope of a variable declaration with more nesting 1`] = `
+Array [
+  Object {
+    "end": Position {
+      "column": 12,
+      "line": 6,
+    },
+    "start": Position {
+      "column": 4,
+      "line": 3,
+    },
+  },
+  Object {
+    "end": Position {
+      "column": 8,
+      "line": 11,
+    },
+    "start": Position {
+      "column": 13,
+      "line": 8,
+    },
+  },
+  Object {
+    "end": Position {
+      "column": 5,
+      "line": 14,
+    },
+    "start": Position {
+      "column": 9,
+      "line": 13,
+    },
+  },
+]
+`;
+
 exports[`Find variable declaration in block statement 1`] = `
 SourceLocation {
   "end": Position {

--- a/src/__tests__/__snapshots__/index.ts.snap
+++ b/src/__tests__/__snapshots__/index.ts.snap
@@ -564,6 +564,36 @@ exports[`Find no declaration from occurrence when there is no declaration (synta
 
 exports[`Find no declaration from selection that does not refer to a declaration 1`] = `null`;
 
+exports[`Find scope of a function declaration 1`] = `
+Array [
+  SourceLocation {
+    "end": Position {
+      "column": 5,
+      "line": 8,
+    },
+    "start": Position {
+      "column": 4,
+      "line": 3,
+    },
+  },
+]
+`;
+
+exports[`Find scope of a function parameter 1`] = `
+Array [
+  SourceLocation {
+    "end": Position {
+      "column": 9,
+      "line": 7,
+    },
+    "start": Position {
+      "column": 22,
+      "line": 5,
+    },
+  },
+]
+`;
+
 exports[`Find scope of a nested variable declaration 1`] = `
 Array [
   SourceLocation {
@@ -574,6 +604,31 @@ Array [
     "start": Position {
       "column": 4,
       "line": 3,
+    },
+  },
+]
+`;
+
+exports[`Find scope of a variable declaration 1`] = `
+Array [
+  Object {
+    "end": Position {
+      "column": 4,
+      "line": 3,
+    },
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  Object {
+    "end": Position {
+      "column": 3,
+      "line": 10,
+    },
+    "start": Position {
+      "column": 5,
+      "line": 8,
     },
   },
 ]

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -793,3 +793,39 @@ test('Find scope of a function declaration', () => {
   })
   expect(actual).toMatchSnapshot()
 })
+
+test('Find scope of a variable declaration with more nesting', () => {
+  const context = createTestContext({ chapter: 4 })
+  const code = `{
+    const x = 1;
+    {
+        const x = 2;
+        function f(y) {
+            for (let x = 10; x < 20; x = x + 1) {
+                display(x);
+            }
+            return x + y;
+        }
+        for (let x = 10; x < 20; x = x + 1) {
+            display(x);
+        }
+    }
+    display(x);
+  }`
+  const expected = [
+    new SourceLocationTestResult(3, 4, 6, 12),
+    new SourceLocationTestResult(8, 13, 11, 8),
+    new SourceLocationTestResult(13, 9, 14, 5)
+  ]
+  const actual = getScope(code, context, { line: 4, column: 15 })
+  expected.forEach((expectedRange, index) => {
+    const actualRange = new SourceLocationTestResult(
+      actual[index].start.line,
+      actual[index].start.column,
+      actual[index].end.line,
+      actual[index].end.column
+    )
+    expectResultsToMatch(actualRange, expectedRange)
+  })
+  expect(actual).toMatchSnapshot()
+})

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -701,15 +701,18 @@ test('Find scope of a variable declaration', () => {
   }`
   const expected = [
     new SourceLocationTestResult(1, 0, 3, 4),
-    new SourceLocationTestResult(8, 5, 10, 3),
+    new SourceLocationTestResult(8, 5, 10, 3)
   ]
   const actual = getScope(code, context, { line: 2, column: 10 })
-  expected.forEach((expectedRange,index) => {
+  expected.forEach((expectedRange, index) => {
     const actualRange = new SourceLocationTestResult(
-      actual[index].start.line, actual[index].start.column,
-      actual[index].end.line, actual[index].end.column)
+      actual[index].start.line,
+      actual[index].start.column,
+      actual[index].end.line,
+      actual[index].end.column
+    )
     expectResultsToMatch(actualRange, expectedRange)
-  });
+  })
   expect(actual).toMatchSnapshot()
 })
 
@@ -725,16 +728,17 @@ test('Find scope of a nested variable declaration', () => {
     }
     display(x);
   }`
-  const expected = [
-    new SourceLocationTestResult(3, 4, 8, 5),
-  ]
+  const expected = [new SourceLocationTestResult(3, 4, 8, 5)]
   const actual = getScope(code, context, { line: 4, column: 15 })
-  expected.forEach((expectedRange,index) => {
+  expected.forEach((expectedRange, index) => {
     const actualRange = new SourceLocationTestResult(
-      actual[index].start.line, actual[index].start.column,
-      actual[index].end.line, actual[index].end.column)
+      actual[index].start.line,
+      actual[index].start.column,
+      actual[index].end.line,
+      actual[index].end.column
+    )
     expectResultsToMatch(actualRange, expectedRange)
-  });
+  })
   expect(actual).toMatchSnapshot()
 })
 
@@ -750,16 +754,17 @@ test('Find scope of a function parameter', () => {
     }
     display(x);
   }`
-  const expected = [
-    new SourceLocationTestResult(5, 22, 7, 9),
-  ]
+  const expected = [new SourceLocationTestResult(5, 22, 7, 9)]
   const actual = getScope(code, context, { line: 5, column: 19 })
-  expected.forEach((expectedRange,index) => {
+  expected.forEach((expectedRange, index) => {
     const actualRange = new SourceLocationTestResult(
-      actual[index].start.line, actual[index].start.column,
-      actual[index].end.line, actual[index].end.column)
+      actual[index].start.line,
+      actual[index].start.column,
+      actual[index].end.line,
+      actual[index].end.column
+    )
     expectResultsToMatch(actualRange, expectedRange)
-  });
+  })
   expect(actual).toMatchSnapshot()
 })
 
@@ -775,15 +780,16 @@ test('Find scope of a function declaration', () => {
     }
     display(x);
   }`
-  const expected = [
-    new SourceLocationTestResult(3, 4, 8, 5),
-  ]
+  const expected = [new SourceLocationTestResult(3, 4, 8, 5)]
   const actual = getScope(code, context, { line: 5, column: 17 })
-  expected.forEach((expectedRange,index) => {
+  expected.forEach((expectedRange, index) => {
     const actualRange = new SourceLocationTestResult(
-      actual[index].start.line, actual[index].start.column,
-      actual[index].end.line, actual[index].end.column)
+      actual[index].start.line,
+      actual[index].start.column,
+      actual[index].end.line,
+      actual[index].end.column
+    )
     expectResultsToMatch(actualRange, expectedRange)
-  });
+  })
   expect(actual).toMatchSnapshot()
 })

--- a/src/__tests__/scope-refactoring.ts
+++ b/src/__tests__/scope-refactoring.ts
@@ -7,7 +7,8 @@ import {
   getBlockFromLoc,
   getAllIdentifiers,
   getNodeLocsInCurrentBlockFrame,
-  getBlockFramesInCurrentBlockFrame
+  getBlockFramesInCurrentBlockFrame,
+  getScopeHelper
 } from '../scope-refactoring'
 import { parse } from '../parser/parser'
 /* tslint:disable:max-classes-per-file */
@@ -475,4 +476,44 @@ if (true) {
       []
     ).length
   ).toBe(6)
+})
+
+test('getScopeHelper', () => {
+  const program = `{
+    const x = 1;
+    {
+        const x = 2;
+        function f(y) {
+            return x + y;
+        }
+    }
+    display(x);
+  }`
+  const definitionLocation = {
+    start: { line: 2, column: 10 },
+    end: { line: 2, column: 11 }
+  }
+  expect(getScopeHelper(definitionLocation, parse(program, context, true) as any, 'x').length).toBe(
+    2
+  )
+})
+
+test('getScopeHelperNested', () => {
+  const program = `{
+    const x = 1;
+    {
+        const x = 2;
+        function f(y) {
+            return x + y;
+        }
+    }
+    display(x);
+  }`
+  const definitionLocation = {
+    start: { line: 4, column: 15 },
+    end: { line: 4, column: 16 }
+  }
+  expect(getScopeHelper(definitionLocation, parse(program, context, true) as any, 'x').length).toBe(
+    1
+  )
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { findDeclarationNode, findIdentifierNode } from './finder'
 import { evaluate } from './interpreter/interpreter'
 import { parse, parseAt } from './parser/parser'
 import { AsyncScheduler, PreemptiveScheduler } from './schedulers'
-import { getAllOccurrencesInScopeHelper, getScopeHelper} from './scope-refactoring'
+import { getAllOccurrencesInScopeHelper, getScopeHelper } from './scope-refactoring'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
 import { getEvaluationSteps } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
@@ -184,7 +184,7 @@ export function getScope(
   if (!program) {
     return []
   }
-  console.log("program", program)
+  console.log('program', program)
 
   const identifierNode = findIdentifierNode(program, context, loc)
   if (!identifierNode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { findDeclarationNode, findIdentifierNode } from './finder'
 import { evaluate } from './interpreter/interpreter'
 import { parse, parseAt } from './parser/parser'
 import { AsyncScheduler, PreemptiveScheduler } from './schedulers'
-import { getAllOccurrencesInScopeHelper } from './scope-refactoring'
+import { getAllOccurrencesInScopeHelper, getScopeHelper} from './scope-refactoring'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
 import { getEvaluationSteps } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
@@ -173,6 +173,29 @@ export function findDeclaration(
     return null
   }
   return declarationNode.loc
+}
+
+export function getScope(
+  code: string,
+  context: Context,
+  loc: { line: number; column: number }
+): SourceLocation[] {
+  const program = parse(code, context, true)
+  if (!program) {
+    return []
+  }
+  console.log("program", program)
+
+  const identifierNode = findIdentifierNode(program, context, loc)
+  if (!identifierNode) {
+    return []
+  }
+  const declarationNode = findDeclarationNode(program, identifierNode)
+  if (!declarationNode || declarationNode.loc == null || identifierNode !== declarationNode) {
+    return []
+  }
+
+  return getScopeHelper(declarationNode.loc, program, identifierNode.name)
 }
 
 export function getAllOccurrencesInScope(

--- a/src/scope-refactoring.ts
+++ b/src/scope-refactoring.ts
@@ -201,10 +201,10 @@ export function getScopeHelper(
 
   // Recurse on the children
   const nestedBlocks = block.children.filter(isBlockFrame)
-  const nestedBlocksWithDefinitions = nestedBlocks.filter(child =>
-    getDefinitionsInChildScope(child, target).length > 0
+  const nestedBlocksWithDefinitions = nestedBlocks.filter(
+    child => getDefinitionsInChildScope(child, target).length > 0
   )
-  console.log("nestedBlocksWithDefinitions", nestedBlocksWithDefinitions)
+  console.log('nestedBlocksWithDefinitions', nestedBlocksWithDefinitions)
   nestedBlocksWithDefinitions.sort(sortByLoc)
   const rangeToExclude = nestedBlocksWithDefinitions.map(b => b.enclosingLoc)
 
@@ -214,12 +214,12 @@ export function getScopeHelper(
 
   const ranges: SourceLocation[] = []
   let prevRange = rangeToExclude.shift()
-  ranges.push({start:(parentRange as any).start, end: (prevRange as any).start})
+  ranges.push({ start: (parentRange as any).start, end: (prevRange as any).start })
   rangeToExclude.map(range => {
-    ranges.push({start:(prevRange as any).end, end: (rangeToExclude.shift() as any).start})
+    ranges.push({ start: (prevRange as any).end, end: (rangeToExclude.shift() as any).start })
     prevRange = range
   })
-  ranges.push({start:(prevRange as any).end, end: (parentRange as any).end})
+  ranges.push({ start: (prevRange as any).end, end: (parentRange as any).end })
 
   return ranges
 }
@@ -228,7 +228,7 @@ function getDefinitionsInChildScope(
   block: BlockFrame,
   target: string
 ): (DefinitionNode | BlockFrame)[] {
-  console.log("Getting definitons for", target, "in", block)
+  console.log('Getting definitons for', target, 'in', block)
   const definitionNodes = block.children
     .filter(isDefinitionNode)
     .filter(node => node.name === target)


### PR DESCRIPTION
## Overview
This PR adds the functionality to get the scope of an identifier, in terms of a list of location ranges to be used by the frontend for highlighting purposes.

## Implementation
Using the tree generated by #471, we find the parent block of the given declaration and remove all child blocks that have an overriding declaration of the same identifier, and return the resulting ranges.

Here's a demo when integrated with the frontend using a hotkey:

![ezgif com-crop](https://user-images.githubusercontent.com/25262251/78230242-a57ce980-7503-11ea-992d-c16546782f58.gif)

