### PR TITLE
Fix timeout issues

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -1,6 +1,6 @@
 // Variable determining chapter of Source is contained in this file.
 
-import { GLOBAL, GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE } from './constants'
+import { GLOBAL, GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE, JSSLANG_PROPERTIES } from './constants'
 import { AsyncScheduler } from './schedulers'
 import * as list from './stdlib/list'
 import { list_to_vector } from './stdlib/list'
@@ -141,8 +141,17 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
   const rawDisplay = (v: Value, s: string) =>
     externalBuiltIns.rawDisplay(v, s, context.externalContext)
   const display = (v: Value, s: string) => (rawDisplay(stringify(v), s), v)
-  const prompt = (v: Value) => externalBuiltIns.prompt(v, '', context.externalContext)
-  const alert = (v: Value) => externalBuiltIns.alert(v, '', context.externalContext)
+  const prompt = (v: Value) => {
+    const start = Date.now()
+    const promptResult = externalBuiltIns.prompt(v, '', context.externalContext)
+    JSSLANG_PROPERTIES.maxExecTime += Date.now() - start
+    return promptResult
+  }
+  const alert = (v: Value) => {
+    const start = Date.now()
+    externalBuiltIns.alert(v, '', context.externalContext)
+    JSSLANG_PROPERTIES.maxExecTime += Date.now() - start
+  }
   const visualiseList = (v: Value) => externalBuiltIns.visualiseList(v, context.externalContext)
 
   if (context.chapter >= 1) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,11 @@ export async function runInContext(
   if (context.prelude !== null) {
     const prelude = context.prelude
     context.prelude = null
+    const oldPreviousCode = previousCode
+    const oldTimeout = JSSLANG_PROPERTIES.maxExecTime
     await runInContext(prelude, context, options)
+    previousCode = oldPreviousCode
+    JSSLANG_PROPERTIES.maxExecTime = oldTimeout
     return runInContext(code, context, options)
   }
   if (isNativeRunnable) {

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -315,7 +315,6 @@ export function expectToLooselyMatchJS(code: string, options: TestOptions = {}) 
 export async function expectNativeToTimeoutAndError(code: string, timeout: number) {
   const start = Date.now()
   const context = mockContext(4)
-  context.prelude = null
   const promise = runInContext(code, context, {
     scheduler: 'preemptive',
     executionMethod: 'native'


### PR DESCRIPTION
Fixes #637 :

`prompt` and `alert` both pause execution, so we increase the timeout by that amount

Fixes #455 :

This is caused by prelude execution. So before execution of prelude, we save the previous code and timeout first before running the prelude, and restore them back after the prelude has been executed.