### PR TITLE
Created interface, type check for stepper contents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { parse, parseAt, parseForNames } from './parser/parser'
 import { AsyncScheduler, PreemptiveScheduler, NonDetScheduler } from './schedulers'
 import { getAllOccurrencesInScopeHelper, getScopeHelper } from './scope-refactoring'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
-import { redexify, getEvaluationSteps } from './stepper/stepper'
+import { redexify, getEvaluationSteps, IStepperPropContents } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
 import { transpile } from './transpiler/transpiler'
 import {
@@ -415,10 +415,14 @@ export async function runInContext(
   }
   if (options.useSubst) {
     const steps = getEvaluationSteps(program, context)
-    const redexedSteps: [string, string, string][] = []
+    const redexedSteps: IStepperPropContents[] = []
     for (const step of steps) {
       const redexed = redexify(step[0], step[1])
-      redexedSteps.push([redexed[0], redexed[1], step[2]])
+      redexedSteps.push({
+        code: redexed[0],
+        redex: redexed[1],
+        explanation: step[2]
+      })
     }
     return Promise.resolve({
       status: 'finished',

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -2132,3 +2132,13 @@ export function getEvaluationSteps(
     return steps
   }
 }
+
+export interface IStepperPropContents {
+  code: string
+  redex: string
+  explanation: string
+}
+
+export function isStepperOutput(output: any): output is IStepperPropContents {
+  return 'code' in output
+}

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -618,7 +618,7 @@ function reduceMain(
         ' declared and substituted into rest of block',
 
       ArrayExpression: (target: es.ArrayExpression): string =>
-        target.elements.map(bodify).toString()
+        '[' + bodify(target.elements[0]) + ', ' + bodify(target.elements[1]) + ']'
     }
 
     const bodifier = bodifiers[target.type]


### PR DESCRIPTION
Created interface IStepperPropContents to replace original stepper output return type of Array<[string, string, string]> with IStepperPropContents[], as well as type check isStepperOutput, for better organisation and better checks in frontend

Edit: Also includes a small fix to display of lists/pairs in redex explanation string