### PR TITLE
Add MATH_E to docs and Source 3 Concurrent

### DIFF
--- a/docs/lib/math.js
+++ b/docs/lib/math.js
@@ -1,5 +1,15 @@
 /**
  * 
+ * The Number value for e, Euler's number,
+ * which is approximately 2.718281828459045.
+ * @const {number}
+ * 
+ */
+const math_E = 2.718281828459045;
+
+
+/**
+ * 
  * The Number value for the natural logarithm of 10, 
  * which is approximately 2.302585092994046.
  * @const {number}

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -730,6 +730,7 @@ export const CONSTANT_PRIMITIVES: [string, any][] = [
   ['undefined', undefined],
   ['Infinity', Infinity],
   ['NaN', NaN],
+  ['math_E', Math.E],
   ['math_LN2', Math.LN2],
   ['math_LN10', Math.LN10],
   ['math_LOG2E', Math.LOG2E],

--- a/src/typeChecker/typeChecker.ts
+++ b/src/typeChecker/typeChecker.ts
@@ -877,6 +877,7 @@ const predeclaredNames: [string, Type | ForAll][] = [
   ['Infinity', tNumber],
   ['NaN', tNumber],
   ['undefined', tUndef],
+  ['math_E', tNumber],
   ['math_LN2', tNumber],
   ['math_LN10', tNumber],
   ['math_LOG2E', tNumber],


### PR DESCRIPTION
I'm not sure whether anything else needs to be done to add `math_e` into the editor suggestions.

Closes #640 