### PR TITLE
Refactor native to not use global variables

### DIFF
--- a/src/__tests__/__snapshots__/block-scoping.ts.snap
+++ b/src/__tests__/__snapshots__/block-scoping.ts.snap
@@ -227,7 +227,7 @@ test();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -238,35 +238,31 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          const x = true;
-          if (boolOrErr(true, 3, 2)) {
-            const x = false;
-          } else {
-            const x = false;
-          }
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function test() {\\\\n  const x = true;\\\\n  if (true) {\\\\n    const x = false;\\\\n  } else {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      const x = true;
+      if (boolOrErr(true, 3, 2)) {
+        const x = false;
+      } else {
+        const x = false;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function test() {\\\\n  const x = true;\\\\n  if (true) {\\\\n    const x = false;\\\\n  } else {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -288,7 +284,7 @@ test();",
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -299,42 +295,38 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          let z = [];
-          const startTime = runtime();
-          for (let x = 0; boolOrErr(binaryOp(\\"<\\", x, 10, 3, 18), 3, 2); x = binaryOp(\\"+\\", x, 1, 3, 30)) {
-            throwIfTimeout(startTime, runtime(), 3, 2);
-            setProp(z, x, wrap(() => ({
-              isTail: false,
-              value: x
-            }), \\"() => x\\"), 4, 4);
-          }
-          return {
-            isTail: true,
-            function: getProp(z, 1, 6, 9),
-            functionName: \\"<anonymous>\\",
-            arguments: [],
-            line: 6,
-            column: 9
-          };
-        }, \\"function test() {\\\\n  let z = [];\\\\n  for (let x = 0; x < 10; x = x + 1) {\\\\n    z[x] = () => x;\\\\n  }\\\\n  return z[1]();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      let z = [];
+      const startTime = runtime();
+      for (let x = 0; boolOrErr(binaryOp(\\"<\\", x, 10, 3, 18), 3, 2); x = binaryOp(\\"+\\", x, 1, 3, 30)) {
+        throwIfTimeout(1000, startTime, runtime(), 3, 2);
+        setProp(z, x, wrap(() => ({
+          isTail: false,
+          value: x
+        }), \\"() => x\\", 1000), 4, 4);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: true,
+        function: getProp(z, 1, 6, 9),
+        functionName: \\"<anonymous>\\",
+        arguments: [],
+        line: 6,
+        column: 9
+      };
+    }, \\"function test() {\\\\n  let z = [];\\\\n  for (let x = 0; x < 10; x = x + 1) {\\\\n    z[x] = () => x;\\\\n  }\\\\n  return z[1]();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -355,7 +347,7 @@ test();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -366,34 +358,30 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          let x = true;
-          const startTime = runtime();
-          for (let x = 1; boolOrErr(binaryOp(\\">\\", x, 0, 3, 18), 3, 2); x = binaryOp(\\"-\\", x, 1, 3, 29)) {
-            throwIfTimeout(startTime, runtime(), 3, 2);
-          }
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function test() {\\\\n  let x = true;\\\\n  for (let x = 1; x > 0; x = x - 1) {}\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 7, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      let x = true;
+      const startTime = runtime();
+      for (let x = 1; boolOrErr(binaryOp(\\">\\", x, 0, 3, 18), 3, 2); x = binaryOp(\\"-\\", x, 1, 3, 29)) {
+        throwIfTimeout(1000, startTime, runtime(), 3, 2);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function test() {\\\\n  let x = true;\\\\n  for (let x = 1; x > 0; x = x - 1) {}\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 7, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -417,7 +405,7 @@ test();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -428,35 +416,31 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          let x = true;
-          if (boolOrErr(true, 3, 2)) {
-            let x = false;
-          } else {
-            let x = false;
-          }
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function test() {\\\\n  let x = true;\\\\n  if (true) {\\\\n    let x = false;\\\\n  } else {\\\\n    let x = false;\\\\n  }\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      let x = true;
+      if (boolOrErr(true, 3, 2)) {
+        let x = false;
+      } else {
+        let x = false;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function test() {\\\\n  let x = true;\\\\n  if (true) {\\\\n    let x = false;\\\\n  } else {\\\\n    let x = false;\\\\n  }\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -478,7 +462,7 @@ test();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -489,33 +473,29 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      const x = true;
       {
-        const test = wrap(() => {
-          const x = true;
-          {
-            const x = false;
-          }
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function test() {\\\\n  const x = true;\\\\n  {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+        const x = false;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function test() {\\\\n  const x = true;\\\\n  {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -538,7 +518,7 @@ test();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -549,36 +529,32 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          let x = true;
-          const startTime = runtime();
-          while (boolOrErr(true, 3, 2)) {
-            throwIfTimeout(startTime, runtime(), 3, 2);
-            let x = false;
-            break;
-          }
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function test() {\\\\n  let x = true;\\\\n  while (true) {\\\\n    let x = false;\\\\n    break;\\\\n  }\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 9, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      let x = true;
+      const startTime = runtime();
+      while (boolOrErr(true, 3, 2)) {
+        throwIfTimeout(1000, startTime, runtime(), 3, 2);
+        let x = false;
+        break;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function test() {\\\\n  let x = true;\\\\n  while (true) {\\\\n    let x = false;\\\\n    break;\\\\n  }\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 9, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/display.ts.snap
+++ b/src/__tests__/__snapshots__/display.ts.snap
@@ -11,7 +11,7 @@ Object {
   "parsedErrors": "",
   "result": "Tom's assisstant said: \\"tuna.\\"",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -22,17 +22,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -56,7 +52,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -67,17 +63,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, [1, 2, [4, 5]]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, [1, 2, [4, 5]]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -112,7 +104,7 @@ Object {
   "parsedErrors": "",
   "result": Infinity,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -123,19 +115,15 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        callIfFuncAndRightArgs(display, 1, 0, 1e38);
-        callIfFuncAndRightArgs(display, 1, 15, NaN);
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 29, Infinity);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    callIfFuncAndRightArgs(display, 1, 0, 1e38);
+    callIfFuncAndRightArgs(display, 1, 15, NaN);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 29, Infinity);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -158,7 +146,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -169,17 +157,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -196,7 +180,7 @@ Object {
   "parsedErrors": "",
   "result": 0,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -207,17 +191,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -255,7 +235,7 @@ Object {
   "parsedErrors": "",
   "result": "Tom's assisstant said: \\"tuna.\\"",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -266,17 +246,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(raw_display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(raw_display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/environment.ts.snap
+++ b/src/__tests__/__snapshots__/environment.ts.snap
@@ -133,7 +133,6 @@ Array [
       },
       "thisContext": Object {
         "chapter": 4,
-        "contextId": 0,
         "debugger": Object {
           "observers": Object {
             "callbacks": Array [],
@@ -148,6 +147,327 @@ Array [
         "executionMethod": "auto",
         "externalContext": undefined,
         "externalSymbols": Array [],
+        "nativeStorage": Object {
+          "globals": Object {
+            "previousScope": null,
+            "variables": Map {
+              "runtime" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "display" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "raw_display" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "stringify" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "error" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "prompt" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_number" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_string" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_function" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_boolean" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_undefined" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "parse_int" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "undefined" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "NaN" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "Infinity" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_abs" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_acos" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_acosh" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_asin" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_asinh" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_atan" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_atanh" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_atan2" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_ceil" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_cbrt" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_expm1" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_clz32" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_cos" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_cosh" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_exp" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_floor" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_fround" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_hypot" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_imul" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_log" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_log1p" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_log2" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_log10" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_max" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_min" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_pow" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_random" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_round" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_sign" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_sin" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_sinh" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_sqrt" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_tan" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_tanh" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_trunc" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_E" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_LN10" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_LN2" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_LOG10E" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_LOG2E" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_PI" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_SQRT1_2" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "math_SQRT2" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "pair" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_pair" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "head" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "tail" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_null" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "list" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "draw_data" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "set_head" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "set_tail" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "array_length" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "is_array" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "stream_tail" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "stream" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "list_to_stream" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "parse" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+              "apply_in_underlying_javascript" => Object {
+                "getValue": [Function],
+                "kind": "const",
+              },
+            },
+          },
+          "gpu": Map {
+            "__createKernel" => [Function],
+          },
+          "maxExecTime": 1000,
+          "operators": Map {
+            "throwIfTimeout" => [Function],
+            "forceIt" => [Function],
+            "callIfFuncAndRightArgs" => [Function],
+            "boolOrErr" => [Function],
+            "unaryOp" => [Function],
+            "evaluateUnaryExpression" => [Function],
+            "binaryOp" => [Function],
+            "evaluateBinaryExpression" => [Function],
+            "callIteratively" => [Function],
+            "wrap" => [Function],
+            "setProp" => [Function],
+            "getProp" => [Function],
+          },
+        },
         "numberOfOuterEnvironments": 2,
         "prelude": null,
         "runtime": Object {
@@ -614,7 +934,6 @@ Array [
     },
     "thisContext": Object {
       "chapter": 4,
-      "contextId": 0,
       "debugger": Object {
         "observers": Object {
           "callbacks": Array [],
@@ -629,6 +948,327 @@ Array [
       "executionMethod": "auto",
       "externalContext": undefined,
       "externalSymbols": Array [],
+      "nativeStorage": Object {
+        "globals": Object {
+          "previousScope": null,
+          "variables": Map {
+            "runtime" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "display" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "raw_display" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "stringify" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "error" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "prompt" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_number" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_string" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_function" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_boolean" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_undefined" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "parse_int" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "undefined" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "NaN" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "Infinity" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_abs" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_acos" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_acosh" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_asin" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_asinh" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_atan" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_atanh" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_atan2" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_ceil" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_cbrt" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_expm1" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_clz32" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_cos" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_cosh" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_exp" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_floor" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_fround" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_hypot" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_imul" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_log" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_log1p" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_log2" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_log10" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_max" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_min" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_pow" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_random" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_round" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_sign" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_sin" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_sinh" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_sqrt" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_tan" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_tanh" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_trunc" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_E" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_LN10" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_LN2" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_LOG10E" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_LOG2E" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_PI" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_SQRT1_2" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "math_SQRT2" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "pair" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_pair" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "head" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "tail" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_null" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "list" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "draw_data" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "set_head" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "set_tail" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "array_length" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "is_array" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "stream_tail" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "stream" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "list_to_stream" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "parse" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+            "apply_in_underlying_javascript" => Object {
+              "getValue": [Function],
+              "kind": "const",
+            },
+          },
+        },
+        "gpu": Map {
+          "__createKernel" => [Function],
+        },
+        "maxExecTime": 1000,
+        "operators": Map {
+          "throwIfTimeout" => [Function],
+          "forceIt" => [Function],
+          "callIfFuncAndRightArgs" => [Function],
+          "boolOrErr" => [Function],
+          "unaryOp" => [Function],
+          "evaluateUnaryExpression" => [Function],
+          "binaryOp" => [Function],
+          "evaluateBinaryExpression" => [Function],
+          "callIteratively" => [Function],
+          "wrap" => [Function],
+          "setProp" => [Function],
+          "getProp" => [Function],
+        },
+      },
       "numberOfOuterEnvironments": 2,
       "prelude": null,
       "runtime": Object {

--- a/src/__tests__/__snapshots__/index.ts.snap
+++ b/src/__tests__/__snapshots__/index.ts.snap
@@ -10,7 +10,7 @@ a[1];",
   "parsedErrors": "",
   "result": undefined,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -21,24 +21,20 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = [];
-        lastStatementResult = eval(\\"getProp(a, 1, 2, 0);\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = [];
+    lastStatementResult = eval(\\"getProp(a, 1, 2, 0);\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -54,7 +50,7 @@ o.nonexistent;",
   "parsedErrors": "",
   "result": undefined,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -65,24 +61,20 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const o = {};
-        lastStatementResult = eval(\\"getProp(o, \\\\\\"nonexistent\\\\\\", 2, 0);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return o;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const o = {};
+    lastStatementResult = eval(\\"getProp(o, \\\\\\"nonexistent\\\\\\", 2, 0);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -112,7 +104,7 @@ Object {
   "parsedErrors": "",
   "result": "1,2",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -123,17 +115,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, [1, 2]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, [1, 2]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -178,7 +166,7 @@ Object {
 	[implementation hidden]
 }",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -189,17 +177,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -216,7 +200,7 @@ Object {
 	[implementation hidden]
 }",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -227,17 +211,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, pair);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, pair);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -257,7 +237,7 @@ test();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -268,31 +248,27 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          let variable = false;
-          variable = true;
-          return {
-            isTail: false,
-            value: variable
-          };
-        }, \\"function test() {\\\\n  let variable = false;\\\\n  variable = true;\\\\n  return variable;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      let variable = false;
+      variable = true;
+      return {
+        isTail: false,
+        value: variable
+      };
+    }, \\"function test() {\\\\n  let variable = false;\\\\n  variable = true;\\\\n  return variable;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -328,7 +304,7 @@ test();",
   "parsedErrors": "Line 3: Cannot assign new value to constant constant.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -339,31 +315,27 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap(() => {
-          const constant = 3;
-          constant = 4;
-          return {
-            isTail: false,
-            value: constant
-          };
-        }, \\"function test() {\\\\n  const constant = 3;\\\\n  constant = 4;\\\\n  return constant;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap(() => {
+      const constant = 3;
+      constant = 4;
+      return {
+        isTail: false,
+        value: constant
+      };
+    }, \\"function test() {\\\\n  const constant = 3;\\\\n  constant = 4;\\\\n  return constant;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -382,7 +354,7 @@ o.a.b.c;",
   "parsedErrors": "",
   "result": "string",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -393,27 +365,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const o = {};
-        setProp(o, \\"a\\", {}, 2, 0);
-        setProp(getProp(o, \\"a\\", 3, 0), \\"b\\", {}, 3, 0);
-        setProp(getProp(getProp(o, \\"a\\", 4, 0), \\"b\\", 4, 0), \\"c\\", \\"string\\", 4, 0);
-        lastStatementResult = eval(\\"getProp(getProp(getProp(o, \\\\\\"a\\\\\\", 5, 0), \\\\\\"b\\\\\\", 5, 0), \\\\\\"c\\\\\\", 5, 0);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return o;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const o = {};
+    setProp(o, \\"a\\", {}, 2, 0);
+    setProp(getProp(o, \\"a\\", 3, 0), \\"b\\", {}, 3, 0);
+    setProp(getProp(getProp(o, \\"a\\", 4, 0), \\"b\\", 4, 0), \\"c\\", \\"string\\", 4, 0);
+    lastStatementResult = eval(\\"getProp(getProp(getProp(o, \\\\\\"a\\\\\\", 5, 0), \\\\\\"b\\\\\\", 5, 0), \\\\\\"c\\\\\\", 5, 0);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -442,7 +410,7 @@ fac(5);",
   "parsedErrors": "",
   "result": 120,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -453,30 +421,26 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const fac = wrap(i => boolOrErr(binaryOp(\\"===\\", i, 1, 1, 19), 1, 19) ? {
-          isTail: false,
-          value: 1
-        } : {
-          isTail: false,
-          value: binaryOp(\\"*\\", i, callIfFuncAndRightArgs(fac, 1, 37, binaryOp(\\"-\\", i, 1, 1, 41)), 1, 33)
-        }, \\"i => i === 1 ? 1 : i * fac(i - 1)\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(fac, 2, 0, 5);\\");
-        globals.variables.set(\\"fac\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return fac;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const fac = wrap(i => boolOrErr(binaryOp(\\"===\\", i, 1, 1, 19), 1, 19) ? {
+      isTail: false,
+      value: 1
+    } : {
+      isTail: false,
+      value: binaryOp(\\"*\\", i, callIfFuncAndRightArgs(fac, 1, 37, binaryOp(\\"-\\", i, 1, 1, 41)), 1, 33)
+    }, \\"i => i === 1 ? 1 : i * fac(i - 1)\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(fac, 2, 0, 5);\\");
+    globals.variables.set(\\"fac\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return fac;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -832,7 +796,7 @@ identity(t) === t && t(1, 2, 3) === 6;",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -843,29 +807,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const t = wrap((x, y, z) => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"+\\", binaryOp(\\"+\\", x, y, 2, 9), z, 2, 9)
-          };
-        }, \\"function t(x, y, z) {\\\\n  return x + y + z;\\\\n}\\");
-        lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(identity, 4, 0, t), t, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(t, 4, 21, 1, 2, 3), 6, 4, 21);\\");
-        globals.variables.set(\\"t\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return t;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const t = wrap((x, y, z) => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"+\\", binaryOp(\\"+\\", x, y, 2, 9), z, 2, 9)
+      };
+    }, \\"function t(x, y, z) {\\\\n  return x + y + z;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(identity, 4, 0, t), t, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(t, 4, 21, 1, 2, 3), 6, 4, 21);\\");
+    globals.variables.set(\\"t\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return t;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -880,7 +840,7 @@ Object {
   "parsedErrors": "",
   "result": "[object Object]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -891,17 +851,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, {   a: 1 });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, {   a: 1 });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -952,7 +908,7 @@ o.a;",
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -963,25 +919,21 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const o = {};
-        setProp(o, \\"a\\", 1, 2, 0);
-        lastStatementResult = eval(\\"getProp(o, \\\\\\"a\\\\\\", 3, 0);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return o;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const o = {};
+    setProp(o, \\"a\\", 1, 2, 0);
+    lastStatementResult = eval(\\"getProp(o, \\\\\\"a\\\\\\", 3, 0);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1035,7 +987,7 @@ Object {
   "parsedErrors": "",
   "result": 60,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1046,17 +998,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(apply_in_underlying_javascript, 1, 0, wrap((a, b, c) => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", binaryOp(\\\\\\"*\\\\\\", a, b, 1, 44), c, 1, 44) }), \\\\\\"(a, b, c) => a * b * c\\\\\\"), callIfFuncAndRightArgs(list, 1, 55, 2, 5, 6));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(apply_in_underlying_javascript, 1, 0, wrap((a, b, c) => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", binaryOp(\\\\\\"*\\\\\\", a, b, 1, 44), c, 1, 44) }), \\\\\\"(a, b, c) => a * b * c\\\\\\", 1000), callIfFuncAndRightArgs(list, 1, 55, 2, 5, 6));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1076,7 +1024,7 @@ i;",
   "parsedErrors": "",
   "result": 0,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1087,40 +1035,36 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let i = 0;
-        const f = wrap(() => {
-          i = binaryOp(\\"+\\", i, 1, 3, 6);
-          return {
-            isTail: false,
-            value: i
-          };
-        }, \\"function f() {\\\\n  i = i + 1;\\\\n  return i;\\\\n}\\");
-        lastStatementResult = eval(\\"i;\\");
-        globals.variables.set(\\"i\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return i;
-          },
-          assignNewValue: function (unique) {
-            return i = unique;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let i = 0;
+    const f = wrap(() => {
+      i = binaryOp(\\"+\\", i, 1, 3, 6);
+      return {
+        isTail: false,
+        value: i
+      };
+    }, \\"function f() {\\\\n  i = i + 1;\\\\n  return i;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"i;\\");
+    globals.variables.set(\\"i\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return i;
+      },
+      assignNewValue: function (unique) {
+        return i = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1135,7 +1079,7 @@ Object {
   "parsedErrors": "",
   "result": 101,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1146,24 +1090,20 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
+const globals = native.globals;
+{
+  {
     {
+      let i = globals.previousScope.variables.get(\\"i\\").getValue();
+      const f = globals.previousScope.variables.get(\\"f\\").getValue();
       {
-        {
-          let i = globals.previousScope.variables.get(\\"i\\").getValue();
-          const f = globals.previousScope.variables.get(\\"f\\").getValue();
-          {
-            i = globals.previousScope.variables.get(\\"i\\").assignNewValue(100);
-            lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 1, 9);\\");
-          }
-        }
+        i = globals.previousScope.variables.get(\\"i\\").assignNewValue(100);
+        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 1, 9);\\");
       }
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1178,7 +1118,7 @@ Object {
   "parsedErrors": "",
   "result": 102,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1189,28 +1129,24 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
+const globals = native.globals;
+{
+  {
     {
+      let i = globals.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
+      const f = globals.previousScope.previousScope.previousScope.variables.get(\\"f\\").getValue();
       {
         {
-          let i = globals.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
-          const f = globals.previousScope.previousScope.previousScope.variables.get(\\"f\\").getValue();
           {
-            {
-              {
-                callIfFuncAndRightArgs(f, 1, 0);
-                lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
-              }
-            }
+            callIfFuncAndRightArgs(f, 1, 0);
+            lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
           }
         }
       }
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1225,7 +1161,7 @@ Object {
   "parsedErrors": "",
   "result": 102,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1236,31 +1172,27 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
+const globals = native.globals;
+{
+  {
     {
+      let i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
+      const f = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"f\\").getValue();
       {
         {
-          let i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
-          const f = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"f\\").getValue();
           {
             {
               {
-                {
-                  {
-                    lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
-                  }
-                }
+                lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
               }
             }
           }
         }
       }
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1275,7 +1207,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1286,17 +1218,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 1, callIfFuncAndRightArgs(list, 1, 7, 1, 2), callIfFuncAndRightArgs(pair, 1, 19, 1, 2)), 1, 0), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 35, callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3), callIfFuncAndRightArgs(list, 1, 56, 1, callIfFuncAndRightArgs(list, 1, 64, 2, 3))), 1, 34);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 1, callIfFuncAndRightArgs(list, 1, 7, 1, 2), callIfFuncAndRightArgs(pair, 1, 19, 1, 2)), 1, 0), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 35, callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3), callIfFuncAndRightArgs(list, 1, 56, 1, callIfFuncAndRightArgs(list, 1, 64, 2, 3))), 1, 34);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1311,7 +1239,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1322,17 +1250,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(list, 1, 6, 1, 2), callIfFuncAndRightArgs(pair, 1, 18, 1, callIfFuncAndRightArgs(pair, 1, 26, 2, null))), 1, 0) && callIfFuncAndRightArgs(equal, 1, 45, callIfFuncAndRightArgs(list, 1, 51, 1, 2, 3, 4), callIfFuncAndRightArgs(list, 1, 69, 1, 2, 3, 4));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(list, 1, 6, 1, 2), callIfFuncAndRightArgs(pair, 1, 18, 1, callIfFuncAndRightArgs(pair, 1, 26, 2, null))), 1, 0) && callIfFuncAndRightArgs(equal, 1, 45, callIfFuncAndRightArgs(list, 1, 51, 1, 2, 3, 4), callIfFuncAndRightArgs(list, 1, 69, 1, 2, 3, 4));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1347,7 +1271,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1358,17 +1282,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, 1, 1), 1, 0) && callIfFuncAndRightArgs(equal, 1, 15, \\\\\\"str\\\\\\", \\\\\\"str\\\\\\"), 1, 0) && callIfFuncAndRightArgs(equal, 1, 38, null, null), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 60, 1, 2), 1, 59), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 76, \\\\\\"str\\\\\\", \\\\\\"\\\\\\"), 1, 75);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, 1, 1), 1, 0) && callIfFuncAndRightArgs(equal, 1, 15, \\\\\\"str\\\\\\", \\\\\\"str\\\\\\"), 1, 0) && callIfFuncAndRightArgs(equal, 1, 38, null, null), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 60, 1, 2), 1, 59), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 76, \\\\\\"str\\\\\\", \\\\\\"\\\\\\"), 1, 75);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1385,7 +1305,7 @@ Object {
   "parsedErrors": "",
   "result": undefined,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1396,17 +1316,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {}\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {}\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1424,7 +1340,7 @@ Object {
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1435,17 +1351,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {   2; }\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {   2; }\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1465,7 +1377,7 @@ toString(a=>a) + toString(f);",
   return 5;
 }",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1476,29 +1388,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(x => {
-          return {
-            isTail: false,
-            value: 5
-          };
-        }, \\"function f(x) {\\\\n  return 5;\\\\n}\\");
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(toString, 4, 0, wrap(a => ({   isTail: false,   value: a }), \\\\\\"a => a\\\\\\")), callIfFuncAndRightArgs(toString, 4, 17, f), 4, 0);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(x => {
+      return {
+        isTail: false,
+        value: 5
+      };
+    }, \\"function f(x) {\\\\n  return 5;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(toString, 4, 0, wrap(a => ({   isTail: false,   value: a }), \\\\\\"a => a\\\\\\", 1000)), callIfFuncAndRightArgs(toString, 4, 17, f), 4, 0);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1547,7 +1455,7 @@ toString(NaN);",
   "parsedErrors": "",
   "result": "truefalse11.5nullundefinedNaN",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1558,17 +1466,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(toString, 1, 0, true), callIfFuncAndRightArgs(toString, 2, 0, false), 1, 0), callIfFuncAndRightArgs(toString, 3, 0, 1), 1, 0), callIfFuncAndRightArgs(toString, 4, 0, 1.5), 1, 0), callIfFuncAndRightArgs(toString, 5, 0, null), 1, 0), callIfFuncAndRightArgs(toString, 6, 0, undefined), 1, 0), callIfFuncAndRightArgs(toString, 7, 0, NaN), 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(toString, 1, 0, true), callIfFuncAndRightArgs(toString, 2, 0, false), 1, 0), callIfFuncAndRightArgs(toString, 3, 0, 1), 1, 0), callIfFuncAndRightArgs(toString, 4, 0, 1.5), 1, 0), callIfFuncAndRightArgs(toString, 5, 0, null), 1, 0), callIfFuncAndRightArgs(toString, 6, 0, undefined), 1, 0), callIfFuncAndRightArgs(toString, 7, 0, NaN), 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1583,7 +1487,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1594,17 +1498,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && callIfFuncAndRightArgs(1, 1, 9);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && callIfFuncAndRightArgs(1, 1, 9);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1619,7 +1519,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1630,17 +1530,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || callIfFuncAndRightArgs(1, 1, 8);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || callIfFuncAndRightArgs(1, 1, 8);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1655,7 +1551,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1666,17 +1562,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1691,7 +1583,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1702,17 +1594,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && true;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && true;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1727,7 +1615,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1738,17 +1626,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1763,7 +1647,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1774,17 +1658,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || true;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || true;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1799,7 +1679,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1810,17 +1690,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(false, 1, 0) ? true : false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) ? true : false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1835,7 +1711,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1846,17 +1722,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1871,7 +1743,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1882,17 +1754,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && true;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && true;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1907,7 +1775,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1918,17 +1786,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1943,7 +1807,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1954,17 +1818,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || true;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || true;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1979,7 +1839,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1990,17 +1850,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? true : false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? true : false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2017,7 +1873,7 @@ Object {
   "parsedErrors": "",
   "result": undefined,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2028,17 +1884,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {} else {}\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {} else {}\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2056,7 +1908,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2067,17 +1919,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {   1; } else {}\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {   1; } else {}\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/inspect.ts.snap
+++ b/src/__tests__/__snapshots__/inspect.ts.snap
@@ -4,7 +4,6 @@ exports[`debugger; pauses for 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 5,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -21,6 +20,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -1884,7 +2196,6 @@ exports[`debugger; pauses while 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 6,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -1901,6 +2212,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -3385,7 +4009,6 @@ exports[`debugger; statement basic test 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 0,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -3402,6 +4025,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -3864,7 +4800,6 @@ exports[`debugger; statement execution sequence 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 2,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -3881,6 +4816,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -4224,7 +5472,6 @@ exports[`debugger; statement hoisting 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 4,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -4241,6 +5488,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -5320,7 +6880,6 @@ exports[`debugger; statement in function 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 1,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -5337,6 +6896,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -6181,7 +8053,6 @@ exports[`debugger; statement test function scope 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 3,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -6198,6 +8069,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -8136,7 +10320,6 @@ exports[`setBreakpointAtLine basic 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 7,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -8153,6 +10336,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -22967,7 +25463,6 @@ exports[`setBreakpointAtLine for loops 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 15,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -22984,6 +25479,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -24494,7 +27302,6 @@ exports[`setBreakpointAtLine for loops 3`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 15,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -24511,6 +27318,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -26021,7 +29141,6 @@ exports[`setBreakpointAtLine for loops 5`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 15,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -26038,6 +29157,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -27548,7 +30980,6 @@ exports[`setBreakpointAtLine for loops 7`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 15,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -27565,6 +30996,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -29075,7 +32819,6 @@ exports[`setBreakpointAtLine for loops 9`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 15,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -29092,6 +32835,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -29433,7 +33489,6 @@ exports[`setBreakpointAtLine function 1 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 8,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -29450,6 +33505,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -30144,7 +34512,6 @@ exports[`setBreakpointAtLine function 2 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 9,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -30161,6 +34528,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -31070,7 +35750,6 @@ exports[`setBreakpointAtLine function 3 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 10,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -31087,6 +35766,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -31430,7 +36422,6 @@ exports[`setBreakpointAtLine function 4 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 11,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -31447,6 +36438,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -32074,7 +37378,6 @@ exports[`setBreakpointAtLine granularity 1 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 12,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -32091,6 +37394,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -33230,7 +38846,6 @@ exports[`setBreakpointAtLine granularity 1 3`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 12,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -33247,6 +38862,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -34386,7 +40314,6 @@ exports[`setBreakpointAtLine granularity 1 5`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 12,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -34403,6 +40330,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -35542,7 +41782,6 @@ exports[`setBreakpointAtLine granularity 2 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 13,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -35559,6 +41798,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -36715,7 +43267,6 @@ exports[`setBreakpointAtLine granularity 2 3`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 13,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -36732,6 +43283,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -37075,7 +43939,6 @@ exports[`setBreakpointAtLine granularity 3 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 14,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -37092,6 +43955,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -38247,7 +45423,6 @@ exports[`setBreakpointAtLine granularity 3 3`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 14,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -38264,6 +45439,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -39419,7 +46907,6 @@ exports[`setBreakpointAtLine granularity 3 5`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 14,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -39436,6 +46923,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -39779,7 +47579,6 @@ exports[`setBreakpointAtLine while loops 1`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 16,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -39796,6 +47595,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -40920,7 +49032,6 @@ exports[`setBreakpointAtLine while loops 3`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 16,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -40937,6 +49048,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -42191,7 +50615,6 @@ exports[`setBreakpointAtLine while loops 5`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 16,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -42208,6 +50631,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -43332,7 +52068,6 @@ exports[`setBreakpointAtLine while loops 7`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 16,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -43349,6 +52084,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {
@@ -44603,7 +53651,6 @@ exports[`setBreakpointAtLine while loops 9`] = `
 Object {
   "context": Object {
     "chapter": 3,
-    "contextId": 16,
     "debugger": Object {
       "observers": Object {
         "callbacks": Array [],
@@ -44620,6 +53667,319 @@ Object {
     "executionMethod": "interpreter",
     "externalContext": undefined,
     "externalSymbols": Array [],
+    "nativeStorage": Object {
+      "globals": Object {
+        "previousScope": null,
+        "variables": Map {
+          "runtime" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "raw_display" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stringify" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "error" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "prompt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_number" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_string" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_function" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_boolean" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "parse_int" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "undefined" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "NaN" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "Infinity" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_abs" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_acosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_asinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_atan2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_ceil" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cbrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_expm1" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_clz32" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cos" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_cosh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_exp" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_floor" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_fround" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_hypot" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_imul" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log1p" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_log10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_max" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_min" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_pow" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_random" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_round" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sign" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sin" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sinh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_sqrt" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tan" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_tanh" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_trunc" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN10" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LN2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG10E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_LOG2E" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_PI" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT1_2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "math_SQRT2" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_pair" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_null" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "draw_data" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_head" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "set_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "array_length" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "is_array" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream_tail" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+          "list_to_stream" => Object {
+            "getValue": [Function],
+            "kind": "const",
+          },
+        },
+      },
+      "gpu": Map {
+        "__createKernel" => [Function],
+      },
+      "maxExecTime": 1000,
+      "operators": Map {
+        "throwIfTimeout" => [Function],
+        "forceIt" => [Function],
+        "callIfFuncAndRightArgs" => [Function],
+        "boolOrErr" => [Function],
+        "unaryOp" => [Function],
+        "evaluateUnaryExpression" => [Function],
+        "binaryOp" => [Function],
+        "evaluateBinaryExpression" => [Function],
+        "callIteratively" => [Function],
+        "wrap" => [Function],
+        "setProp" => [Function],
+        "getProp" => [Function],
+      },
+    },
     "numberOfOuterEnvironments": 3,
     "prelude": null,
     "runtime": Object {

--- a/src/__tests__/__snapshots__/lazy.ts.snap
+++ b/src/__tests__/__snapshots__/lazy.ts.snap
@@ -9,7 +9,7 @@ Object {
   "parsedErrors": "",
   "result": 15,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -20,29 +20,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const add = wrap((x, y) => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"+\\", x, y, 1, 28)
-          };
-        }, \\"function add(x, y) {\\\\n  return x + y;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(add, 1, 37, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\"), 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", x, 1, 1, 64)     }), \\\\\\"x => x + 1\\\\\\"), 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     });   } });\\");
-        globals.variables.set(\\"add\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return add;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const add = wrap((x, y) => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"+\\", x, y, 1, 28)
+      };
+    }, \\"function add(x, y) {\\\\n  return x + y;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(add, 1, 37, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", 1000), 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", x, 1, 1, 64)     }), \\\\\\"x => x + 1\\\\\\", 1000), 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     });   } });\\");
+    globals.variables.set(\\"add\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return add;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -63,7 +59,7 @@ f(((b) => b)(true), ((b) => !b)(true));
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -74,50 +70,46 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((a, b) => {
-          return boolOrErr(boolOrErr(a, 3, 10) ? true : callIfFuncAndRightArgs(head, 3, 21, {
-            isThunk: true,
-            memoizedValue: 0,
-            isMemoized: false,
-            expr: () => {
-              return null;
-            }
-          }), 3, 9) && (boolOrErr(unaryOp(\\"!\\", b, 3, 37), 3, 37) ? {
-            isTail: false,
-            value: true
-          } : {
-            isTail: true,
-            function: head,
-            functionName: \\"head\\",
-            arguments: [{
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return null;
-              }
-            }],
-            line: 3,
-            column: 49
-          });
-        }, \\"function f(a, b) {\\\\n  return (a ? true : head(null)) && (!b ? true : head(null));\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: b     }), \\\\\\"b => b\\\\\\"), 6, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: unaryOp(\\\\\\"!\\\\\\", b, 6, 28)     }), \\\\\\"b => !b\\\\\\"), 6, 20, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } });\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
+const globals = native.globals;
+{
+  {
+    const f = wrap((a, b) => {
+      return boolOrErr(boolOrErr(a, 3, 10) ? true : callIfFuncAndRightArgs(head, 3, 21, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return null;
+        }
+      }), 3, 9) && (boolOrErr(unaryOp(\\"!\\", b, 3, 37), 3, 37) ? {
+        isTail: false,
+        value: true
+      } : {
+        isTail: true,
+        function: head,
+        functionName: \\"head\\",
+        arguments: [{
+          isThunk: true,
+          memoizedValue: 0,
+          isMemoized: false,
+          expr: () => {
+            return null;
           }
-        });
+        }],
+        line: 3,
+        column: 49
+      });
+    }, \\"function f(a, b) {\\\\n  return (a ? true : head(null)) && (!b ? true : head(null));\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: b     }), \\\\\\"b => b\\\\\\", 1000), 6, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: unaryOp(\\\\\\"!\\\\\\", b, 6, 28)     }), \\\\\\"b => !b\\\\\\", 1000), 6, 20, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } });\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -138,7 +130,7 @@ test2(1);
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -149,69 +141,65 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap((a, b) => {
-          return boolOrErr(binaryOp(\\"===\\", a, 1, 2, 29), 2, 29) ? {
-            isTail: false,
-            value: a
-          } : {
-            isTail: false,
-            value: b
-          };
-        }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\");
-        const test2 = wrap(a => {
-          return {
-            isTail: true,
-            function: test,
-            functionName: \\"test\\",
-            arguments: [{
+const globals = native.globals;
+{
+  {
+    const test = wrap((a, b) => {
+      return boolOrErr(binaryOp(\\"===\\", a, 1, 2, 29), 2, 29) ? {
+        isTail: false,
+        value: a
+      } : {
+        isTail: false,
+        value: b
+      };
+    }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\", 1000);
+    const test2 = wrap(a => {
+      return {
+        isTail: true,
+        function: test,
+        functionName: \\"test\\",
+        arguments: [{
+          isThunk: true,
+          memoizedValue: 0,
+          isMemoized: false,
+          expr: () => {
+            return a;
+          }
+        }, {
+          isThunk: true,
+          memoizedValue: 0,
+          isMemoized: false,
+          expr: () => {
+            return callIfFuncAndRightArgs(head, 4, 35, {
               isThunk: true,
               memoizedValue: 0,
               isMemoized: false,
               expr: () => {
-                return a;
+                return null;
               }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return callIfFuncAndRightArgs(head, 4, 35, {
-                  isThunk: true,
-                  memoizedValue: 0,
-                  isMemoized: false,
-                  expr: () => {
-                    return null;
-                  }
-                });
-              }
-            }],
-            line: 4,
-            column: 27
-          };
-        }, \\"function test2(a) {\\\\n  return test(a, head(null));\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test2, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
+            });
           }
-        });
-        globals.variables.set(\\"test2\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test2;
-          }
-        });
+        }],
+        line: 4,
+        column: 27
+      };
+    }, \\"function test2(a) {\\\\n  return test(a, head(null));\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test2, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"test2\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test2;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -238,7 +226,7 @@ square(incX());",
   "parsedErrors": "",
   "result": 4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -249,52 +237,48 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let x = 1;
-        const incX = wrap(() => {
-          x = binaryOp(\\"+\\", x, 1, 5, 6);
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function incX() {\\\\n  x = x + 1;\\\\n  return x;\\\\n}\\");
-        const square = wrap(n => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"*\\", n, n, 10, 9)
-          };
-        }, \\"function square(n) {\\\\n  return n * n;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(square, 13, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(incX, 13, 7);   } });\\");
-        globals.variables.set(\\"x\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return x;
-          },
-          assignNewValue: function (unique) {
-            return x = unique;
-          }
-        });
-        globals.variables.set(\\"incX\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return incX;
-          }
-        });
-        globals.variables.set(\\"square\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return square;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let x = 1;
+    const incX = wrap(() => {
+      x = binaryOp(\\"+\\", x, 1, 5, 6);
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function incX() {\\\\n  x = x + 1;\\\\n  return x;\\\\n}\\", 1000);
+    const square = wrap(n => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"*\\", n, n, 10, 9)
+      };
+    }, \\"function square(n) {\\\\n  return n * n;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(square, 13, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(incX, 13, 7);   } });\\");
+    globals.variables.set(\\"x\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return x;
+      },
+      assignNewValue: function (unique) {
+        return x = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"incX\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return incX;
+      }
+    });
+    globals.variables.set(\\"square\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return square;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -318,7 +302,7 @@ addSome2(3);
   "parsedErrors": "",
   "result": 6,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -329,47 +313,43 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const addSome = wrap(x => {
-          const y = binaryOp(\\"+\\", x, 1, 3, 12);
-          return {
-            isTail: false,
-            value: wrap(z => ({
-              isTail: false,
-              value: binaryOp(\\"+\\", y, z, 4, 14)
-            }), \\"z => y + z\\")
-          };
-        }, \\"function addSome(x) {\\\\n  const y = x + 1;\\\\n  return z => y + z;\\\\n}\\");
-        const addSome2 = callIfFuncAndRightArgs(addSome, 7, 17, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 2;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(addSome2, 9, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
-        globals.variables.set(\\"addSome\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return addSome;
-          }
-        });
-        globals.variables.set(\\"addSome2\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return addSome2;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const addSome = wrap(x => {
+      const y = binaryOp(\\"+\\", x, 1, 3, 12);
+      return {
+        isTail: false,
+        value: wrap(z => ({
+          isTail: false,
+          value: binaryOp(\\"+\\", y, z, 4, 14)
+        }), \\"z => y + z\\", 1000)
+      };
+    }, \\"function addSome(x) {\\\\n  const y = x + 1;\\\\n  return z => y + z;\\\\n}\\", 1000);
+    const addSome2 = callIfFuncAndRightArgs(addSome, 7, 17, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 2;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(addSome2, 9, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
+    globals.variables.set(\\"addSome\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return addSome;
+      }
+    });
+    globals.variables.set(\\"addSome2\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return addSome2;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -384,7 +364,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -395,29 +375,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const neg = wrap(b => {
-          return {
-            isTail: false,
-            value: unaryOp(\\"!\\", b, 1, 25)
-          };
-        }, \\"function neg(b) {\\\\n  return !b;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(neg, 1, 31, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\"), 1, 35, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return false;       }     });   } });\\");
-        globals.variables.set(\\"neg\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return neg;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const neg = wrap(b => {
+      return {
+        isTail: false,
+        value: unaryOp(\\"!\\", b, 1, 25)
+      };
+    }, \\"function neg(b) {\\\\n  return !b;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(neg, 1, 31, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", 1000), 1, 35, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return false;       }     });   } });\\");
+    globals.variables.set(\\"neg\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return neg;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -432,7 +408,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -443,32 +419,28 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const test = wrap((a, b) => {
-          return boolOrErr(binaryOp(\\"===\\", a, 1, 1, 29), 1, 29) ? {
-            isTail: false,
-            value: a
-          } : {
-            isTail: false,
-            value: b
-          };
-        }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 1, 48, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     });   } });\\");
-        globals.variables.set(\\"test\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return test;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const test = wrap((a, b) => {
+      return boolOrErr(binaryOp(\\"===\\", a, 1, 1, 29), 1, 29) ? {
+        isTail: false,
+        value: a
+      } : {
+        isTail: false,
+        value: b
+      };
+    }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 1, 48, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     });   } });\\");
+    globals.variables.set(\\"test\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return test;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/return-regressions.ts.snap
+++ b/src/__tests__/__snapshots__/return-regressions.ts.snap
@@ -23,7 +23,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -34,52 +34,48 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const f = wrap(() => {
-          const startTime = runtime();
-          for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 6, 22), 6, 6); i = binaryOp(\\"+\\", i, 1, 6, 35)) {
-            throwIfTimeout(startTime, runtime(), 6, 6);
-            return {
-              isTail: false,
-              value: binaryOp(\\"+\\", i, 1, 7, 15)
-            };
-            callIfFuncAndRightArgs(unreachable, 8, 8);
-          }
-          callIfFuncAndRightArgs(unreachable, 10, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 12, 6);
-        }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return i + 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      const startTime = runtime();
+      for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 6, 22), 6, 6); i = binaryOp(\\"+\\", i, 1, 6, 35)) {
+        throwIfTimeout(1000, startTime, runtime(), 6, 6);
+        return {
+          isTail: false,
+          value: binaryOp(\\"+\\", i, 1, 7, 15)
+        };
+        callIfFuncAndRightArgs(unreachable, 8, 8);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      callIfFuncAndRightArgs(unreachable, 10, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 12, 6);
+    }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return i + 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -108,7 +104,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -119,50 +115,46 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const f = wrap(() => {
-          if (boolOrErr(true, 6, 6)) {
-            return {
-              isTail: false,
-              value: 1
-            };
-            callIfFuncAndRightArgs(unreachable, 8, 8);
-          } else {}
-          callIfFuncAndRightArgs(unreachable, 10, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 12, 6);
-        }, \\"function f() {\\\\n  if (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      if (boolOrErr(true, 6, 6)) {
+        return {
+          isTail: false,
+          value: 1
+        };
+        callIfFuncAndRightArgs(unreachable, 8, 8);
+      } else {}
+      callIfFuncAndRightArgs(unreachable, 10, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 12, 6);
+    }, \\"function f() {\\\\n  if (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -191,7 +183,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -202,52 +194,48 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const f = wrap(() => {
-          const startTime = runtime();
-          while (boolOrErr(true, 6, 6)) {
-            throwIfTimeout(startTime, runtime(), 6, 6);
-            return {
-              isTail: false,
-              value: 1
-            };
-            callIfFuncAndRightArgs(unreachable, 8, 8);
-          }
-          callIfFuncAndRightArgs(unreachable, 10, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 12, 6);
-        }, \\"function f() {\\\\n  while (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      const startTime = runtime();
+      while (boolOrErr(true, 6, 6)) {
+        throwIfTimeout(1000, startTime, runtime(), 6, 6);
+        return {
+          isTail: false,
+          value: 1
+        };
+        callIfFuncAndRightArgs(unreachable, 8, 8);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      callIfFuncAndRightArgs(unreachable, 10, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 12, 6);
+    }, \\"function f() {\\\\n  while (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -273,7 +261,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -284,47 +272,43 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const f = wrap(() => {
-          return {
-            isTail: false,
-            value: 1
-          };
-          callIfFuncAndRightArgs(unreachable, 7, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 9, 6);
-        }, \\"function f() {\\\\n  return 1;\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 11, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      return {
+        isTail: false,
+        value: 1
+      };
+      callIfFuncAndRightArgs(unreachable, 7, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 9, 6);
+    }, \\"function f() {\\\\n  return 1;\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 11, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -393,7 +377,7 @@ Object {
   "parsedErrors": "",
   "result": 3,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -404,61 +388,57 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          const startTime = runtime();
-          for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", i, 1, 9, 35)) {
-            throwIfTimeout(startTime, runtime(), 9, 6);
-            return {
-              isTail: false,
-              value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 10, 15, binaryOp(\\"+\\", i, 1, 10, 18)), callIfFuncAndRightArgs(id, 10, 25, binaryOp(\\"+\\", i, 2, 10, 28)), 10, 15)
-            };
-          }
-          return {
-            isTail: false,
-            value: 0
-          };
-        }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1) + id(i + 2);\\\\n  }\\\\n  return 0;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      const startTime = runtime();
+      for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", i, 1, 9, 35)) {
+        throwIfTimeout(1000, startTime, runtime(), 9, 6);
+        return {
+          isTail: false,
+          value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 10, 15, binaryOp(\\"+\\", i, 1, 10, 18)), callIfFuncAndRightArgs(id, 10, 25, binaryOp(\\"+\\", i, 2, 10, 28)), 10, 15)
+        };
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      return {
+        isTail: false,
+        value: 0
+      };
+    }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1) + id(i + 2);\\\\n  }\\\\n  return 0;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
+      }
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -490,7 +470,7 @@ Object {
   "parsedErrors": "",
   "result": 3,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -501,62 +481,58 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          if (boolOrErr(true, 9, 6)) {
-            return {
-              isTail: false,
-              value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
-            };
-            callIfFuncAndRightArgs(unreachable, 11, 8);
-          } else {}
-          callIfFuncAndRightArgs(unreachable, 13, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 15, 6);
-        }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      if (boolOrErr(true, 9, 6)) {
+        return {
+          isTail: false,
+          value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
+        };
+        callIfFuncAndRightArgs(unreachable, 11, 8);
+      } else {}
+      callIfFuncAndRightArgs(unreachable, 13, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 15, 6);
+    }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -588,7 +564,7 @@ Object {
   "parsedErrors": "",
   "result": 3,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -599,64 +575,60 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          const startTime = runtime();
-          while (boolOrErr(true, 9, 6)) {
-            throwIfTimeout(startTime, runtime(), 9, 6);
-            return {
-              isTail: false,
-              value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
-            };
-            callIfFuncAndRightArgs(unreachable, 11, 8);
-          }
-          callIfFuncAndRightArgs(unreachable, 13, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 15, 6);
-        }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      const startTime = runtime();
+      while (boolOrErr(true, 9, 6)) {
+        throwIfTimeout(1000, startTime, runtime(), 9, 6);
+        return {
+          isTail: false,
+          value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
+        };
+        callIfFuncAndRightArgs(unreachable, 11, 8);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      callIfFuncAndRightArgs(unreachable, 13, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 15, 6);
+    }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
+      }
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -685,7 +657,7 @@ Object {
   "parsedErrors": "",
   "result": 3,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -696,59 +668,55 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 9, 13, 1), callIfFuncAndRightArgs(id, 9, 21, 2), 9, 13)
-          };
-          callIfFuncAndRightArgs(unreachable, 10, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 12, 6);
-        }, \\"function f() {\\\\n  return id(1) + id(2);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"+\\", callIfFuncAndRightArgs(id, 9, 13, 1), callIfFuncAndRightArgs(id, 9, 21, 2), 9, 13)
+      };
+      callIfFuncAndRightArgs(unreachable, 10, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 12, 6);
+    }, \\"function f() {\\\\n  return id(1) + id(2);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -780,7 +748,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -791,68 +759,64 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          const startTime = runtime();
-          for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", i, 1, 9, 35)) {
-            throwIfTimeout(startTime, runtime(), 9, 6);
-            return {
-              isTail: true,
-              function: id,
-              functionName: \\"id\\",
-              arguments: [binaryOp(\\"+\\", i, 1, 10, 18)],
-              line: 10,
-              column: 15
-            };
-            callIfFuncAndRightArgs(unreachable, 11, 8);
-          }
-          callIfFuncAndRightArgs(unreachable, 13, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 15, 6);
-        }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      const startTime = runtime();
+      for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", i, 1, 9, 35)) {
+        throwIfTimeout(1000, startTime, runtime(), 9, 6);
+        return {
+          isTail: true,
+          function: id,
+          functionName: \\"id\\",
+          arguments: [binaryOp(\\"+\\", i, 1, 10, 18)],
+          line: 10,
+          column: 15
+        };
+        callIfFuncAndRightArgs(unreachable, 11, 8);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      callIfFuncAndRightArgs(unreachable, 13, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 15, 6);
+    }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
+      }
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -884,7 +848,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -895,66 +859,62 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          if (boolOrErr(true, 9, 6)) {
-            return {
-              isTail: true,
-              function: id,
-              functionName: \\"id\\",
-              arguments: [1],
-              line: 10,
-              column: 15
-            };
-            callIfFuncAndRightArgs(unreachable, 11, 8);
-          } else {}
-          callIfFuncAndRightArgs(unreachable, 13, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 15, 6);
-        }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      if (boolOrErr(true, 9, 6)) {
+        return {
+          isTail: true,
+          function: id,
+          functionName: \\"id\\",
+          arguments: [1],
+          line: 10,
+          column: 15
+        };
+        callIfFuncAndRightArgs(unreachable, 11, 8);
+      } else {}
+      callIfFuncAndRightArgs(unreachable, 13, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 15, 6);
+    }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -986,7 +946,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -997,68 +957,64 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          const startTime = runtime();
-          while (boolOrErr(true, 9, 6)) {
-            throwIfTimeout(startTime, runtime(), 9, 6);
-            return {
-              isTail: true,
-              function: id,
-              functionName: \\"id\\",
-              arguments: [1],
-              line: 10,
-              column: 15
-            };
-            callIfFuncAndRightArgs(unreachable, 11, 8);
-          }
-          callIfFuncAndRightArgs(unreachable, 13, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 15, 6);
-        }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      const startTime = runtime();
+      while (boolOrErr(true, 9, 6)) {
+        throwIfTimeout(1000, startTime, runtime(), 9, 6);
+        return {
+          isTail: true,
+          function: id,
+          functionName: \\"id\\",
+          arguments: [1],
+          line: 10,
+          column: 15
+        };
+        callIfFuncAndRightArgs(unreachable, 11, 8);
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+      callIfFuncAndRightArgs(unreachable, 13, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 15, 6);
+    }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
+      }
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1087,7 +1043,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1098,63 +1054,59 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const unreachable = wrap(() => {
-          return {
-            isTail: false,
-            value: binaryOp(\\"<\\", 1, true, 3, 13)
-          };
-        }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\");
-        const id = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function id(x) {\\\\n  return x;\\\\n}\\");
-        const f = wrap(() => {
-          return {
-            isTail: true,
-            function: id,
-            functionName: \\"id\\",
-            arguments: [1],
-            line: 9,
-            column: 13
-          };
-          callIfFuncAndRightArgs(unreachable, 10, 6);
-          return {
-            isTail: false,
-            value: 0
-          };
-          callIfFuncAndRightArgs(unreachable, 12, 6);
-        }, \\"function f() {\\\\n  return id(1);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-        globals.variables.set(\\"unreachable\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return unreachable;
-          }
-        });
-        globals.variables.set(\\"id\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return id;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const unreachable = wrap(() => {
+      return {
+        isTail: false,
+        value: binaryOp(\\"<\\", 1, true, 3, 13)
+      };
+    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", 1000);
+    const id = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", 1000);
+    const f = wrap(() => {
+      return {
+        isTail: true,
+        function: id,
+        functionName: \\"id\\",
+        arguments: [1],
+        line: 9,
+        column: 13
+      };
+      callIfFuncAndRightArgs(unreachable, 10, 6);
+      return {
+        isTail: false,
+        value: 0
+      };
+      callIfFuncAndRightArgs(unreachable, 12, 6);
+    }, \\"function f() {\\\\n  return id(1);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+    globals.variables.set(\\"unreachable\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return unreachable;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"id\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return id;
+      }
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/stdlib.ts.snap
+++ b/src/__tests__/__snapshots__/stdlib.ts.snap
@@ -11,7 +11,7 @@ Object {
   "parsedErrors": "",
   "result": "message",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -22,17 +22,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 'message');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 'message');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -76,7 +72,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -87,17 +83,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, undefined);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, undefined);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -112,7 +104,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -123,17 +115,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, null);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, null);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -148,7 +136,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -159,17 +147,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, undefined);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, undefined);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -184,7 +168,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -195,17 +179,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, null);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, null);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -220,7 +200,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -231,17 +211,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'string');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'string');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -256,7 +232,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -267,17 +243,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'true');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'true');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -292,7 +264,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -303,17 +275,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, '1');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, '1');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -328,7 +296,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -339,17 +307,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, true);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, true);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -364,7 +328,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -375,17 +339,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -400,7 +360,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -411,17 +371,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'string');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'string');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -436,7 +392,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -447,17 +403,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'true');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'true');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -472,7 +424,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -483,17 +435,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, '1');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, '1');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -508,7 +456,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -519,17 +467,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, true);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, true);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -544,7 +488,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -555,17 +499,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -580,7 +520,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -591,17 +531,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'string');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'string');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -616,7 +552,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -627,17 +563,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'true');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'true');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -652,7 +584,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -663,17 +595,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, '1');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, '1');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -688,7 +616,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -699,17 +627,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, true);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, true);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -724,7 +648,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -735,17 +659,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -760,7 +680,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -771,17 +691,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, display);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, display);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -796,7 +712,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -807,17 +723,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\"));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", 1000));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -835,7 +747,7 @@ is_function(f);",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -846,29 +758,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function f(x) {\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 4, 0, f);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function f(x) {\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 4, 0, f);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -883,7 +791,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -894,17 +802,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -919,7 +823,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -930,17 +834,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -955,7 +855,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -966,17 +866,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, callIfFuncAndRightArgs(pair, 1, 9, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, callIfFuncAndRightArgs(pair, 1, 9, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -991,7 +887,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1002,17 +898,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, [1]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, [1]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1235,7 +1127,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1246,17 +1138,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(array_length, 1, 0, [1]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(array_length, 1, 0, [1]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1271,7 +1159,7 @@ Object {
   "parsedErrors": "",
   "result": 10,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1282,17 +1170,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 10);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 10);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1307,7 +1191,7 @@ Object {
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1318,17 +1202,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 2);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 2);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1343,7 +1223,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1354,17 +1234,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, callIfFuncAndRightArgs(runtime, 1, 10));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, callIfFuncAndRightArgs(runtime, 1, 10));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1387,7 +1263,7 @@ repeatUntilDifferentTime();",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1398,47 +1274,43 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const start = callIfFuncAndRightArgs(runtime, 1, 14);
-        const repeatUntilDifferentTime = wrap(() => {
-          if (boolOrErr(binaryOp(\\"===\\", start, callIfFuncAndRightArgs(runtime, 3, 16), 3, 6), 3, 2)) {
-            return {
-              isTail: true,
-              function: repeatUntilDifferentTime,
-              functionName: \\"repeatUntilDifferentTime\\",
-              arguments: [],
-              line: 4,
-              column: 11
-            };
-          } else {
-            return {
-              isTail: false,
-              value: true
-            };
-          }
-        }, \\"function repeatUntilDifferentTime() {\\\\n  if (start === runtime()) {\\\\n    return repeatUntilDifferentTime();\\\\n  } else {\\\\n    return true;\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(repeatUntilDifferentTime, 9, 0);\\");
-        globals.variables.set(\\"start\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return start;
-          }
-        });
-        globals.variables.set(\\"repeatUntilDifferentTime\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return repeatUntilDifferentTime;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const start = callIfFuncAndRightArgs(runtime, 1, 14);
+    const repeatUntilDifferentTime = wrap(() => {
+      if (boolOrErr(binaryOp(\\"===\\", start, callIfFuncAndRightArgs(runtime, 3, 16), 3, 6), 3, 2)) {
+        return {
+          isTail: true,
+          function: repeatUntilDifferentTime,
+          functionName: \\"repeatUntilDifferentTime\\",
+          arguments: [],
+          line: 4,
+          column: 11
+        };
+      } else {
+        return {
+          isTail: false,
+          value: true
+        };
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"function repeatUntilDifferentTime() {\\\\n  if (start === runtime()) {\\\\n    return repeatUntilDifferentTime();\\\\n  } else {\\\\n    return true;\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(repeatUntilDifferentTime, 9, 0);\\");
+    globals.variables.set(\\"start\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return start;
+      }
+    });
+    globals.variables.set(\\"repeatUntilDifferentTime\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return repeatUntilDifferentTime;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1456,7 +1328,7 @@ Object {
     2,
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1467,17 +1339,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 2);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 2);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1498,7 +1366,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1509,17 +1377,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1, 2);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1, 2);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1534,7 +1398,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1545,17 +1409,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1570,7 +1430,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1581,17 +1441,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(pair, 1, 8, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(pair, 1, 8, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1606,7 +1462,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1617,17 +1473,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1642,7 +1494,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1653,17 +1505,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1678,7 +1526,7 @@ Object {
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1689,17 +1537,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1830,7 +1674,7 @@ Object {
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1841,17 +1685,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, callIfFuncAndRightArgs(list, 1, 7, 1, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, callIfFuncAndRightArgs(list, 1, 7, 1, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/stringify.ts.snap
+++ b/src/__tests__/__snapshots__/stringify.ts.snap
@@ -10,7 +10,7 @@ stringify(xs);",
   "parsedErrors": "",
   "result": "[1, \\"true\\", true, () => 1]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -21,27 +21,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const xs = [1, 'true', true, wrap(() => ({
-          isTail: false,
-          value: 1
-        }), \\"() => 1\\")];
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
-        globals.variables.set(\\"xs\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return xs;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const xs = [1, 'true', true, wrap(() => ({
+      isTail: false,
+      value: 1
+    }), \\"() => 1\\", 1000)];
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
+    globals.variables.set(\\"xs\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return xs;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -57,7 +53,7 @@ stringify(f);",
   "parsedErrors": "",
   "result": "(x, y) => x",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -68,27 +64,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => ({
-          isTail: false,
-          value: x
-        }), \\"(x, y) => x\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, f);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => ({
+      isTail: false,
+      value: x
+    }), \\"(x, y) => x\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, f);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -115,7 +107,7 @@ stringify(o);",
   \\"m\\": 0,
   \\"n\\": 0 }",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -126,43 +118,39 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const o = {
-          a: 1,
-          b: true,
-          c: wrap(() => ({
-            isTail: false,
-            value: 1
-          }), \\"() => 1\\"),
-          d: {
-            e: 5,
-            f: 6
-          },
-          g: 0,
-          h: 0,
-          i: 0,
-          j: 0,
-          k: 0,
-          l: 0,
-          m: 0,
-          n: 0
-        };
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return o;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const o = {
+      a: 1,
+      b: true,
+      c: wrap(() => ({
+        isTail: false,
+        value: 1
+      }), \\"() => 1\\", 1000),
+      d: {
+        e: 5,
+        f: 6
+      },
+      g: 0,
+      h: 0,
+      i: 0,
+      j: 0,
+      k: 0,
+      l: 0,
+      m: 0,
+      n: 0
+    };
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -177,7 +165,7 @@ Object {
   "parsedErrors": "",
   "result": "\\"true\\"",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -188,17 +176,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'true');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'true');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -215,7 +199,7 @@ Object {
 	[implementation hidden]
 }",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -226,17 +210,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -252,7 +232,7 @@ stringify(xs);",
   "parsedErrors": "",
   "result": "[]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -263,24 +243,20 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const xs = [];
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
-        globals.variables.set(\\"xs\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return xs;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const xs = [];
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
+    globals.variables.set(\\"xs\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return xs;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -300,7 +276,7 @@ stringify(f);",
   return x;
 }",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -311,29 +287,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function f(x, y) {\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 4, 0, f);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function f(x, y) {\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 4, 0, f);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -451,7 +423,7 @@ stringify(arr);",
   98,
   99 ]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -462,35 +434,31 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const arr = [];
-        const startTime = runtime();
-        for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 2, 16), 2, 0); i = binaryOp(\\"+\\", i, 1, 2, 29)) {
-          throwIfTimeout(startTime, runtime(), 2, 0);
-          setProp(arr, i, i, 3, 2);
-        }
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 5, 0, arr);\\");
-        globals.variables.set(\\"arr\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return arr;
-          }
-        });
-        globals.variables.set(\\"startTime\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return startTime;
-          }
-        });
-      }
+const globals = native.globals;
+{
+  {
+    const arr = [];
+    const startTime = runtime();
+    for (let i = 0; boolOrErr(binaryOp(\\"<\\", i, 100, 2, 16), 2, 0); i = binaryOp(\\"+\\", i, 1, 2, 29)) {
+      throwIfTimeout(1000, startTime, runtime(), 2, 0);
+      setProp(arr, i, i, 3, 2);
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 5, 0, arr);\\");
+    globals.variables.set(\\"arr\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return arr;
+      }
+    });
+    globals.variables.set(\\"startTime\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return startTime;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -593,7 +561,7 @@ Object {
 [ 88,
 [89, [90, [91, [92, [93, [94, [95, [96, [97, [98, [99, [100, null]]]]]]]]]]]] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ] ]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -604,17 +572,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 100));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 100));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -629,7 +593,7 @@ Object {
   "parsedErrors": "",
   "result": "[1, [2, [3, [4, [5, [6, [7, [8, [9, [10, null]]]]]]]]]]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -640,17 +604,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 10));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 10));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -666,7 +626,7 @@ stringify(xs);",
   "parsedErrors": "",
   "result": "[1, \\"true\\", [true, () => 1, [[]]]]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -677,27 +637,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const xs = [1, 'true', [true, wrap(() => ({
-          isTail: false,
-          value: 1
-        }), \\"() => 1\\"), [[]]]];
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
-        globals.variables.set(\\"xs\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return xs;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const xs = [1, 'true', [true, wrap(() => ({
+      isTail: false,
+      value: 1
+    }), \\"() => 1\\", 1000), [[]]]];
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
+    globals.variables.set(\\"xs\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return xs;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -713,7 +669,7 @@ stringify(o);",
   "parsedErrors": "",
   "result": "{\\"a\\": 1, \\"b\\": true, \\"c\\": () => 1, \\"d\\": {\\"e\\": 5, \\"f\\": 6}}",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -724,35 +680,31 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const o = {
-          a: 1,
-          b: true,
-          c: wrap(() => ({
-            isTail: false,
-            value: 1
-          }), \\"() => 1\\"),
-          d: {
-            e: 5,
-            f: 6
-          }
-        };
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return o;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const o = {
+      a: 1,
+      b: true,
+      c: wrap(() => ({
+        isTail: false,
+        value: 1
+      }), \\"() => 1\\", 1000),
+      d: {
+        e: 5,
+        f: 6
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    };
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -769,7 +721,7 @@ stringify(o);",
   "parsedErrors": "",
   "result": "{\\"o\\": ...<circular>}",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -780,28 +732,24 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let o = {};
-        setProp(o, \\"o\\", o, 2, 0);
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 3, 0, o);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return o;
-          },
-          assignNewValue: function (unique) {
-            return o = unique;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let o = {};
+    setProp(o, \\"o\\", o, 2, 0);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 3, 0, o);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return o;
+      },
+      assignNewValue: function (unique) {
+        return o = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -816,7 +764,7 @@ Object {
   "parsedErrors": "",
   "result": "null",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -827,17 +775,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, null);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, null);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -852,7 +796,7 @@ Object {
   "parsedErrors": "",
   "result": "0",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -863,17 +807,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -889,7 +829,7 @@ stringify(o);",
   "parsedErrors": "",
   "result": "{\\"a\\": 1, \\"b\\": true, \\"c\\": () => 1}",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -900,31 +840,27 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const o = {
-          a: 1,
-          b: true,
-          c: wrap(() => ({
-            isTail: false,
-            value: 1
-          }), \\"() => 1\\")
-        };
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
-        globals.variables.set(\\"o\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return o;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const o = {
+      a: 1,
+      b: true,
+      c: wrap(() => ({
+        isTail: false,
+        value: 1
+      }), \\"() => 1\\", 1000)
+    };
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -939,7 +875,7 @@ Object {
   "parsedErrors": "",
   "result": "\\"a string\\"",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -950,17 +886,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'a string');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'a string');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -975,7 +907,7 @@ Object {
   "parsedErrors": "",
   "result": "undefined",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -986,17 +918,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, undefined);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, undefined);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1013,7 +941,7 @@ Object {
 [[[\\"name\\", [\\"x\\", null]], null],
 [[\\"return_statement\\", [[\\"name\\", [\\"x\\", null]], null]], null]]]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1024,17 +952,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1051,7 +975,7 @@ Object {
 [... [[\\"name\\", [\\"x\\", null]], null],
 [[\\"return_statement\\", [[\\"name\\", [\\"x\\", null]], null]], null] ...] ...]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1062,17 +986,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), ' ... ');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), ' ... ');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1089,7 +1009,7 @@ Object {
 [ [[\\"name\\", [\\"x\\", null]], null],
 [[\\"return_statement\\", [[\\"name\\", [\\"x\\", null]], null]], null] ] ]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1100,17 +1020,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1127,7 +1043,7 @@ Object {
 [.........[[\\"name\\", [\\"x\\", null]], null],
 [[\\"return_statement\\", [[\\"name\\", [\\"x\\", null]], null]], null].........].........]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1138,17 +1054,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), '.................................');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), '.................................');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1165,7 +1077,7 @@ Object {
 [         [[\\"name\\", [\\"x\\", null]], null],
 [[\\"return_statement\\", [[\\"name\\", [\\"x\\", null]], null]], null]         ]         ]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1176,17 +1088,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 100);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 100);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1201,7 +1109,7 @@ Object {
   "parsedErrors": "",
   "result": "[\\"function_definition\\", [[[\\"name\\", [\\"x\\", null]], null], [[\\"return_statement\\", [[\\"name\\", [\\"x\\", null]], null]], null]]]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1212,17 +1120,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/__tests__/__snapshots__/tailcall-return.ts.snap
+++ b/src/__tests__/__snapshots__/tailcall-return.ts.snap
@@ -16,7 +16,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -27,40 +27,36 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
-            return {
-              isTail: false,
-              value: y
-            };
-          } else {
-            return {
-              isTail: true,
-              function: f,
-              functionName: \\"f\\",
-              arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, 1, 5, 18)],
-              line: 5,
-              column: 11
-            };
-          }
-        }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
+        return {
+          isTail: false,
+          value: y
+        };
+      } else {
+        return {
+          isTail: true,
+          function: f,
+          functionName: \\"f\\",
+          arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, 1, 5, 18)],
+          line: 5,
+          column: 11
+        };
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -82,7 +78,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -93,40 +89,36 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
-            return {
-              isTail: false,
-              value: y
-            };
-          } else {
-            return boolOrErr(false, 5, 11) || ({
-              isTail: true,
-              function: f,
-              functionName: \\"f\\",
-              arguments: [binaryOp(\\"-\\", x, 1, 5, 22), binaryOp(\\"+\\", y, 1, 5, 27)],
-              line: 5,
-              column: 20
-            });
-          }
-        }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return false || f(x - 1, y + 1);\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
+        return {
+          isTail: false,
+          value: y
+        };
+      } else {
+        return boolOrErr(false, 5, 11) || ({
+          isTail: true,
+          function: f,
+          functionName: \\"f\\",
+          arguments: [binaryOp(\\"-\\", x, 1, 5, 22), binaryOp(\\"+\\", y, 1, 5, 27)],
+          line: 5,
+          column: 20
         });
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return false || f(x - 1, y + 1);\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -144,7 +136,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -155,36 +147,32 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          return boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 9), 2, 9) ? {
-            isTail: false,
-            value: y
-          } : {
-            isTail: true,
-            function: f,
-            functionName: \\"f\\",
-            arguments: [binaryOp(\\"-\\", x, 1, 2, 24), binaryOp(\\"+\\", y, 1, 2, 29)],
-            line: 2,
-            column: 22
-          };
-        }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : f(x - 1, y + 1);\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      return boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 9), 2, 9) ? {
+        isTail: false,
+        value: y
+      } : {
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", x, 1, 2, 24), binaryOp(\\"+\\", y, 1, 2, 29)],
+        line: 2,
+        column: 22
+      };
+    }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : f(x - 1, y + 1);\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -202,7 +190,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -213,39 +201,35 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          return boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 9), 2, 9) ? {
-            isTail: false,
-            value: y
-          } : boolOrErr(boolOrErr(false, 2, 22) || binaryOp(\\">\\", x, 0, 2, 31), 2, 22) ? {
-            isTail: true,
-            function: f,
-            functionName: \\"f\\",
-            arguments: [binaryOp(\\"-\\", x, 1, 2, 41), binaryOp(\\"+\\", y, 1, 2, 46)],
-            line: 2,
-            column: 39
-          } : {
-            isTail: false,
-            value: 'unreachable'
-          };
-        }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : false || x > 0 ? f(x - 1, y + 1) : 'unreachable';\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      return boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 9), 2, 9) ? {
+        isTail: false,
+        value: y
+      } : boolOrErr(boolOrErr(false, 2, 22) || binaryOp(\\">\\", x, 0, 2, 31), 2, 22) ? {
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", x, 1, 2, 41), binaryOp(\\"+\\", y, 1, 2, 46)],
+        line: 2,
+        column: 39
+      } : {
+        isTail: false,
+        value: 'unreachable'
+      };
+    }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : false || x > 0 ? f(x - 1, y + 1) : 'unreachable';\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -267,7 +251,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -278,40 +262,36 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
-            return {
-              isTail: false,
-              value: y
-            };
-          } else {
-            return {
-              isTail: true,
-              function: f,
-              functionName: \\"f\\",
-              arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, 1, 5, 18)],
-              line: 5,
-              column: 11
-            };
-          }
-        }, \\"(x, y) => {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
+        return {
+          isTail: false,
+          value: y
+        };
+      } else {
+        return {
+          isTail: true,
+          function: f,
+          functionName: \\"f\\",
+          arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, 1, 5, 18)],
+          line: 5,
+          column: 11
+        };
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"(x, y) => {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -327,7 +307,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -338,34 +318,30 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", x, 0, 1, 20), 1, 20) ? {
-          isTail: false,
-          value: y
-        } : {
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", x, 1, 1, 35), binaryOp(\\"+\\", y, 1, 1, 40)],
-          line: 1,
-          column: 33
-        }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", x, 0, 1, 20), 1, 20) ? {
+      isTail: false,
+      value: y
+    } : {
+      isTail: true,
+      function: f,
+      functionName: \\"f\\",
+      arguments: [binaryOp(\\"-\\", x, 1, 1, 35), binaryOp(\\"+\\", y, 1, 1, 40)],
+      line: 1,
+      column: 33
+    }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -387,7 +363,7 @@ f(5000, 5000, 2);",
   "parsedErrors": "",
   "result": 15000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -398,40 +374,36 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y, z) => {
-          if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
-            return {
-              isTail: false,
-              value: y
-            };
-          } else {
-            return {
-              isTail: true,
-              function: f,
-              functionName: \\"f\\",
-              arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, callIfFuncAndRightArgs(f, 5, 20, 0, z, 0), 5, 18), z],
-              line: 5,
-              column: 11
-            };
-          }
-        }, \\"function f(x, y, z) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + f(0, z, 0), z);\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000, 2);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y, z) => {
+      if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
+        return {
+          isTail: false,
+          value: y
+        };
+      } else {
+        return {
+          isTail: true,
+          function: f,
+          functionName: \\"f\\",
+          arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, callIfFuncAndRightArgs(f, 5, 20, 0, z, 0), 5, 18), z],
+          line: 5,
+          column: 11
+        };
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"function f(x, y, z) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + f(0, z, 0), z);\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000, 2);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -448,7 +420,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -459,51 +431,47 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", x, 0, 1, 20), 1, 20) ? {
-          isTail: false,
-          value: y
-        } : {
-          isTail: true,
-          function: g,
-          functionName: \\"g\\",
-          arguments: [binaryOp(\\"-\\", x, 1, 1, 35), binaryOp(\\"+\\", y, 1, 1, 40)],
-          line: 1,
-          column: 33
-        }, \\"(x, y) => x <= 0 ? y : g(x - 1, y + 1)\\");
-        const g = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 20), 2, 20) ? {
-          isTail: false,
-          value: y
-        } : {
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", x, 1, 2, 35), binaryOp(\\"+\\", y, 1, 2, 40)],
-          line: 2,
-          column: 33
-        }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
-        globals.variables.set(\\"g\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return g;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", x, 0, 1, 20), 1, 20) ? {
+      isTail: false,
+      value: y
+    } : {
+      isTail: true,
+      function: g,
+      functionName: \\"g\\",
+      arguments: [binaryOp(\\"-\\", x, 1, 1, 35), binaryOp(\\"+\\", y, 1, 1, 40)],
+      line: 1,
+      column: 33
+    }, \\"(x, y) => x <= 0 ? y : g(x - 1, y + 1)\\", 1000);
+    const g = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 20), 2, 20) ? {
+      isTail: false,
+      value: y
+    } : {
+      isTail: true,
+      function: f,
+      functionName: \\"f\\",
+      arguments: [binaryOp(\\"-\\", x, 1, 2, 35), binaryOp(\\"+\\", y, 1, 2, 40)],
+      line: 2,
+      column: 33
+    }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"g\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return g;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -532,7 +500,7 @@ f(5000, 5000);",
   "parsedErrors": "",
   "result": 10000,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -543,63 +511,59 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap((x, y) => {
-          if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
-            return {
-              isTail: false,
-              value: y
-            };
-          } else {
-            return {
-              isTail: true,
-              function: g,
-              functionName: \\"g\\",
-              arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, 1, 5, 18)],
-              line: 5,
-              column: 11
-            };
-          }
-        }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return g(x - 1, y + 1);\\\\n  }\\\\n}\\");
-        const g = wrap((x, y) => {
-          if (boolOrErr(binaryOp(\\"<=\\", x, 0, 9, 6), 9, 2)) {
-            return {
-              isTail: false,
-              value: y
-            };
-          } else {
-            return {
-              isTail: true,
-              function: f,
-              functionName: \\"f\\",
-              arguments: [binaryOp(\\"-\\", x, 1, 12, 13), binaryOp(\\"+\\", y, 1, 12, 18)],
-              line: 12,
-              column: 11
-            };
-          }
-        }, \\"function g(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 15, 0, 5000, 5000);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
-        globals.variables.set(\\"g\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return g;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap((x, y) => {
+      if (boolOrErr(binaryOp(\\"<=\\", x, 0, 2, 6), 2, 2)) {
+        return {
+          isTail: false,
+          value: y
+        };
+      } else {
+        return {
+          isTail: true,
+          function: g,
+          functionName: \\"g\\",
+          arguments: [binaryOp(\\"-\\", x, 1, 5, 13), binaryOp(\\"+\\", y, 1, 5, 18)],
+          line: 5,
+          column: 11
+        };
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return g(x - 1, y + 1);\\\\n  }\\\\n}\\", 1000);
+    const g = wrap((x, y) => {
+      if (boolOrErr(binaryOp(\\"<=\\", x, 0, 9, 6), 9, 2)) {
+        return {
+          isTail: false,
+          value: y
+        };
+      } else {
+        return {
+          isTail: true,
+          function: f,
+          functionName: \\"f\\",
+          arguments: [binaryOp(\\"-\\", x, 1, 12, 13), binaryOp(\\"+\\", y, 1, 12, 18)],
+          line: 12,
+          column: 11
+        };
+      }
+    }, \\"function g(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 15, 0, 5000, 5000);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+    globals.variables.set(\\"g\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return g;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ import { SourceLanguage } from './types'
 export const CUT = 'cut' // cut operator for Source 4.3
 export const TRY_AGAIN = 'try again' // command for Source 4.3
 export const GLOBAL = typeof window === 'undefined' ? global : window
-export const GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE = '$$NATIVE_STORAGE'
+export const NATIVE_STORAGE_ID = 'nativeStorage'
 export const MAX_LIST_DISPLAY_LENGTH = 100
 export const UNKNOWN_LOCATION: es.SourceLocation = {
   start: {

--- a/src/gpu/__tests__/noTranspile.ts
+++ b/src/gpu/__tests__/noTranspile.ts
@@ -8,8 +8,7 @@ test('empty for loop does not get transpiled', () => {
     for (let i = 0; i < 10; i = i + 1) {}
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -23,8 +22,7 @@ test('simple for loop with different update does not get transpiled', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -39,8 +37,7 @@ test('simple for loop with different loop variables does not get transpiled', ()
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -55,8 +52,7 @@ test('simple for loop with const initialization does not get transpiled', () => 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -70,8 +66,7 @@ test('simple for loop with non-zero initialization does not get transpiled', () 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -86,8 +81,7 @@ test('simple for loop with a function end counter does not get transpiled', () =
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -102,8 +96,7 @@ test('simple for loop with different initialization does not get transpiled', ()
       }
       `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -119,8 +112,7 @@ test('simple for loop with global variable update does not get transpiled', () =
       }
       `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -136,8 +128,7 @@ test('simple for loop with function call does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -152,8 +143,7 @@ test('simple for loop with double update does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -169,8 +159,7 @@ test('2 for loops with wrong indice order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -186,8 +175,7 @@ test('2 for loops with wrong indices order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -212,8 +200,7 @@ test('2 for loop case with 2 indices being written + use of result variable[i-1]
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
 })
@@ -230,8 +217,7 @@ test('3 for loops with wrong indice order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)
@@ -249,8 +235,7 @@ test('3 for loops with wrong indice order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(2)

--- a/src/gpu/__tests__/transpile.ts
+++ b/src/gpu/__tests__/transpile.ts
@@ -11,8 +11,7 @@ test('simple for loop gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -31,8 +30,7 @@ test('many simple for loop gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(4)
@@ -47,8 +45,7 @@ test('simple for loop with constant condition transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
 })
@@ -62,8 +59,7 @@ test('simple for loop with let condition transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -78,8 +74,7 @@ test('simple for loop with math function call transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -95,8 +90,7 @@ test('simple for loop with different end condition transpiled correctly', () => 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -112,8 +106,7 @@ test('2 for loop case gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -131,8 +124,7 @@ test('2 for loop case with body gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -148,8 +140,7 @@ test('2 for loop case with 2 indices being written to gets transpiled correctly'
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -175,8 +166,7 @@ test('2 for loop case with 2 indices being written + local updates to gets trans
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -201,8 +191,7 @@ test('2 for loop case with 2 indices being written + use of result variable[i][j
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
 })
@@ -219,8 +208,7 @@ test('3 for loop case with 1 index being written to gets transpiled correctly', 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -238,8 +226,7 @@ test('3 for loop case with 2 indices being written to gets transpiled correctly'
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -257,8 +244,7 @@ test('3 for loop case with 3 indices being written to gets transpiled correctly'
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(3)
@@ -294,8 +280,7 @@ test('many for loop case - matrix multiplication (2 transpilations)', () => {
     }
   `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   const cnt = transpiled.match(/__createKernel/g)?.length
   expect(cnt).toEqual(4)
@@ -311,8 +296,7 @@ test('resolve naming conflicts if __createKernel is used', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context.contextId, false, context.variant)
-    .transpiled
+  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
 
   // a new kernel function with name __createKernel0 should be created here
   const cntNewName = transpiled.match(/__createKernel0/g)?.length

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -21,9 +21,7 @@ class GPUTransformer {
   program: es.Program
 
   // helps reference the main function
-  static globalIds = {
-    __createKernel: create.identifier('__createKernel')
-  }
+  globalIds: { __createKernel: es.Identifier }
 
   outputArray: es.Identifier
   innerBody: any
@@ -34,8 +32,11 @@ class GPUTransformer {
   outerVariables: any
   targetBody: any
 
-  constructor(program: es.Program) {
+  constructor(program: es.Program, createKernel: es.Identifier) {
     this.program = program
+    this.globalIds = {
+      __createKernel: createKernel
+    }
   }
 
   // transforms away top-level for loops if possible
@@ -222,7 +223,7 @@ class GPUTransformer {
     create.mutateToExpressionStatement(
       node,
       create.callExpression(
-        GPUTransformer.globalIds.__createKernel,
+        this.globalIds.__createKernel,
         [
           create.arrayExpression(this.end),
           create.objectExpression(externObject),

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,9 +394,9 @@ export async function runInContext(
   }
   if (context.variant === 'concurrent') {
     if (previousCode === code) {
-      JSSLANG_PROPERTIES.maxExecTime *= JSSLANG_PROPERTIES.factorToIncreaseBy
+      context.nativeStorage.maxExecTime *= JSSLANG_PROPERTIES.factorToIncreaseBy
     } else {
-      JSSLANG_PROPERTIES.maxExecTime = theOptions.originalMaxExecTime
+      context.nativeStorage.maxExecTime = theOptions.originalMaxExecTime
     }
     previousCode = code
     try {
@@ -437,31 +437,31 @@ export async function runInContext(
     const prelude = context.prelude
     context.prelude = null
     const oldPreviousCode = previousCode
-    const oldTimeout = JSSLANG_PROPERTIES.maxExecTime
+    const oldTimeout = context.nativeStorage.maxExecTime
     await runInContext(prelude, context, options)
     previousCode = oldPreviousCode
-    JSSLANG_PROPERTIES.maxExecTime = oldTimeout
+    context.nativeStorage.maxExecTime = oldTimeout
     return runInContext(code, context, options)
   }
   if (isNativeRunnable) {
     if (previousCode === code) {
-      JSSLANG_PROPERTIES.maxExecTime *= JSSLANG_PROPERTIES.factorToIncreaseBy
+      context.nativeStorage.maxExecTime *= JSSLANG_PROPERTIES.factorToIncreaseBy
     } else {
-      JSSLANG_PROPERTIES.maxExecTime = theOptions.originalMaxExecTime
+      context.nativeStorage.maxExecTime = theOptions.originalMaxExecTime
     }
     previousCode = code
     let transpiled
     let sourceMapJson: RawSourceMap | undefined
     let lastStatementSourceMapJson: RawSourceMap | undefined
     try {
-      const temp = transpile(program, context.contextId, false, context.variant)
+      const temp = transpile(program, context, false, context.variant)
       // some issues with formatting and semicolons and tslint so no destructure
       transpiled = temp.transpiled
       sourceMapJson = temp.codeMap
       lastStatementSourceMapJson = temp.evalMap
       return Promise.resolve({
         status: 'finished',
-        value: sandboxedEval(transpiled)
+        value: sandboxedEval(transpiled, context.nativeStorage)
       } as Result)
     } catch (error) {
       if (error instanceof RuntimeSourceError) {

--- a/src/interpreter/__tests__/__snapshots__/interpreter-errors.ts.snap
+++ b/src/interpreter/__tests__/__snapshots__/interpreter-errors.ts.snap
@@ -9,7 +9,7 @@ Object {
   "parsedErrors": "",
   "result": 0,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -20,17 +20,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"getProp({   a: 0 }, \\\\\\"a\\\\\\", 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"getProp({   a: 0 }, \\\\\\"a\\\\\\", 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -104,7 +100,7 @@ eval_stream(make_alternating_stream(enum_stream(1, 9)), 9);",
   "parsedErrors": "Line 8: Error: head(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -115,73 +111,69 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const make_alternating_stream = wrap(stream => {
-          return {
-            isTail: true,
-            function: pair,
-            functionName: \\"pair\\",
-            arguments: [callIfFuncAndRightArgs(head, 2, 14, stream), wrap(() => ({
-              isTail: true,
-              function: make_alternating_stream,
-              functionName: \\"make_alternating_stream\\",
-              arguments: [callIfFuncAndRightArgs(negate_whole_stream, 3, 36, callIfFuncAndRightArgs(stream_tail, 4, 40, stream))],
-              line: 2,
-              column: 34
-            }), \\"() => make_alternating_stream(negate_whole_stream(stream_tail(stream)))\\")],
-            line: 2,
-            column: 9
-          };
-        }, \\"function make_alternating_stream(stream) {\\\\n  return pair(head(stream), () => make_alternating_stream(negate_whole_stream(stream_tail(stream))));\\\\n}\\");
-        const negate_whole_stream = wrap(stream => {
-          return {
-            isTail: true,
-            function: pair,
-            functionName: \\"pair\\",
-            arguments: [unaryOp(\\"-\\", callIfFuncAndRightArgs(head, 8, 17, stream), 8, 16), wrap(() => ({
-              isTail: true,
-              function: negate_whole_stream,
-              functionName: \\"negate_whole_stream\\",
-              arguments: [callIfFuncAndRightArgs(stream_tail, 8, 57, stream)],
-              line: 8,
-              column: 37
-            }), \\"() => negate_whole_stream(stream_tail(stream))\\")],
-            line: 8,
-            column: 11
-          };
-        }, \\"function negate_whole_stream(stream) {\\\\n  return pair(-head(stream), () => negate_whole_stream(stream_tail(stream)));\\\\n}\\");
-        const ones = callIfFuncAndRightArgs(pair, 11, 13, 1, wrap(() => ({
-          isTail: false,
-          value: ones
-        }), \\"() => ones\\"));
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(eval_stream, 12, 0, callIfFuncAndRightArgs(make_alternating_stream, 12, 12, callIfFuncAndRightArgs(enum_stream, 12, 36, 1, 9)), 9);\\");
-        globals.variables.set(\\"make_alternating_stream\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return make_alternating_stream;
-          }
-        });
-        globals.variables.set(\\"negate_whole_stream\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return negate_whole_stream;
-          }
-        });
-        globals.variables.set(\\"ones\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return ones;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const make_alternating_stream = wrap(stream => {
+      return {
+        isTail: true,
+        function: pair,
+        functionName: \\"pair\\",
+        arguments: [callIfFuncAndRightArgs(head, 2, 14, stream), wrap(() => ({
+          isTail: true,
+          function: make_alternating_stream,
+          functionName: \\"make_alternating_stream\\",
+          arguments: [callIfFuncAndRightArgs(negate_whole_stream, 3, 36, callIfFuncAndRightArgs(stream_tail, 4, 40, stream))],
+          line: 2,
+          column: 34
+        }), \\"() => make_alternating_stream(negate_whole_stream(stream_tail(stream)))\\", 1000)],
+        line: 2,
+        column: 9
+      };
+    }, \\"function make_alternating_stream(stream) {\\\\n  return pair(head(stream), () => make_alternating_stream(negate_whole_stream(stream_tail(stream))));\\\\n}\\", 1000);
+    const negate_whole_stream = wrap(stream => {
+      return {
+        isTail: true,
+        function: pair,
+        functionName: \\"pair\\",
+        arguments: [unaryOp(\\"-\\", callIfFuncAndRightArgs(head, 8, 17, stream), 8, 16), wrap(() => ({
+          isTail: true,
+          function: negate_whole_stream,
+          functionName: \\"negate_whole_stream\\",
+          arguments: [callIfFuncAndRightArgs(stream_tail, 8, 57, stream)],
+          line: 8,
+          column: 37
+        }), \\"() => negate_whole_stream(stream_tail(stream))\\", 1000)],
+        line: 8,
+        column: 11
+      };
+    }, \\"function negate_whole_stream(stream) {\\\\n  return pair(-head(stream), () => negate_whole_stream(stream_tail(stream)));\\\\n}\\", 1000);
+    const ones = callIfFuncAndRightArgs(pair, 11, 13, 1, wrap(() => ({
+      isTail: false,
+      value: ones
+    }), \\"() => ones\\", 1000));
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(eval_stream, 12, 0, callIfFuncAndRightArgs(make_alternating_stream, 12, 12, callIfFuncAndRightArgs(enum_stream, 12, 36, 1, 9)), 9);\\");
+    globals.variables.set(\\"make_alternating_stream\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return make_alternating_stream;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"negate_whole_stream\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return negate_whole_stream;
+      }
+    });
+    globals.variables.set(\\"ones\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return ones;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -216,7 +208,7 @@ h(null);",
   "parsedErrors": "Line 2: Error: head(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -227,33 +219,29 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const h = wrap(p => {
-          return {
-            isTail: true,
-            function: head,
-            functionName: \\"head\\",
-            arguments: [p],
-            line: 2,
-            column: 9
-          };
-        }, \\"function h(p) {\\\\n  return head(p);\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(h, 5, 0, null);\\");
-        globals.variables.set(\\"h\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return h;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const h = wrap(p => {
+      return {
+        isTail: true,
+        function: head,
+        functionName: \\"head\\",
+        arguments: [p],
+        line: 2,
+        column: 9
+      };
+    }, \\"function h(p) {\\\\n  return head(p);\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(h, 5, 0, null);\\");
+    globals.variables.set(\\"h\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return h;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -285,7 +273,7 @@ Object {
   "parsedErrors": "Line 1: Cannot read inherited property valueOf of {}.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -296,17 +284,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"getProp({}, \\\\\\"valueOf\\\\\\", 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"getProp({}, \\\\\\"valueOf\\\\\\", 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -499,7 +483,7 @@ f(1);",
   "parsedErrors": "Line 2: Expected 0 arguments, but got 1.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -510,41 +494,37 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const g = wrap(() => ({
-          isTail: false,
-          value: 1
-        }), \\"() => 1\\");
-        const f = wrap(x => ({
-          isTail: true,
-          function: g,
-          functionName: \\"g\\",
-          arguments: [x],
-          line: 2,
-          column: 15
-        }), \\"x => g(x)\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 1);\\");
-        globals.variables.set(\\"g\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return g;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const g = wrap(() => ({
+      isTail: false,
+      value: 1
+    }), \\"() => 1\\", 1000);
+    const f = wrap(x => ({
+      isTail: true,
+      function: g,
+      functionName: \\"g\\",
+      arguments: [x],
+      line: 2,
+      column: 15
+    }), \\"x => g(x)\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 1);\\");
+    globals.variables.set(\\"g\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return g;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -613,7 +593,7 @@ f();",
   "parsedErrors": "Line 2: Expected 1 arguments, but got 0.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -624,27 +604,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(x => ({
-          isTail: false,
-          value: x
-        }), \\"x => x\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(x => ({
+      isTail: false,
+      value: x
+    }), \\"x => x\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -713,7 +689,7 @@ f(1, 2);",
   "parsedErrors": "Line 2: Expected 1 arguments, but got 2.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -724,27 +700,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(x => ({
-          isTail: false,
-          value: x
-        }), \\"x => x\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 1, 2);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(x => ({
+      isTail: false,
+      value: x
+    }), \\"x => x\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 1, 2);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -813,7 +785,7 @@ f[0](1, 2);",
   "parsedErrors": "Line 2: Expected 1 arguments, but got 2.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -824,27 +796,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = [wrap(x => ({
-          isTail: false,
-          value: x
-        }), \\"x => x\\")];
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(getProp(f, 0, 2, 0), 2, 0, 1, 2);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = [wrap(x => ({
+      isTail: false,
+      value: x
+    }), \\"x => x\\", 1000)];
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(getProp(f, 0, 2, 0), 2, 0, 1, 2);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -917,7 +885,7 @@ f();",
   "parsedErrors": "Line 4: Expected 1 arguments, but got 0.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -928,29 +896,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function f(x) {\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function f(x) {\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1023,7 +987,7 @@ f(1, 2);",
   "parsedErrors": "Line 4: Expected 1 arguments, but got 2.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1034,29 +998,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(x => {
-          return {
-            isTail: false,
-            value: x
-          };
-        }, \\"function f(x) {\\\\n  return x;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 1, 2);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(x => {
+      return {
+        isTail: false,
+        value: x
+      };
+    }, \\"function f(x) {\\\\n  return x;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 1, 2);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1185,7 +1145,7 @@ Object {
   "parsedErrors": "Line 1: Calling non-function value \\"string\\".",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1196,17 +1156,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs('string', 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs('string', 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1335,7 +1291,7 @@ Object {
   "parsedErrors": "Line 1: Calling non-function value 0.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1346,17 +1302,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(0, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(0, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1523,7 +1475,7 @@ Object {
   "parsedErrors": "Line 1: Calling non-function value [1].",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1534,17 +1486,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs([1], 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs([1], 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2100,7 +2048,7 @@ Object {
   "parsedErrors": "Line 1: Calling non-function value true.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2111,17 +2059,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(true, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(true, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2443,7 +2387,7 @@ Object {
   "parsedErrors": "Line 1: Calling non-function value undefined.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2454,17 +2398,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(undefined, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(undefined, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3007,7 +2947,7 @@ f.prototype;",
   "parsedErrors": "Line 4: Expected object or array, got function.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3018,29 +2958,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(() => {
-          return {
-            isTail: false,
-            value: 1
-          };
-        }, \\"function f() {\\\\n  return 1;\\\\n}\\");
-        lastStatementResult = eval(\\"getProp(f, \\\\\\"prototype\\\\\\", 4, 0);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(() => {
+      return {
+        isTail: false,
+        value: 1
+      };
+    }, \\"function f() {\\\\n  return 1;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"getProp(f, \\\\\\"prototype\\\\\\", 4, 0);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3073,7 +3009,7 @@ Object {
   "parsedErrors": "Line 1: Expected object or array, got null.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3084,17 +3020,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"getProp(null, \\\\\\"prop\\\\\\", 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"getProp(null, \\\\\\"prop\\\\\\", 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3127,7 +3059,7 @@ Object {
   "parsedErrors": "Line 1: Expected object or array, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3138,17 +3070,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"getProp('hi', \\\\\\"length\\\\\\", 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"getProp('hi', \\\\\\"length\\\\\\", 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3184,7 +3112,7 @@ f.prop = 5;",
   "parsedErrors": "Line 4: Expected object or array, got function.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3195,29 +3123,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(() => {
-          return {
-            isTail: false,
-            value: 1
-          };
-        }, \\"function f() {\\\\n  return 1;\\\\n}\\");
-        lastStatementResult = eval(\\"setProp(f, \\\\\\"prop\\\\\\", 5, 4, 0);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(() => {
+      return {
+        isTail: false,
+        value: 1
+      };
+    }, \\"function f() {\\\\n  return 1;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"setProp(f, \\\\\\"prop\\\\\\", 5, 4, 0);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3250,7 +3174,7 @@ Object {
   "parsedErrors": "Line 1: Expected object or array, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3261,17 +3185,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"setProp('hi', \\\\\\"prop\\\\\\", 5, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"setProp('hi', \\\\\\"prop\\\\\\", 5, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3306,7 +3226,7 @@ Object {
   "parsedErrors": "Line 1: Expected number on right hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3317,17 +3237,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"*\\\\\\", 12, 'string', 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"*\\\\\\", 12, 'string', 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3364,7 +3280,7 @@ Object {
   "parsedErrors": "Line 1: Expected boolean as condition, got number.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3375,17 +3291,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"if (boolOrErr(1, 1, 0)) {   2; } else {}\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"if (boolOrErr(1, 1, 0)) {   2; } else {}\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/parser/__tests__/__snapshots__/allowed-syntax.ts.snap
+++ b/src/parser/__tests__/__snapshots__/allowed-syntax.ts.snap
@@ -15,7 +15,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -26,17 +26,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -500,7 +496,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -511,17 +507,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"function name(a, b) {\\\\\\\\n  const sum = a + b;\\\\\\\\n  if (sum > 1) {\\\\\\\\n    return sum;\\\\\\\\n  } else {\\\\\\\\n    if (a % 2 === 0) {\\\\\\\\n      return -1;\\\\\\\\n    } else if (b % 2 === 0) {\\\\\\\\n      return 1;\\\\\\\\n    } else {\\\\\\\\n      return a > b ? 0 : -2;\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\nname(1, 2);\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"function name(a, b) {\\\\\\\\n  const sum = a + b;\\\\\\\\n  if (sum > 1) {\\\\\\\\n    return sum;\\\\\\\\n  } else {\\\\\\\\n    if (a % 2 === 0) {\\\\\\\\n      return -1;\\\\\\\\n    } else if (b % 2 === 0) {\\\\\\\\n      return 1;\\\\\\\\n    } else {\\\\\\\\n      return a > b ? 0 : -2;\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\nname(1, 2);\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -550,7 +542,7 @@ name(1, 2);",
   "parsedErrors": "",
   "result": 3,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -561,52 +553,48 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const name = wrap((a, b) => {
-          const sum = binaryOp(\\"+\\", a, b, 2, 14);
-          if (boolOrErr(binaryOp(\\">\\", sum, 1, 3, 6), 3, 2)) {
-            return {
-              isTail: false,
-              value: sum
-            };
-          } else {
-            if (boolOrErr(binaryOp(\\"===\\", binaryOp(\\"%\\", a, 2, 6, 8), 0, 6, 8), 6, 4)) {
-              return {
-                isTail: false,
-                value: unaryOp(\\"-\\", 1, 7, 13)
-              };
-            } else if (boolOrErr(binaryOp(\\"===\\", binaryOp(\\"%\\", b, 2, 8, 15), 0, 8, 15), 8, 11)) {
-              return {
-                isTail: false,
-                value: 1
-              };
-            } else {
-              return boolOrErr(binaryOp(\\">\\", a, b, 11, 13), 11, 13) ? {
-                isTail: false,
-                value: 0
-              } : {
-                isTail: false,
-                value: unaryOp(\\"-\\", 2, 11, 25)
-              };
-            }
-          }
-        }, \\"function name(a, b) {\\\\n  const sum = a + b;\\\\n  if (sum > 1) {\\\\n    return sum;\\\\n  } else {\\\\n    if (a % 2 === 0) {\\\\n      return -1;\\\\n    } else if (b % 2 === 0) {\\\\n      return 1;\\\\n    } else {\\\\n      return a > b ? 0 : -2;\\\\n    }\\\\n  }\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(name, 15, 0, 1, 2);\\");
-        globals.variables.set(\\"name\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return name;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const name = wrap((a, b) => {
+      const sum = binaryOp(\\"+\\", a, b, 2, 14);
+      if (boolOrErr(binaryOp(\\">\\", sum, 1, 3, 6), 3, 2)) {
+        return {
+          isTail: false,
+          value: sum
+        };
+      } else {
+        if (boolOrErr(binaryOp(\\"===\\", binaryOp(\\"%\\", a, 2, 6, 8), 0, 6, 8), 6, 4)) {
+          return {
+            isTail: false,
+            value: unaryOp(\\"-\\", 1, 7, 13)
+          };
+        } else if (boolOrErr(binaryOp(\\"===\\", binaryOp(\\"%\\", b, 2, 8, 15), 0, 8, 15), 8, 11)) {
+          return {
+            isTail: false,
+            value: 1
+          };
+        } else {
+          return boolOrErr(binaryOp(\\">\\", a, b, 11, 13), 11, 13) ? {
+            isTail: false,
+            value: 0
+          } : {
+            isTail: false,
+            value: unaryOp(\\"-\\", 2, 11, 25)
+          };
+        }
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, \\"function name(a, b) {\\\\n  const sum = a + b;\\\\n  if (sum > 1) {\\\\n    return sum;\\\\n  } else {\\\\n    if (a % 2 === 0) {\\\\n      return -1;\\\\n    } else if (b % 2 === 0) {\\\\n      return 1;\\\\n    } else {\\\\n      return a > b ? 0 : -2;\\\\n    }\\\\n  }\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(name, 15, 0, 1, 2);\\");
+    globals.variables.set(\\"name\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return name;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -645,7 +633,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -656,17 +644,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"(() => true)();\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"(() => true)();\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -681,7 +665,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -692,17 +676,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap(() => ({   isTail: false,   value: true }), \\\\\\"() => true\\\\\\"), 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap(() => ({   isTail: false,   value: true }), \\\\\\"() => true\\\\\\", 1000), 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -798,7 +778,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -809,17 +789,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"((x, y) => { return x + y; })(1, 2);\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"((x, y) => { return x + y; })(1, 2);\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -834,7 +810,7 @@ Object {
   "parsedErrors": "",
   "result": 3,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -845,17 +821,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap((x, y) => {   return {     isTail: false,     value: binaryOp(\\\\\\"+\\\\\\", x, y, 1, 20)   }; }, \\\\\\"(x, y) => {\\\\\\\\n  return x + y;\\\\\\\\n}\\\\\\"), 1, 0, 1, 2);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap((x, y) => {   return {     isTail: false,     value: binaryOp(\\\\\\"+\\\\\\", x, y, 1, 20)   }; }, \\\\\\"(x, y) => {\\\\\\\\n  return x + y;\\\\\\\\n}\\\\\\", 1000), 1, 0, 1, 2);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -870,7 +842,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -881,17 +853,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -906,7 +874,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -917,17 +885,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"true;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"true;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -942,7 +906,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -953,17 +917,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"false;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"false;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -978,7 +938,7 @@ Object {
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -989,17 +949,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1014,7 +970,7 @@ Object {
   "parsedErrors": "",
   "result": "a string \\"\\" ''",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1025,17 +981,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"'a string \\\\\\\\\\\\\\"\\\\\\\\\\\\\\" \\\\\\\\\\\\\\\\'\\\\\\\\\\\\\\\\'';\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"'a string \\\\\\\\\\\\\\"\\\\\\\\\\\\\\" \\\\\\\\\\\\\\\\'\\\\\\\\\\\\\\\\'';\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1050,7 +1002,7 @@ Object {
   "parsedErrors": "",
   "result": "a string \\"\\" ''",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1061,17 +1013,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"'a string \\\\\\"\\\\\\" \\\\\\\\'\\\\\\\\'';\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"'a string \\\\\\"\\\\\\" \\\\\\\\'\\\\\\\\'';\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1206,7 +1154,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1217,17 +1165,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"31.4 + (-3.14e10) * -1 % 2 / 1.5;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"31.4 + (-3.14e10) * -1 % 2 / 1.5;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1242,7 +1186,7 @@ Object {
   "parsedErrors": "",
   "result": 31.4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1253,17 +1197,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 31.4, binaryOp(\\\\\\"/\\\\\\", binaryOp(\\\\\\"%\\\\\\", binaryOp(\\\\\\"*\\\\\\", unaryOp(\\\\\\"-\\\\\\", 3.14e10, 1, 8), unaryOp(\\\\\\"-\\\\\\", 1, 1, 20), 1, 7), 2, 1, 7), 1.5, 1, 7), 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 31.4, binaryOp(\\\\\\"/\\\\\\", binaryOp(\\\\\\"%\\\\\\", binaryOp(\\\\\\"*\\\\\\", unaryOp(\\\\\\"-\\\\\\", 3.14e10, 1, 8), unaryOp(\\\\\\"-\\\\\\", 1, 1, 20), 1, 7), 2, 1, 7), 1.5, 1, 7), 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1527,7 +1467,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1538,17 +1478,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"!false === (1 !== 2) && 1 < 2 && 1 <= 2 && 2 >= 1 && 2 > 1 || false;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"!false === (1 !== 2) && 1 < 2 && 1 <= 2 && 2 >= 1 && 2 > 1 || false;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1563,7 +1499,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1574,17 +1510,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", unaryOp(\\\\\\"!\\\\\\", false, 1, 0), binaryOp(\\\\\\"!==\\\\\\", 1, 2, 1, 12), 1, 0), 1, 0) && binaryOp(\\\\\\"<\\\\\\", 1, 2, 1, 24), 1, 0) && binaryOp(\\\\\\"<=\\\\\\", 1, 2, 1, 33), 1, 0) && binaryOp(\\\\\\">=\\\\\\", 2, 1, 1, 43), 1, 0) && binaryOp(\\\\\\">\\\\\\", 2, 1, 1, 53), 1, 0) || false;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", unaryOp(\\\\\\"!\\\\\\", false, 1, 0), binaryOp(\\\\\\"!==\\\\\\", 1, 2, 1, 12), 1, 0), 1, 0) && binaryOp(\\\\\\"<\\\\\\", 1, 2, 1, 24), 1, 0) && binaryOp(\\\\\\"<=\\\\\\", 1, 2, 1, 33), 1, 0) && binaryOp(\\\\\\">=\\\\\\", 2, 1, 1, 43), 1, 0) && binaryOp(\\\\\\">\\\\\\", 2, 1, 1, 53), 1, 0) || false;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1611,7 +1543,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1622,17 +1554,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true ? 1 : 2;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true ? 1 : 2;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1647,7 +1575,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1658,17 +1586,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? 1 : 2;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? 1 : 2;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1718,7 +1642,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1729,17 +1653,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"null;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"null;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1754,7 +1674,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1765,17 +1685,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"null;\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"null;\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1846,7 +1762,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1857,17 +1773,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"pair(1, null);\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"pair(1, null);\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1885,7 +1797,7 @@ Object {
     null,
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1896,17 +1808,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, null);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, null);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1968,7 +1876,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1979,17 +1887,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"list(1);\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"list(1);\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2007,7 +1911,7 @@ Object {
     null,
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2018,17 +1922,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2521,7 +2421,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2532,17 +2432,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nwhile (i < 5) {\\\\\\\\n  i = i + 1;\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nwhile (i < 5) {\\\\\\\\n  i = i + 1;\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2561,7 +2457,7 @@ i;",
   "parsedErrors": "",
   "result": 5,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2572,38 +2468,34 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let i = 1;
-        const startTime = runtime();
-        while (boolOrErr(binaryOp(\\"<\\", i, 5, 2, 7), 2, 0)) {
-          throwIfTimeout(startTime, runtime(), 2, 0);
-          i = binaryOp(\\"+\\", i, 1, 3, 6);
-        }
-        lastStatementResult = eval(\\"i;\\");
-        globals.variables.set(\\"i\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return i;
-          },
-          assignNewValue: function (unique) {
-            return i = unique;
-          }
-        });
-        globals.variables.set(\\"startTime\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return startTime;
-          }
-        });
-      }
+const globals = native.globals;
+{
+  {
+    let i = 1;
+    const startTime = runtime();
+    while (boolOrErr(binaryOp(\\"<\\", i, 5, 2, 7), 2, 0)) {
+      throwIfTimeout(1000, startTime, runtime(), 2, 0);
+      i = binaryOp(\\"+\\", i, 1, 3, 6);
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    lastStatementResult = eval(\\"i;\\");
+    globals.variables.set(\\"i\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return i;
+      },
+      assignNewValue: function (unique) {
+        return i = unique;
+      }
+    });
+    globals.variables.set(\\"startTime\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return startTime;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3210,7 +3102,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3221,17 +3113,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (i = 1; i < 5; i = i + 1) {\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (i = 1; i < 5; i = i + 1) {\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -3249,7 +3137,7 @@ i;",
   "parsedErrors": "",
   "result": 5,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -3260,37 +3148,33 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let i = 1;
-        const startTime = runtime();
-        for (i = 1; boolOrErr(binaryOp(\\"<\\", i, 5, 2, 12), 2, 0); i = binaryOp(\\"+\\", i, 1, 2, 23)) {
-          throwIfTimeout(startTime, runtime(), 2, 0);
-        }
-        lastStatementResult = eval(\\"i;\\");
-        globals.variables.set(\\"i\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return i;
-          },
-          assignNewValue: function (unique) {
-            return i = unique;
-          }
-        });
-        globals.variables.set(\\"startTime\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return startTime;
-          }
-        });
-      }
+const globals = native.globals;
+{
+  {
+    let i = 1;
+    const startTime = runtime();
+    for (i = 1; boolOrErr(binaryOp(\\"<\\", i, 5, 2, 12), 2, 0); i = binaryOp(\\"+\\", i, 1, 2, 23)) {
+      throwIfTimeout(1000, startTime, runtime(), 2, 0);
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    lastStatementResult = eval(\\"i;\\");
+    globals.variables.set(\\"i\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return i;
+      },
+      assignNewValue: function (unique) {
+        return i = unique;
+      }
+    });
+    globals.variables.set(\\"startTime\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return startTime;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -4556,7 +4440,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -4567,17 +4451,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (let j = 0; j < 5; j = j + 1) {\\\\\\\\n  if (j < 1) {\\\\\\\\n    continue;\\\\\\\\n  } else {\\\\\\\\n    i = i + 1;\\\\\\\\n    if (j > 2) {\\\\\\\\n      break;\\\\\\\\n    } else {\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (let j = 0; j < 5; j = j + 1) {\\\\\\\\n  if (j < 1) {\\\\\\\\n    continue;\\\\\\\\n  } else {\\\\\\\\n    i = i + 1;\\\\\\\\n    if (j > 2) {\\\\\\\\n      break;\\\\\\\\n    } else {\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -4604,7 +4484,7 @@ i;",
   "parsedErrors": "",
   "result": 4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -4615,45 +4495,41 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let i = 1;
-        const startTime = runtime();
-        for (let j = 0; boolOrErr(binaryOp(\\"<\\", j, 5, 2, 16), 2, 0); j = binaryOp(\\"+\\", j, 1, 2, 27)) {
-          throwIfTimeout(startTime, runtime(), 2, 0);
-          if (boolOrErr(binaryOp(\\"<\\", j, 1, 3, 6), 3, 2)) {
-            continue;
-          } else {
-            i = binaryOp(\\"+\\", i, 1, 6, 8);
-            if (boolOrErr(binaryOp(\\">\\", j, 2, 7, 8), 7, 4)) {
-              break;
-            } else {}
-          }
-        }
-        lastStatementResult = eval(\\"i;\\");
-        globals.variables.set(\\"i\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return i;
-          },
-          assignNewValue: function (unique) {
-            return i = unique;
-          }
-        });
-        globals.variables.set(\\"startTime\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return startTime;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let i = 1;
+    const startTime = runtime();
+    for (let j = 0; boolOrErr(binaryOp(\\"<\\", j, 5, 2, 16), 2, 0); j = binaryOp(\\"+\\", j, 1, 2, 27)) {
+      throwIfTimeout(1000, startTime, runtime(), 2, 0);
+      if (boolOrErr(binaryOp(\\"<\\", j, 1, 3, 6), 3, 2)) {
+        continue;
+      } else {
+        i = binaryOp(\\"+\\", i, 1, 6, 8);
+        if (boolOrErr(binaryOp(\\">\\", j, 2, 7, 8), 7, 4)) {
+          break;
+        } else {}
       }
     }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    lastStatementResult = eval(\\"i;\\");
+    globals.variables.set(\\"i\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return i;
+      },
+      assignNewValue: function (unique) {
+        return i = unique;
+      }
+    });
+    globals.variables.set(\\"startTime\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return startTime;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -4709,7 +4585,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -4720,17 +4596,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -4745,7 +4617,7 @@ Object {
   "parsedErrors": "",
   "result": Array [],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -4756,17 +4628,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"[];\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"[];\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -4883,7 +4751,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -4894,17 +4762,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -4923,7 +4787,7 @@ Object {
     3,
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -4934,17 +4798,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"[1, 2, 3];\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"[1, 2, 3];\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -5177,7 +5037,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -5188,17 +5048,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3][1];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3][1];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -5213,7 +5069,7 @@ Object {
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -5224,17 +5080,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"getProp([1, 2, 3], 1, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"getProp([1, 2, 3], 1, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -5571,7 +5423,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -5582,17 +5434,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -5608,7 +5456,7 @@ x[1];",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -5619,27 +5467,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let x = [1, 2, 3];
-        lastStatementResult = eval(\\"getProp(x, 1, 2, 0);\\");
-        globals.variables.set(\\"x\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return x;
-          },
-          assignNewValue: function (unique) {
-            return x = unique;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let x = [1, 2, 3];
+    lastStatementResult = eval(\\"getProp(x, 1, 2, 0);\\");
+    globals.variables.set(\\"x\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return x;
+      },
+      assignNewValue: function (unique) {
+        return x = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -6073,7 +5917,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -6084,17 +5928,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1] = 4;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1] = 4;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -6110,7 +5950,7 @@ x[1] = 4;",
   "parsedErrors": "",
   "result": 4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -6121,27 +5961,23 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let x = [1, 2, 3];
-        lastStatementResult = eval(\\"setProp(x, 1, 4, 2, 0);\\");
-        globals.variables.set(\\"x\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return x;
-          },
-          assignNewValue: function (unique) {
-            return x = unique;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let x = [1, 2, 3];
+    lastStatementResult = eval(\\"setProp(x, 1, 4, 2, 0);\\");
+    globals.variables.set(\\"x\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return x;
+      },
+      assignNewValue: function (unique) {
+        return x = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -6197,7 +6033,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -6208,17 +6044,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({});\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({});\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -6416,7 +6248,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -6427,17 +6259,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2});\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2});\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -6647,7 +6475,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -6658,17 +6486,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2})['a'];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2})['a'];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -7039,7 +6863,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -7050,17 +6874,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2}).a;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2}).a;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -7423,7 +7243,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -7434,17 +7254,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({'a': 1, 'b': 2}).a;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({'a': 1, 'b': 2}).a;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -7641,7 +7457,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -7652,17 +7468,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({1: 1, 2: 2})['1'];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({1: 1, 2: 2})['1'];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -7903,7 +7715,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -7914,17 +7726,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"const key = 'a';\\\\\\\\n({a: 1, b: 2})[key];\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"const key = 'a';\\\\\\\\n({a: 1, b: 2})[key];\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -8234,7 +8042,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -8245,17 +8053,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx.a = 3;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx.a = 3;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -8506,7 +8310,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -8517,17 +8321,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx['a'] = 3;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx['a'] = 3;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -8803,7 +8603,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -8814,17 +8614,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nconst key = 'a';\\\\\\\\nx[key] = 3;\\\\\\");\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nconst key = 'a';\\\\\\\\nx[key] = 3;\\\\\\");\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/stdlib/__tests__/__snapshots__/lazyLists.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/lazyLists.ts.snap
@@ -9,7 +9,7 @@ Object {
   "parsedErrors": "",
   "result": 10,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -20,17 +20,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap((curr, acc) => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", curr, acc, 1, 26)     }), \\\\\\"(curr, acc) => curr + acc\\\\\\");   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 0;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap((curr, acc) => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", curr, acc, 1, 26)     }), \\\\\\"(curr, acc) => curr + acc\\\\\\", 1000);   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 0;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -47,7 +43,7 @@ list_ref(b,200);",
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -58,73 +54,69 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    const b = callIfFuncAndRightArgs(append, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return callIfFuncAndRightArgs(list, 2, 20, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return 1;
+            return 3;
           }
         }, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return a;
-          }
-        });
-        const b = callIfFuncAndRightArgs(append, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return callIfFuncAndRightArgs(list, 2, 20, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 3;
-              }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 4;
-              }
-            });
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
+            return 4;
           }
         });
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -141,7 +133,7 @@ list_ref(b,200);",
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -152,73 +144,69 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    const b = callIfFuncAndRightArgs(append, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return callIfFuncAndRightArgs(list, 2, 17, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return 1;
+            return 3;
           }
         }, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return a;
-          }
-        });
-        const b = callIfFuncAndRightArgs(append, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return callIfFuncAndRightArgs(list, 2, 17, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 3;
-              }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 4;
-              }
-            });
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
+            return 4;
           }
         });
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -233,7 +221,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -244,17 +232,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(append, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 13, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 34, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return undefined;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 63, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return undefined;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(append, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 13, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 34, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return undefined;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 63, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return undefined;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -269,7 +253,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -280,17 +264,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -305,7 +285,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -316,17 +296,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -357,7 +333,7 @@ Object {
   "parsedErrors": "Line 148: Error: tail(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -368,17 +344,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -409,7 +381,7 @@ Object {
   "parsedErrors": "Line 148: Error: tail(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -420,17 +392,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return unaryOp(\\\\\\"-\\\\\\", 1, 1, 24);   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return unaryOp(\\\\\\"-\\\\\\", 1, 1, 24);   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -461,7 +429,7 @@ Object {
   "parsedErrors": "Line 148: Error: tail(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -472,17 +440,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1.5;   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1.5;   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -515,7 +479,7 @@ Object {
   "parsedErrors": "Line 149: Expected number on left hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -526,17 +490,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -569,7 +529,7 @@ Object {
   "parsedErrors": "Line 45: Expected number on left hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -580,17 +540,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\");   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", 1000);   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -623,7 +579,7 @@ Object {
   "parsedErrors": "Line 139: Expected string on right hand side of operation, got number.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -634,17 +590,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -677,7 +629,7 @@ Object {
   "parsedErrors": "Line 139: Expected string on right hand side of operation, got number.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -688,17 +640,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 5;   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 5;   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -731,7 +679,7 @@ Object {
   "parsedErrors": "Line 140: Expected number on right hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -742,17 +690,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -767,7 +711,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -778,17 +722,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(build_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", x, x, 1, 25)         }), \\\\\\"x => x * x\\\\\\");       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 33, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 0;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 16;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(build_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", x, x, 1, 25)         }), \\\\\\"x => x * x\\\\\\", 1000);       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 33, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 0;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 16;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -803,7 +743,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -814,17 +754,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -839,7 +775,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -850,17 +786,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 25, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4.5;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 25, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4.5;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -875,7 +807,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -886,17 +818,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 23, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 23, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -913,7 +841,7 @@ list_ref(b,1);",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -924,49 +852,27 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return callIfFuncAndRightArgs(pair, 1, 17, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return callIfFuncAndRightArgs(pair, 1, 17, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 2;
-              }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return a;
-              }
-            });
-          }
-        });
-        const b = callIfFuncAndRightArgs(filter, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return wrap(x => ({
-              isTail: false,
-              value: binaryOp(\\"===\\", binaryOp(\\"%\\", x, 2, 2, 22), 0, 2, 22)
-            }), \\"x => x % 2 === 0\\");
+            return 2;
           }
         }, {
           isThunk: true,
@@ -974,26 +880,44 @@ const globals = $NATIVE_STORAGE.globals;
           isMemoized: false,
           expr: () => {
             return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
           }
         });
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    const b = callIfFuncAndRightArgs(filter, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return wrap(x => ({
+          isTail: false,
+          value: binaryOp(\\"===\\", binaryOp(\\"%\\", x, 2, 2, 22), 0, 2, 22)
+        }), \\"x => x % 2 === 0\\", 1000);
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1008,7 +932,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1019,17 +943,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(filter, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"<=\\\\\\", x, 4, 1, 18)         }), \\\\\\"x => x <= 4\\\\\\");       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 26, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 10;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 100;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 72, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(filter, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"<=\\\\\\", x, 4, 1, 18)         }), \\\\\\"x => x <= 4\\\\\\", 1000);       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 26, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 10;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 100;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 72, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1048,7 +968,7 @@ sum;",
   "parsedErrors": "",
   "result": 6,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1059,65 +979,61 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let sum = 0;
-        callIfFuncAndRightArgs(for_each, 2, 0, {
+const globals = native.globals;
+{
+  {
+    let sum = 0;
+    callIfFuncAndRightArgs(for_each, 2, 0, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return wrap(x => {
+          sum = binaryOp(\\"+\\", sum, x, 3, 8);
+        }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", 1000);
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return callIfFuncAndRightArgs(list, 4, 3, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return wrap(x => {
-              sum = binaryOp(\\"+\\", sum, x, 3, 8);
-            }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\");
+            return 1;
           }
         }, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return callIfFuncAndRightArgs(list, 4, 3, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 1;
-              }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 2;
-              }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 3;
-              }
-            });
+            return 2;
           }
-        });
-        lastStatementResult = eval(\\"sum;\\");
-        globals.variables.set(\\"sum\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return sum;
-          },
-          assignNewValue: function (unique) {
-            return sum = unique;
+        }, {
+          isThunk: true,
+          memoizedValue: 0,
+          isMemoized: false,
+          expr: () => {
+            return 3;
           }
         });
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    lastStatementResult = eval(\\"sum;\\");
+    globals.variables.set(\\"sum\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return sum;
+      },
+      assignNewValue: function (unique) {
+        return sum = unique;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1132,7 +1048,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1143,17 +1059,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1169,7 +1081,7 @@ is_list(a);",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1180,38 +1092,34 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(list, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(list, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1227,7 +1135,7 @@ list_ref(a,200);",
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1238,38 +1146,34 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1284,7 +1188,7 @@ Object {
   "parsedErrors": "",
   "result": 4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1295,17 +1199,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"4\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 4;   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"4\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 4;   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1320,7 +1220,7 @@ Object {
   "parsedErrors": "",
   "result": "[1,[2,[3,null]]]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1331,17 +1231,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1358,7 +1254,7 @@ list_ref(b,200);",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1369,62 +1265,58 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        const b = callIfFuncAndRightArgs(map, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return wrap(x => ({
-              isTail: false,
-              value: binaryOp(\\"*\\", 2, x, 2, 19)
-            }), \\"x => 2 * x\\");
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    const b = callIfFuncAndRightArgs(map, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return wrap(x => ({
+          isTail: false,
+          value: binaryOp(\\"*\\", 2, x, 2, 19)
+        }), \\"x => 2 * x\\", 1000);
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1441,7 +1333,7 @@ list_ref(b,200);",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1452,62 +1344,58 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        const b = callIfFuncAndRightArgs(map, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return wrap(x => ({
-              isTail: false,
-              value: binaryOp(\\"*\\", 2, x, 2, 19)
-            }), \\"x => 2 * x\\");
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    const b = callIfFuncAndRightArgs(map, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return wrap(x => ({
+          isTail: false,
+          value: binaryOp(\\"*\\", 2, x, 2, 19)
+        }), \\"x => 2 * x\\", 1000);
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1522,7 +1410,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1533,17 +1421,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(map, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", 2, x, 1, 15)         }), \\\\\\"x => 2 * x\\\\\\");       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 22, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 12;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 11;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 40, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 24;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 22;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(map, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", 2, x, 1, 15)         }), \\\\\\"x => 2 * x\\\\\\", 1000);       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 22, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 12;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 11;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 40, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 24;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 22;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1560,7 +1444,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1571,17 +1455,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(member, 2, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 2, 19, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return undefined;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 3, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return undefined;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(member, 2, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 2, 19, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return undefined;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 3, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return undefined;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1596,7 +1476,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1607,17 +1487,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_pair, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_pair, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1633,7 +1509,7 @@ head(a) + head(head(tail(a)));",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1644,38 +1520,34 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(list, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(tail, 2, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return a;           }         });       }     });   } }), 2, 0);\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(list, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(tail, 2, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return a;           }         });       }     });   } }), 2, 0);\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1691,7 +1563,7 @@ tail(a) + tail(head(a));",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1702,38 +1574,34 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        });
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(tail, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(tail, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    });
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(tail, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(tail, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1749,7 +1617,7 @@ head(a) + head(tail(a));",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1760,38 +1628,34 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(tail, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(tail, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1808,7 +1672,7 @@ list_ref(b,200);",
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1819,46 +1683,27 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return callIfFuncAndRightArgs(pair, 1, 17, {
           isThunk: true,
           memoizedValue: 0,
           isMemoized: false,
           expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return callIfFuncAndRightArgs(pair, 1, 17, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return 2;
-              }
-            }, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return a;
-              }
-            });
-          }
-        });
-        const b = callIfFuncAndRightArgs(remove_all, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
+            return 2;
           }
         }, {
           isThunk: true,
@@ -1866,26 +1711,41 @@ const globals = $NATIVE_STORAGE.globals;
           isMemoized: false,
           expr: () => {
             return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
           }
         });
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    const b = callIfFuncAndRightArgs(remove_all, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1900,7 +1760,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1911,17 +1771,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove, 1, 7, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 17, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 26, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove, 1, 7, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 17, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 26, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1938,7 +1794,7 @@ list_ref(b,200);",
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1949,59 +1805,55 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const a = callIfFuncAndRightArgs(pair, 1, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        const b = callIfFuncAndRightArgs(remove, 2, 10, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-        globals.variables.set(\\"a\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return a;
-          }
-        });
-        globals.variables.set(\\"b\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return b;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const a = callIfFuncAndRightArgs(pair, 1, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    const b = callIfFuncAndRightArgs(remove, 2, 10, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return 1;
+      }
+    }, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return a;
+      }
+    });
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+    globals.variables.set(\\"a\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return a;
+      }
+    });
+    globals.variables.set(\\"b\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return b;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2016,7 +1868,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2027,17 +1879,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 10, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 10, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2052,7 +1900,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2063,17 +1911,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"1\\\\\\";           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 38, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"1\\\\\\";       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"1\\\\\\";           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 38, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"1\\\\\\";       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2088,7 +1932,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2099,17 +1943,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"1\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 6;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 62, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"1\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"1\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 6;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 62, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"1\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2124,7 +1964,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2135,17 +1975,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(reverse, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 14, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return undefined;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 59, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return undefined;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(reverse, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 14, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return undefined;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 59, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return undefined;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2160,7 +1996,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2171,17 +2007,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2196,7 +2028,7 @@ Object {
   "parsedErrors": "",
   "result": "a string \\"\\"",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2207,17 +2039,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/stdlib/__tests__/__snapshots__/list.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/list.ts.snap
@@ -25,7 +25,7 @@ Object {
   "parsedErrors": "Line 147: Error: head(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -36,17 +36,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 3);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 3);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -77,7 +73,7 @@ Object {
   "parsedErrors": "Line 147: Error: tail(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -88,17 +84,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), unaryOp(\\\\\\"-\\\\\\", 1, 1, 24));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), unaryOp(\\\\\\"-\\\\\\", 1, 1, 24));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -129,7 +121,7 @@ Object {
   "parsedErrors": "Line 147: Error: tail(xs) expects a pair as argument xs, but encountered null",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -140,17 +132,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 1.5);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 1.5);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -183,7 +171,7 @@ Object {
   "parsedErrors": "Line 147: Expected number on left hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -194,17 +182,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), '1');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), '1');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -237,7 +221,7 @@ Object {
   "parsedErrors": "Line 45: Expected number on left hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -248,17 +232,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, '1', wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\"));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, '1', wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", 1000));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -291,7 +271,7 @@ Object {
   "parsedErrors": "Line 139: Expected string on right hand side of operation, got number.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -302,17 +282,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', '5');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', '5');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -345,7 +321,7 @@ Object {
   "parsedErrors": "Line 139: Expected string on right hand side of operation, got number.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -356,17 +332,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', 5);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', 5);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -399,7 +371,7 @@ Object {
   "parsedErrors": "Line 139: Expected number on right hand side of operation, got string.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -410,17 +382,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, 1, '5');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, 1, '5');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -453,7 +421,7 @@ Object {
   "parsedErrors": "Line 1: Expected 3 arguments, but got 2.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -464,17 +432,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\"), [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\", 1000), [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -507,7 +471,7 @@ Object {
   "parsedErrors": "Line 1: Expected 3 arguments, but got 2.",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -518,17 +482,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\"), [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\", 1000), [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -559,7 +519,7 @@ Object {
   "parsedErrors": "Line 91: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -570,17 +530,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(append, 1, 0, [1, 2, 3], callIfFuncAndRightArgs(list, 1, 18, 1, 2, 3));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(append, 1, 0, [1, 2, 3], callIfFuncAndRightArgs(list, 1, 18, 1, 2, 3));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -640,7 +596,7 @@ Object {
   "parsedErrors": "Line 129: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -651,17 +607,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(filter, 1, 0, wrap(x => ({   isTail: false,   value: true }), \\\\\\"x => true\\\\\\"), [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(filter, 1, 0, wrap(x => ({   isTail: false,   value: true }), \\\\\\"x => true\\\\\\", 1000), [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -692,7 +644,7 @@ Object {
   "parsedErrors": "Line 58: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -703,17 +655,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(for_each, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\"), [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(for_each, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", 1000), [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -744,7 +692,7 @@ Object {
   "parsedErrors": "Line 24: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -755,17 +703,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -796,7 +740,7 @@ Object {
   "parsedErrors": "Line 33: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -807,17 +751,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(map, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\"), [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(map, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", 1000), [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -848,7 +788,7 @@ Object {
   "parsedErrors": "Line 100: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -859,17 +799,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(member, 1, 0, 1, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(member, 1, 0, 1, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -900,7 +836,7 @@ Object {
   "parsedErrors": "Line 108: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -911,17 +847,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -952,7 +884,7 @@ Object {
   "parsedErrors": "Line 117: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -963,17 +895,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove_all, 1, 0, 1, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove_all, 1, 0, 1, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1004,7 +932,7 @@ Object {
   "parsedErrors": "Line 80: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1015,17 +943,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(reverse, 1, 0, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(reverse, 1, 0, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1056,7 +980,7 @@ Object {
   "parsedErrors": "Line 1: Error: set_head(xs,x) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1067,17 +991,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_head, 1, 0, [1, 2, 3], 4);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_head, 1, 0, [1, 2, 3], 4);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1108,7 +1028,7 @@ Object {
   "parsedErrors": "Line 1: Error: set_tail(xs,x) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1119,17 +1039,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_tail, 1, 0, [1, 2, 3], 4);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_tail, 1, 0, [1, 2, 3], 4);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1144,7 +1060,7 @@ Object {
   "parsedErrors": "",
   "result": 10,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1155,17 +1071,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((curr, acc) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", curr, acc, 1, 26) }), \\\\\\"(curr, acc) => curr + acc\\\\\\"), 0, callIfFuncAndRightArgs(list, 1, 41, 2, 3, 4, 1));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((curr, acc) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", curr, acc, 1, 26) }), \\\\\\"(curr, acc) => curr + acc\\\\\\", 1000), 0, callIfFuncAndRightArgs(list, 1, 41, 2, 3, 4, 1));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1180,7 +1092,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1191,17 +1103,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(append, 1, 6, callIfFuncAndRightArgs(list, 1, 13, \\\\\\"string\\\\\\", 123), callIfFuncAndRightArgs(list, 1, 34, 456, null, undefined)), callIfFuncAndRightArgs(list, 1, 63, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(append, 1, 6, callIfFuncAndRightArgs(list, 1, 13, \\\\\\"string\\\\\\", 123), callIfFuncAndRightArgs(list, 1, 34, 456, null, undefined)), callIfFuncAndRightArgs(list, 1, 63, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1216,7 +1124,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1227,17 +1135,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(build_list, 1, 6, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", x, x, 1, 25) }), \\\\\\"x => x * x\\\\\\")), callIfFuncAndRightArgs(list, 1, 33, 0, 1, 4, 9, 16));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(build_list, 1, 6, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", x, x, 1, 25) }), \\\\\\"x => x * x\\\\\\", 1000)), callIfFuncAndRightArgs(list, 1, 33, 0, 1, 4, 9, 16));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1252,7 +1156,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1263,17 +1167,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1288,7 +1188,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1299,17 +1199,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1.5, 5), callIfFuncAndRightArgs(list, 1, 25, 1.5, 2.5, 3.5, 4.5));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1.5, 5), callIfFuncAndRightArgs(list, 1, 25, 1.5, 2.5, 3.5, 4.5));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1324,7 +1220,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1335,17 +1231,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1, 5), callIfFuncAndRightArgs(list, 1, 23, 1, 2, 3, 4, 5));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1, 5), callIfFuncAndRightArgs(list, 1, 23, 1, 2, 3, 4, 5));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1360,7 +1252,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1371,17 +1263,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(filter, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", x, 4, 1, 18) }), \\\\\\"x => x <= 4\\\\\\"), callIfFuncAndRightArgs(list, 1, 26, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000)), callIfFuncAndRightArgs(list, 1, 72, 2, 1, 3, 4, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(filter, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", x, 4, 1, 18) }), \\\\\\"x => x <= 4\\\\\\", 1000), callIfFuncAndRightArgs(list, 1, 26, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000)), callIfFuncAndRightArgs(list, 1, 72, 2, 1, 3, 4, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1400,7 +1288,7 @@ sum;",
   "parsedErrors": "",
   "result": 6,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1411,30 +1299,26 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let sum = 0;
-        callIfFuncAndRightArgs(for_each, 2, 0, wrap(x => {
-          sum = binaryOp(\\"+\\", sum, x, 3, 8);
-        }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\"), callIfFuncAndRightArgs(list, 4, 3, 1, 2, 3));
-        lastStatementResult = eval(\\"sum;\\");
-        globals.variables.set(\\"sum\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return sum;
-          },
-          assignNewValue: function (unique) {
-            return sum = unique;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let sum = 0;
+    callIfFuncAndRightArgs(for_each, 2, 0, wrap(x => {
+      sum = binaryOp(\\"+\\", sum, x, 3, 8);
+    }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", 1000), callIfFuncAndRightArgs(list, 4, 3, 1, 2, 3));
+    lastStatementResult = eval(\\"sum;\\");
+    globals.variables.set(\\"sum\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return sum;
+      },
+      assignNewValue: function (unique) {
+        return sum = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1449,7 +1333,7 @@ Object {
   "parsedErrors": "",
   "result": 1,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1460,17 +1344,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1504,7 +1384,7 @@ list(1, 'a string \\"\\"', () => f, f, true, 3.14);",
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1515,29 +1395,25 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const f = wrap(() => {
-          return {
-            isTail: false,
-            value: 1
-          };
-        }, \\"function f() {\\\\n  return 1;\\\\n}\\");
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 2, 0, 1, 'a string \\\\\\"\\\\\\"', wrap(() => ({   isTail: false,   value: f }), \\\\\\"() => f\\\\\\"), f, true, 3.14);\\");
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const f = wrap(() => {
+      return {
+        isTail: false,
+        value: 1
+      };
+    }, \\"function f() {\\\\n  return 1;\\\\n}\\", 1000);
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 2, 0, 1, 'a string \\\\\\"\\\\\\"', wrap(() => ({   isTail: false,   value: f }), \\\\\\"() => f\\\\\\", 1000), f, true, 3.14);\\");
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1552,7 +1428,7 @@ Object {
   "parsedErrors": "",
   "result": 4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1563,17 +1439,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1588,7 +1460,7 @@ Object {
   "parsedErrors": "",
   "result": "[1,[2,[3,null]]]",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1599,17 +1471,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, callIfFuncAndRightArgs(list, 1, 15, 1, 2, 3));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, callIfFuncAndRightArgs(list, 1, 15, 1, 2, 3));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1624,7 +1492,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1635,17 +1503,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(map, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, x, 1, 15) }), \\\\\\"x => 2 * x\\\\\\"), callIfFuncAndRightArgs(list, 1, 22, 12, 11, 3)), callIfFuncAndRightArgs(list, 1, 40, 24, 22, 6));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(map, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, x, 1, 15) }), \\\\\\"x => 2 * x\\\\\\", 1000), callIfFuncAndRightArgs(list, 1, 22, 12, 11, 3)), callIfFuncAndRightArgs(list, 1, 40, 24, 22, 6));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1662,7 +1526,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1673,17 +1537,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(member, 2, 2, \\\\\\"string\\\\\\", callIfFuncAndRightArgs(list, 2, 19, 1, 2, 3, \\\\\\"string\\\\\\", 123, 456, null, undefined)), callIfFuncAndRightArgs(list, 3, 2, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(member, 2, 2, \\\\\\"string\\\\\\", callIfFuncAndRightArgs(list, 2, 19, 1, 2, 3, \\\\\\"string\\\\\\", 123, 456, null, undefined)), callIfFuncAndRightArgs(list, 3, 2, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1714,7 +1574,7 @@ Object {
   "parsedErrors": "Line 1: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1725,17 +1585,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1766,7 +1622,7 @@ Object {
   "parsedErrors": "Line 1: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
   "result": undefined,
   "resultStatus": "error",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1777,17 +1633,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, [1, 2, 3]);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, [1, 2, 3]);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1805,7 +1657,7 @@ Object {
     "a string \\"\\"",
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1816,17 +1668,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 'a string \\\\\\"\\\\\\"');\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 'a string \\\\\\"\\\\\\"');\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1844,7 +1692,7 @@ Object {
     null,
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1855,17 +1703,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 2, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 2, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1880,7 +1724,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1891,17 +1735,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1916,7 +1756,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1927,17 +1767,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 2, 3, \\\\\\"1\\\\\\")), callIfFuncAndRightArgs(list, 1, 38, 2, 3, \\\\\\"1\\\\\\"));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 2, 3, \\\\\\"1\\\\\\")), callIfFuncAndRightArgs(list, 1, 38, 2, 3, \\\\\\"1\\\\\\"));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1952,7 +1788,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1963,17 +1799,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 1, 2, 3, 4, 1, 1, \\\\\\"1\\\\\\", 5, 1, 1, 6)), callIfFuncAndRightArgs(list, 1, 62, 2, 3, 4, \\\\\\"1\\\\\\", 5, 6));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 1, 2, 3, 4, 1, 1, \\\\\\"1\\\\\\", 5, 1, 1, 6)), callIfFuncAndRightArgs(list, 1, 62, 2, 3, 4, \\\\\\"1\\\\\\", 5, 6));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -1988,7 +1820,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -1999,17 +1831,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(reverse, 1, 6, callIfFuncAndRightArgs(list, 1, 14, \\\\\\"string\\\\\\", null, undefined, null, 123)), callIfFuncAndRightArgs(list, 1, 59, 123, null, undefined, null, \\\\\\"string\\\\\\"));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(reverse, 1, 6, callIfFuncAndRightArgs(list, 1, 14, \\\\\\"string\\\\\\", null, undefined, null, 123)), callIfFuncAndRightArgs(list, 1, 59, 123, null, undefined, null, \\\\\\"string\\\\\\"));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2027,7 +1855,7 @@ p === q && equal(p, pair(3, 2));",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2038,35 +1866,31 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
-        const q = p;
-        callIfFuncAndRightArgs(set_head, 3, 0, p, 3);
-        lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 3, 2));\\");
-        globals.variables.set(\\"p\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return p;
-          },
-          assignNewValue: function (unique) {
-            return p = unique;
-          }
-        });
-        globals.variables.set(\\"q\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return q;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
+    const q = p;
+    callIfFuncAndRightArgs(set_head, 3, 0, p, 3);
+    lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 3, 2));\\");
+    globals.variables.set(\\"p\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return p;
+      },
+      assignNewValue: function (unique) {
+        return p = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"q\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return q;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2084,7 +1908,7 @@ p === q && equal(p, pair(1, 3));",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2095,35 +1919,31 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
-        const q = p;
-        callIfFuncAndRightArgs(set_tail, 3, 0, p, 3);
-        lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 1, 3));\\");
-        globals.variables.set(\\"p\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return p;
-          },
-          assignNewValue: function (unique) {
-            return p = unique;
-          }
-        });
-        globals.variables.set(\\"q\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return q;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
+    const q = p;
+    callIfFuncAndRightArgs(set_tail, 3, 0, p, 3);
+    lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 1, 3));\\");
+    globals.variables.set(\\"p\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return p;
+      },
+      assignNewValue: function (unique) {
+        return p = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"q\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return q;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2138,7 +1958,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2149,17 +1969,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(list, 1, 5, 1));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(list, 1, 5, 1));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -2174,7 +1990,7 @@ Object {
   "parsedErrors": "",
   "result": "a string \\"\\"",
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -2185,17 +2001,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/stdlib/__tests__/__snapshots__/misc.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/misc.ts.snap
@@ -154,7 +154,7 @@ Object {
   "parsedErrors": "",
   "result": NaN,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -165,17 +165,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 2);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 2);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -190,7 +186,7 @@ Object {
   "parsedErrors": "",
   "result": 6485,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -201,17 +197,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '1100101010101', 2);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '1100101010101', 2);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -226,7 +218,7 @@ Object {
   "parsedErrors": "",
   "result": 39961,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -237,17 +229,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 36);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 36);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/stdlib/__tests__/__snapshots__/stream.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/stream.ts.snap
@@ -10,7 +10,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -21,17 +21,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_append, 1, 21, callIfFuncAndRightArgs(stream, 1, 35, \\\\\\"string\\\\\\", 123), callIfFuncAndRightArgs(stream, 1, 58, 456, null, undefined))), callIfFuncAndRightArgs(list, 2, 4, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_append, 1, 21, callIfFuncAndRightArgs(stream, 1, 35, \\\\\\"string\\\\\\", 123), callIfFuncAndRightArgs(stream, 1, 58, 456, null, undefined))), callIfFuncAndRightArgs(list, 2, 4, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -46,7 +42,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -57,17 +53,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(build_stream, 1, 21, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", x, x, 1, 42) }), \\\\\\"x => x * x\\\\\\"))), callIfFuncAndRightArgs(list, 1, 51, 0, 1, 4, 9, 16));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(build_stream, 1, 21, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", x, x, 1, 42) }), \\\\\\"x => x * x\\\\\\", 1000))), callIfFuncAndRightArgs(list, 1, 51, 0, 1, 4, 9, 16));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -82,7 +74,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -93,17 +85,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1.5, 5)), callIfFuncAndRightArgs(list, 1, 43, 1.5, 2.5, 3.5, 4.5));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1.5, 5)), callIfFuncAndRightArgs(list, 1, 43, 1.5, 2.5, 3.5, 4.5));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -118,7 +106,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -129,17 +117,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1, 5)), callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3, 4, 5));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1, 5)), callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3, 4, 5));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -158,7 +142,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -169,17 +153,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_filter, 3, 4, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", x, 4, 3, 23) }), \\\\\\"x => x <= 4\\\\\\"), callIfFuncAndRightArgs(stream, 3, 31, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000))), callIfFuncAndRightArgs(list, 5, 2, 2, 1, 3, 4, 2));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_filter, 3, 4, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", x, 4, 3, 23) }), \\\\\\"x => x <= 4\\\\\\", 1000), callIfFuncAndRightArgs(stream, 3, 31, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000))), callIfFuncAndRightArgs(list, 5, 2, 2, 1, 3, 4, 2));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -198,7 +178,7 @@ sum;",
   "parsedErrors": "",
   "result": 6,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -209,30 +189,26 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        let sum = 0;
-        callIfFuncAndRightArgs(stream_for_each, 2, 0, wrap(x => {
-          sum = binaryOp(\\"+\\", sum, x, 3, 8);
-        }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\"), callIfFuncAndRightArgs(stream, 4, 3, 1, 2, 3));
-        lastStatementResult = eval(\\"sum;\\");
-        globals.variables.set(\\"sum\\", {
-          kind: \\"let\\",
-          getValue: () => {
-            return sum;
-          },
-          assignNewValue: function (unique) {
-            return sum = unique;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    let sum = 0;
+    callIfFuncAndRightArgs(stream_for_each, 2, 0, wrap(x => {
+      sum = binaryOp(\\"+\\", sum, x, 3, 8);
+    }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", 1000), callIfFuncAndRightArgs(stream, 4, 3, 1, 2, 3));
+    lastStatementResult = eval(\\"sum;\\");
+    globals.variables.set(\\"sum\\", {
+      kind: \\"let\\",
+      getValue: () => {
+        return sum;
+      },
+      assignNewValue: function (unique) {
+        return sum = unique;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -247,7 +223,7 @@ Object {
   "parsedErrors": "",
   "result": 4,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -258,17 +234,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_ref, 1, 0, callIfFuncAndRightArgs(stream, 1, 11, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_ref, 1, 0, callIfFuncAndRightArgs(stream, 1, 11, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -283,7 +255,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -294,17 +266,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_map, 1, 21, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, x, 1, 37) }), \\\\\\"x => 2 * x\\\\\\"), callIfFuncAndRightArgs(stream, 1, 44, 12, 11, 3))), callIfFuncAndRightArgs(list, 1, 65, 24, 22, 6));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_map, 1, 21, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, x, 1, 37) }), \\\\\\"x => 2 * x\\\\\\", 1000), callIfFuncAndRightArgs(stream, 1, 44, 12, 11, 3))), callIfFuncAndRightArgs(list, 1, 65, 24, 22, 6));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -321,7 +289,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -332,17 +300,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_member, 2, 17, \\\\\\"string\\\\\\", callIfFuncAndRightArgs(stream, 2, 41, 1, 2, 3, \\\\\\"string\\\\\\", 123, 456, null, undefined))), callIfFuncAndRightArgs(list, 3, 2, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_member, 2, 17, \\\\\\"string\\\\\\", callIfFuncAndRightArgs(stream, 2, 41, 1, 2, 3, \\\\\\"string\\\\\\", 123, 456, null, undefined))), callIfFuncAndRightArgs(list, 3, 2, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -357,7 +321,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -368,17 +332,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream, 1, 0);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream, 1, 0);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -396,7 +356,7 @@ stream_ref(s,4)(22) === 22 && stream_ref(s,7)(pair('', '1')) === '1' && result;"
   "parsedErrors": "",
   "result": false,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -407,37 +367,33 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        const s = callIfFuncAndRightArgs(stream, 1, 10, true, false, undefined, 1, wrap(x => ({
-          isTail: false,
-          value: x
-        }), \\"x => x\\"), null, unaryOp(\\"-\\", 123, 1, 56), head);
-        const result = [];
-        callIfFuncAndRightArgs(stream_for_each, 3, 0, wrap(item => {
-          setProp(result, callIfFuncAndRightArgs(array_length, 3, 32, result), item, 3, 25);
-        }, \\"item => {\\\\n  result[array_length(result)] = item;\\\\n}\\"), s);
-        lastStatementResult = eval(\\"boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 0, s, 4), 4, 0, 22), 22, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 30, s, 7), 4, 30, callIfFuncAndRightArgs(pair, 4, 46, '', '1')), '1', 4, 30), 4, 0) && result;\\");
-        globals.variables.set(\\"s\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return s;
-          }
-        });
-        globals.variables.set(\\"result\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return result;
-          }
-        });
+const globals = native.globals;
+{
+  {
+    const s = callIfFuncAndRightArgs(stream, 1, 10, true, false, undefined, 1, wrap(x => ({
+      isTail: false,
+      value: x
+    }), \\"x => x\\", 1000), null, unaryOp(\\"-\\", 123, 1, 56), head);
+    const result = [];
+    callIfFuncAndRightArgs(stream_for_each, 3, 0, wrap(item => {
+      setProp(result, callIfFuncAndRightArgs(array_length, 3, 32, result), item, 3, 25);
+    }, \\"item => {\\\\n  result[array_length(result)] = item;\\\\n}\\", 1000), s);
+    lastStatementResult = eval(\\"boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 0, s, 4), 4, 0, 22), 22, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 30, s, 7), 4, 30, callIfFuncAndRightArgs(pair, 4, 46, '', '1')), '1', 4, 30), 4, 0) && result;\\");
+    globals.variables.set(\\"s\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return s;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"result\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return result;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -455,7 +411,7 @@ Object {
     [Function],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -466,17 +422,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_tail, 1, 0, callIfFuncAndRightArgs(integers_from, 1, 12, 0));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_tail, 1, 0, callIfFuncAndRightArgs(integers_from, 1, 12, 0));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -491,7 +443,7 @@ Object {
   "parsedErrors": "",
   "result": 2,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -502,17 +454,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(stream_tail, 1, 5, callIfFuncAndRightArgs(stream, 1, 17, 1, 2)));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(stream_tail, 1, 5, callIfFuncAndRightArgs(stream, 1, 17, 1, 2)));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -527,7 +475,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -538,17 +486,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, null);\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, null);\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -581,7 +525,7 @@ Object {
     ],
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -592,17 +536,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream, 1, 15, 1, true, 3, 4.4, [1, 2]));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream, 1, 15, 1, true, 3, 4.4, [1, 2]));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -620,7 +560,7 @@ Object {
     null,
   ],
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -631,17 +571,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream_remove, 1, 15, 2, callIfFuncAndRightArgs(stream, 1, 32, 1)));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream_remove, 1, 15, 2, callIfFuncAndRightArgs(stream, 1, 32, 1)));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -656,7 +592,7 @@ Object {
   "parsedErrors": "",
   "result": null,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -667,17 +603,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_remove, 1, 0, 1, callIfFuncAndRightArgs(stream, 1, 17, 1));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_remove, 1, 0, 1, callIfFuncAndRightArgs(stream, 1, 17, 1));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -692,7 +624,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -703,17 +635,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 2, 3, \\\\\\"1\\\\\\"))), callIfFuncAndRightArgs(list, 1, 63, 2, 3, \\\\\\"1\\\\\\"));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 2, 3, \\\\\\"1\\\\\\"))), callIfFuncAndRightArgs(list, 1, 63, 2, 3, \\\\\\"1\\\\\\"));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -729,7 +657,7 @@ Object {
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -740,17 +668,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 1, 2, 3, 4, 1, 1, \\\\\\"1\\\\\\", 5, 1, 1, 6))), callIfFuncAndRightArgs(list, 2, 2, 2, 3, 4, \\\\\\"1\\\\\\", 5, 6));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 1, 2, 3, 4, 1, 1, \\\\\\"1\\\\\\", 5, 1, 1, 6))), callIfFuncAndRightArgs(list, 2, 2, 2, 3, 4, \\\\\\"1\\\\\\", 5, 6));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }
@@ -768,7 +692,7 @@ list(123, null, undefined, null, \\"string\\"));",
   "parsedErrors": "",
   "result": true,
   "resultStatus": "finished",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -779,17 +703,13 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $NATIVE_STORAGE.globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      {
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_reverse, 2, 2, callIfFuncAndRightArgs(stream, 3, 4, \\\\\\"string\\\\\\", null, undefined, null, 123))), callIfFuncAndRightArgs(list, 4, 0, 123, null, undefined, null, \\\\\\"string\\\\\\"));\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  {
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_reverse, 2, 2, callIfFuncAndRightArgs(stream, 3, 4, \\\\\\"string\\\\\\", null, undefined, null, 123))), callIfFuncAndRightArgs(list, 4, 0, 123, null, undefined, null, \\\\\\"string\\\\\\"));\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
   "visualiseListResult": Array [],
 }

--- a/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
@@ -1,142 +1,138 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Ensure no name clashes 1`] = `
-"const native0 = $$NATIVE_STORAGE;
-const forceIt = native.operators.get(\\"forceIt\\");
-const callIfFuncAndRightArgs0 = native.operators.get(\\"callIfFuncAndRightArgs\\");
-const boolOrErr0 = native.operators.get(\\"boolOrErr\\");
-const wrap90 = native.operators.get(\\"wrap\\");
-const unaryOp = native.operators.get(\\"unaryOp\\");
-const binaryOp = native.operators.get(\\"binaryOp\\");
-const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
-const setProp = native.operators.get(\\"setProp\\");
-const getProp = native.operators.get(\\"getProp\\");
+"const native0 = nativeStorage;
+const forceIt = native0.operators.get(\\"forceIt\\");
+const callIfFuncAndRightArgs0 = native0.operators.get(\\"callIfFuncAndRightArgs\\");
+const boolOrErr0 = native0.operators.get(\\"boolOrErr\\");
+const wrap90 = native0.operators.get(\\"wrap\\");
+const unaryOp = native0.operators.get(\\"unaryOp\\");
+const binaryOp = native0.operators.get(\\"binaryOp\\");
+const throwIfTimeout = native0.operators.get(\\"throwIfTimeout\\");
+const setProp = native0.operators.get(\\"setProp\\");
+const getProp = native0.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $$NATIVE_STORAGE[1].globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      const runtime = globals.previousScope.variables.get(\\"runtime\\").getValue();
-      const display = globals.previousScope.variables.get(\\"display\\").getValue();
-      const raw_display = globals.previousScope.variables.get(\\"raw_display\\").getValue();
-      const stringify = globals.previousScope.variables.get(\\"stringify\\").getValue();
-      const error = globals.previousScope.variables.get(\\"error\\").getValue();
-      const prompt = globals.previousScope.variables.get(\\"prompt\\").getValue();
-      const is_number = globals.previousScope.variables.get(\\"is_number\\").getValue();
-      const is_string = globals.previousScope.variables.get(\\"is_string\\").getValue();
-      const is_function = globals.previousScope.variables.get(\\"is_function\\").getValue();
-      const is_boolean = globals.previousScope.variables.get(\\"is_boolean\\").getValue();
-      const is_undefined = globals.previousScope.variables.get(\\"is_undefined\\").getValue();
-      const parse_int = globals.previousScope.variables.get(\\"parse_int\\").getValue();
-      const undefined = globals.previousScope.variables.get(\\"undefined\\").getValue();
-      const NaN = globals.previousScope.variables.get(\\"NaN\\").getValue();
-      const Infinity = globals.previousScope.variables.get(\\"Infinity\\").getValue();
-      const math_abs = globals.previousScope.variables.get(\\"math_abs\\").getValue();
-      const math_acos = globals.previousScope.variables.get(\\"math_acos\\").getValue();
-      const math_acosh = globals.previousScope.variables.get(\\"math_acosh\\").getValue();
-      const math_asin = globals.previousScope.variables.get(\\"math_asin\\").getValue();
-      const math_asinh = globals.previousScope.variables.get(\\"math_asinh\\").getValue();
-      const math_atan = globals.previousScope.variables.get(\\"math_atan\\").getValue();
-      const math_atanh = globals.previousScope.variables.get(\\"math_atanh\\").getValue();
-      const math_atan2 = globals.previousScope.variables.get(\\"math_atan2\\").getValue();
-      const math_ceil = globals.previousScope.variables.get(\\"math_ceil\\").getValue();
-      const math_cbrt = globals.previousScope.variables.get(\\"math_cbrt\\").getValue();
-      const math_expm1 = globals.previousScope.variables.get(\\"math_expm1\\").getValue();
-      const math_clz32 = globals.previousScope.variables.get(\\"math_clz32\\").getValue();
-      const math_cos = globals.previousScope.variables.get(\\"math_cos\\").getValue();
-      const math_cosh = globals.previousScope.variables.get(\\"math_cosh\\").getValue();
-      const math_exp = globals.previousScope.variables.get(\\"math_exp\\").getValue();
-      const math_floor = globals.previousScope.variables.get(\\"math_floor\\").getValue();
-      const math_fround = globals.previousScope.variables.get(\\"math_fround\\").getValue();
-      const math_hypot = globals.previousScope.variables.get(\\"math_hypot\\").getValue();
-      const math_imul = globals.previousScope.variables.get(\\"math_imul\\").getValue();
-      const math_log = globals.previousScope.variables.get(\\"math_log\\").getValue();
-      const math_log1p = globals.previousScope.variables.get(\\"math_log1p\\").getValue();
-      const math_log2 = globals.previousScope.variables.get(\\"math_log2\\").getValue();
-      const math_log10 = globals.previousScope.variables.get(\\"math_log10\\").getValue();
-      const math_max = globals.previousScope.variables.get(\\"math_max\\").getValue();
-      const math_min = globals.previousScope.variables.get(\\"math_min\\").getValue();
-      const math_pow = globals.previousScope.variables.get(\\"math_pow\\").getValue();
-      const math_random = globals.previousScope.variables.get(\\"math_random\\").getValue();
-      const math_round = globals.previousScope.variables.get(\\"math_round\\").getValue();
-      const math_sign = globals.previousScope.variables.get(\\"math_sign\\").getValue();
-      const math_sin = globals.previousScope.variables.get(\\"math_sin\\").getValue();
-      const math_sinh = globals.previousScope.variables.get(\\"math_sinh\\").getValue();
-      const math_sqrt = globals.previousScope.variables.get(\\"math_sqrt\\").getValue();
-      const math_tan = globals.previousScope.variables.get(\\"math_tan\\").getValue();
-      const math_tanh = globals.previousScope.variables.get(\\"math_tanh\\").getValue();
-      const math_trunc = globals.previousScope.variables.get(\\"math_trunc\\").getValue();
-      const math_E = globals.previousScope.variables.get(\\"math_E\\").getValue();
-      const math_LN10 = globals.previousScope.variables.get(\\"math_LN10\\").getValue();
-      const math_LN2 = globals.previousScope.variables.get(\\"math_LN2\\").getValue();
-      const math_LOG10E = globals.previousScope.variables.get(\\"math_LOG10E\\").getValue();
-      const math_LOG2E = globals.previousScope.variables.get(\\"math_LOG2E\\").getValue();
-      const math_PI = globals.previousScope.variables.get(\\"math_PI\\").getValue();
-      const math_SQRT1_2 = globals.previousScope.variables.get(\\"math_SQRT1_2\\").getValue();
-      const math_SQRT2 = globals.previousScope.variables.get(\\"math_SQRT2\\").getValue();
-      const pair = globals.previousScope.variables.get(\\"pair\\").getValue();
-      const is_pair = globals.previousScope.variables.get(\\"is_pair\\").getValue();
-      const head = globals.previousScope.variables.get(\\"head\\").getValue();
-      const tail = globals.previousScope.variables.get(\\"tail\\").getValue();
-      const is_null = globals.previousScope.variables.get(\\"is_null\\").getValue();
-      const list = globals.previousScope.variables.get(\\"list\\").getValue();
-      const draw_data = globals.previousScope.variables.get(\\"draw_data\\").getValue();
-      const set_head = globals.previousScope.variables.get(\\"set_head\\").getValue();
-      const set_tail = globals.previousScope.variables.get(\\"set_tail\\").getValue();
-      const array_length = globals.previousScope.variables.get(\\"array_length\\").getValue();
-      const is_array = globals.previousScope.variables.get(\\"is_array\\").getValue();
-      const stream_tail = globals.previousScope.variables.get(\\"stream_tail\\").getValue();
-      const stream = globals.previousScope.variables.get(\\"stream\\").getValue();
-      const list_to_stream = globals.previousScope.variables.get(\\"list_to_stream\\").getValue();
-      const parse = globals.previousScope.variables.get(\\"parse\\").getValue();
-      const apply_in_underlying_javascript = globals.previousScope.variables.get(\\"apply_in_underlying_javascript\\").getValue();
-      {
-        const boolOrErr = 1;
-        setProp(boolOrErr, 123, 1, 2, 0);
-        const f = wrap90((callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) => {
-          let wrap = 2;
-          wrap0;
-          wrap1;
-          wrap2;
-          wrap3;
-          wrap4;
-          wrap5;
-          wrap6;
-          wrap7;
-          wrap8;
-          wrap9;
-        }, \\"function f(callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) {\\\\n  let wrap = 2;\\\\n  wrap0;\\\\n  wrap1;\\\\n  wrap2;\\\\n  wrap3;\\\\n  wrap4;\\\\n  wrap5;\\\\n  wrap6;\\\\n  wrap7;\\\\n  wrap8;\\\\n  wrap9;\\\\n}\\");
-        const native = 123;
-        globals.variables.set(\\"boolOrErr\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return boolOrErr;
-          }
-        });
-        globals.variables.set(\\"f\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return f;
-          }
-        });
-        globals.variables.set(\\"native\\", {
-          kind: \\"const\\",
-          getValue: () => {
-            return native;
-          }
-        });
+const globals = native0.globals;
+{
+  const runtime = globals.previousScope.variables.get(\\"runtime\\").getValue();
+  const display = globals.previousScope.variables.get(\\"display\\").getValue();
+  const raw_display = globals.previousScope.variables.get(\\"raw_display\\").getValue();
+  const stringify = globals.previousScope.variables.get(\\"stringify\\").getValue();
+  const error = globals.previousScope.variables.get(\\"error\\").getValue();
+  const prompt = globals.previousScope.variables.get(\\"prompt\\").getValue();
+  const is_number = globals.previousScope.variables.get(\\"is_number\\").getValue();
+  const is_string = globals.previousScope.variables.get(\\"is_string\\").getValue();
+  const is_function = globals.previousScope.variables.get(\\"is_function\\").getValue();
+  const is_boolean = globals.previousScope.variables.get(\\"is_boolean\\").getValue();
+  const is_undefined = globals.previousScope.variables.get(\\"is_undefined\\").getValue();
+  const parse_int = globals.previousScope.variables.get(\\"parse_int\\").getValue();
+  const undefined = globals.previousScope.variables.get(\\"undefined\\").getValue();
+  const NaN = globals.previousScope.variables.get(\\"NaN\\").getValue();
+  const Infinity = globals.previousScope.variables.get(\\"Infinity\\").getValue();
+  const math_abs = globals.previousScope.variables.get(\\"math_abs\\").getValue();
+  const math_acos = globals.previousScope.variables.get(\\"math_acos\\").getValue();
+  const math_acosh = globals.previousScope.variables.get(\\"math_acosh\\").getValue();
+  const math_asin = globals.previousScope.variables.get(\\"math_asin\\").getValue();
+  const math_asinh = globals.previousScope.variables.get(\\"math_asinh\\").getValue();
+  const math_atan = globals.previousScope.variables.get(\\"math_atan\\").getValue();
+  const math_atanh = globals.previousScope.variables.get(\\"math_atanh\\").getValue();
+  const math_atan2 = globals.previousScope.variables.get(\\"math_atan2\\").getValue();
+  const math_ceil = globals.previousScope.variables.get(\\"math_ceil\\").getValue();
+  const math_cbrt = globals.previousScope.variables.get(\\"math_cbrt\\").getValue();
+  const math_expm1 = globals.previousScope.variables.get(\\"math_expm1\\").getValue();
+  const math_clz32 = globals.previousScope.variables.get(\\"math_clz32\\").getValue();
+  const math_cos = globals.previousScope.variables.get(\\"math_cos\\").getValue();
+  const math_cosh = globals.previousScope.variables.get(\\"math_cosh\\").getValue();
+  const math_exp = globals.previousScope.variables.get(\\"math_exp\\").getValue();
+  const math_floor = globals.previousScope.variables.get(\\"math_floor\\").getValue();
+  const math_fround = globals.previousScope.variables.get(\\"math_fround\\").getValue();
+  const math_hypot = globals.previousScope.variables.get(\\"math_hypot\\").getValue();
+  const math_imul = globals.previousScope.variables.get(\\"math_imul\\").getValue();
+  const math_log = globals.previousScope.variables.get(\\"math_log\\").getValue();
+  const math_log1p = globals.previousScope.variables.get(\\"math_log1p\\").getValue();
+  const math_log2 = globals.previousScope.variables.get(\\"math_log2\\").getValue();
+  const math_log10 = globals.previousScope.variables.get(\\"math_log10\\").getValue();
+  const math_max = globals.previousScope.variables.get(\\"math_max\\").getValue();
+  const math_min = globals.previousScope.variables.get(\\"math_min\\").getValue();
+  const math_pow = globals.previousScope.variables.get(\\"math_pow\\").getValue();
+  const math_random = globals.previousScope.variables.get(\\"math_random\\").getValue();
+  const math_round = globals.previousScope.variables.get(\\"math_round\\").getValue();
+  const math_sign = globals.previousScope.variables.get(\\"math_sign\\").getValue();
+  const math_sin = globals.previousScope.variables.get(\\"math_sin\\").getValue();
+  const math_sinh = globals.previousScope.variables.get(\\"math_sinh\\").getValue();
+  const math_sqrt = globals.previousScope.variables.get(\\"math_sqrt\\").getValue();
+  const math_tan = globals.previousScope.variables.get(\\"math_tan\\").getValue();
+  const math_tanh = globals.previousScope.variables.get(\\"math_tanh\\").getValue();
+  const math_trunc = globals.previousScope.variables.get(\\"math_trunc\\").getValue();
+  const math_E = globals.previousScope.variables.get(\\"math_E\\").getValue();
+  const math_LN10 = globals.previousScope.variables.get(\\"math_LN10\\").getValue();
+  const math_LN2 = globals.previousScope.variables.get(\\"math_LN2\\").getValue();
+  const math_LOG10E = globals.previousScope.variables.get(\\"math_LOG10E\\").getValue();
+  const math_LOG2E = globals.previousScope.variables.get(\\"math_LOG2E\\").getValue();
+  const math_PI = globals.previousScope.variables.get(\\"math_PI\\").getValue();
+  const math_SQRT1_2 = globals.previousScope.variables.get(\\"math_SQRT1_2\\").getValue();
+  const math_SQRT2 = globals.previousScope.variables.get(\\"math_SQRT2\\").getValue();
+  const pair = globals.previousScope.variables.get(\\"pair\\").getValue();
+  const is_pair = globals.previousScope.variables.get(\\"is_pair\\").getValue();
+  const head = globals.previousScope.variables.get(\\"head\\").getValue();
+  const tail = globals.previousScope.variables.get(\\"tail\\").getValue();
+  const is_null = globals.previousScope.variables.get(\\"is_null\\").getValue();
+  const list = globals.previousScope.variables.get(\\"list\\").getValue();
+  const draw_data = globals.previousScope.variables.get(\\"draw_data\\").getValue();
+  const set_head = globals.previousScope.variables.get(\\"set_head\\").getValue();
+  const set_tail = globals.previousScope.variables.get(\\"set_tail\\").getValue();
+  const array_length = globals.previousScope.variables.get(\\"array_length\\").getValue();
+  const is_array = globals.previousScope.variables.get(\\"is_array\\").getValue();
+  const stream_tail = globals.previousScope.variables.get(\\"stream_tail\\").getValue();
+  const stream = globals.previousScope.variables.get(\\"stream\\").getValue();
+  const list_to_stream = globals.previousScope.variables.get(\\"list_to_stream\\").getValue();
+  const parse = globals.previousScope.variables.get(\\"parse\\").getValue();
+  const apply_in_underlying_javascript = globals.previousScope.variables.get(\\"apply_in_underlying_javascript\\").getValue();
+  {
+    const boolOrErr = 1;
+    setProp(boolOrErr, 123, 1, 2, 0);
+    const f = wrap90((callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) => {
+      let wrap = 2;
+      wrap0;
+      wrap1;
+      wrap2;
+      wrap3;
+      wrap4;
+      wrap5;
+      wrap6;
+      wrap7;
+      wrap8;
+      wrap9;
+    }, \\"function f(callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) {\\\\n  let wrap = 2;\\\\n  wrap0;\\\\n  wrap1;\\\\n  wrap2;\\\\n  wrap3;\\\\n  wrap4;\\\\n  wrap5;\\\\n  wrap6;\\\\n  wrap7;\\\\n  wrap8;\\\\n  wrap9;\\\\n}\\", 1000);
+    const native = 123;
+    globals.variables.set(\\"boolOrErr\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return boolOrErr;
       }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+    });
+    globals.variables.set(\\"f\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return f;
+      }
+    });
+    globals.variables.set(\\"native\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return native;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
 "
 `;
 
 exports[`builtins do get prepended 1`] = `
 Object {
   "code": "\\"ensure_builtins\\";",
-  "transpiled": "const native = $$NATIVE_STORAGE;
+  "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
 const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
 const boolOrErr = native.operators.get(\\"boolOrErr\\");
@@ -147,91 +143,87 @@ const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
 const setProp = native.operators.get(\\"setProp\\");
 const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
-const globals = $$NATIVE_STORAGE[0].globals;
-(( <globals redacted> ) => {
-  return (() => {
-    {
-      const runtime = globals.previousScope.variables.get(\\"runtime\\").getValue();
-      const display = globals.previousScope.variables.get(\\"display\\").getValue();
-      const raw_display = globals.previousScope.variables.get(\\"raw_display\\").getValue();
-      const stringify = globals.previousScope.variables.get(\\"stringify\\").getValue();
-      const error = globals.previousScope.variables.get(\\"error\\").getValue();
-      const prompt = globals.previousScope.variables.get(\\"prompt\\").getValue();
-      const is_number = globals.previousScope.variables.get(\\"is_number\\").getValue();
-      const is_string = globals.previousScope.variables.get(\\"is_string\\").getValue();
-      const is_function = globals.previousScope.variables.get(\\"is_function\\").getValue();
-      const is_boolean = globals.previousScope.variables.get(\\"is_boolean\\").getValue();
-      const is_undefined = globals.previousScope.variables.get(\\"is_undefined\\").getValue();
-      const parse_int = globals.previousScope.variables.get(\\"parse_int\\").getValue();
-      const undefined = globals.previousScope.variables.get(\\"undefined\\").getValue();
-      const NaN = globals.previousScope.variables.get(\\"NaN\\").getValue();
-      const Infinity = globals.previousScope.variables.get(\\"Infinity\\").getValue();
-      const math_abs = globals.previousScope.variables.get(\\"math_abs\\").getValue();
-      const math_acos = globals.previousScope.variables.get(\\"math_acos\\").getValue();
-      const math_acosh = globals.previousScope.variables.get(\\"math_acosh\\").getValue();
-      const math_asin = globals.previousScope.variables.get(\\"math_asin\\").getValue();
-      const math_asinh = globals.previousScope.variables.get(\\"math_asinh\\").getValue();
-      const math_atan = globals.previousScope.variables.get(\\"math_atan\\").getValue();
-      const math_atanh = globals.previousScope.variables.get(\\"math_atanh\\").getValue();
-      const math_atan2 = globals.previousScope.variables.get(\\"math_atan2\\").getValue();
-      const math_ceil = globals.previousScope.variables.get(\\"math_ceil\\").getValue();
-      const math_cbrt = globals.previousScope.variables.get(\\"math_cbrt\\").getValue();
-      const math_expm1 = globals.previousScope.variables.get(\\"math_expm1\\").getValue();
-      const math_clz32 = globals.previousScope.variables.get(\\"math_clz32\\").getValue();
-      const math_cos = globals.previousScope.variables.get(\\"math_cos\\").getValue();
-      const math_cosh = globals.previousScope.variables.get(\\"math_cosh\\").getValue();
-      const math_exp = globals.previousScope.variables.get(\\"math_exp\\").getValue();
-      const math_floor = globals.previousScope.variables.get(\\"math_floor\\").getValue();
-      const math_fround = globals.previousScope.variables.get(\\"math_fround\\").getValue();
-      const math_hypot = globals.previousScope.variables.get(\\"math_hypot\\").getValue();
-      const math_imul = globals.previousScope.variables.get(\\"math_imul\\").getValue();
-      const math_log = globals.previousScope.variables.get(\\"math_log\\").getValue();
-      const math_log1p = globals.previousScope.variables.get(\\"math_log1p\\").getValue();
-      const math_log2 = globals.previousScope.variables.get(\\"math_log2\\").getValue();
-      const math_log10 = globals.previousScope.variables.get(\\"math_log10\\").getValue();
-      const math_max = globals.previousScope.variables.get(\\"math_max\\").getValue();
-      const math_min = globals.previousScope.variables.get(\\"math_min\\").getValue();
-      const math_pow = globals.previousScope.variables.get(\\"math_pow\\").getValue();
-      const math_random = globals.previousScope.variables.get(\\"math_random\\").getValue();
-      const math_round = globals.previousScope.variables.get(\\"math_round\\").getValue();
-      const math_sign = globals.previousScope.variables.get(\\"math_sign\\").getValue();
-      const math_sin = globals.previousScope.variables.get(\\"math_sin\\").getValue();
-      const math_sinh = globals.previousScope.variables.get(\\"math_sinh\\").getValue();
-      const math_sqrt = globals.previousScope.variables.get(\\"math_sqrt\\").getValue();
-      const math_tan = globals.previousScope.variables.get(\\"math_tan\\").getValue();
-      const math_tanh = globals.previousScope.variables.get(\\"math_tanh\\").getValue();
-      const math_trunc = globals.previousScope.variables.get(\\"math_trunc\\").getValue();
-      const math_E = globals.previousScope.variables.get(\\"math_E\\").getValue();
-      const math_LN10 = globals.previousScope.variables.get(\\"math_LN10\\").getValue();
-      const math_LN2 = globals.previousScope.variables.get(\\"math_LN2\\").getValue();
-      const math_LOG10E = globals.previousScope.variables.get(\\"math_LOG10E\\").getValue();
-      const math_LOG2E = globals.previousScope.variables.get(\\"math_LOG2E\\").getValue();
-      const math_PI = globals.previousScope.variables.get(\\"math_PI\\").getValue();
-      const math_SQRT1_2 = globals.previousScope.variables.get(\\"math_SQRT1_2\\").getValue();
-      const math_SQRT2 = globals.previousScope.variables.get(\\"math_SQRT2\\").getValue();
-      const pair = globals.previousScope.variables.get(\\"pair\\").getValue();
-      const is_pair = globals.previousScope.variables.get(\\"is_pair\\").getValue();
-      const head = globals.previousScope.variables.get(\\"head\\").getValue();
-      const tail = globals.previousScope.variables.get(\\"tail\\").getValue();
-      const is_null = globals.previousScope.variables.get(\\"is_null\\").getValue();
-      const list = globals.previousScope.variables.get(\\"list\\").getValue();
-      const draw_data = globals.previousScope.variables.get(\\"draw_data\\").getValue();
-      const set_head = globals.previousScope.variables.get(\\"set_head\\").getValue();
-      const set_tail = globals.previousScope.variables.get(\\"set_tail\\").getValue();
-      const array_length = globals.previousScope.variables.get(\\"array_length\\").getValue();
-      const is_array = globals.previousScope.variables.get(\\"is_array\\").getValue();
-      const stream_tail = globals.previousScope.variables.get(\\"stream_tail\\").getValue();
-      const stream = globals.previousScope.variables.get(\\"stream\\").getValue();
-      const list_to_stream = globals.previousScope.variables.get(\\"list_to_stream\\").getValue();
-      const parse = globals.previousScope.variables.get(\\"parse\\").getValue();
-      const apply_in_underlying_javascript = globals.previousScope.variables.get(\\"apply_in_underlying_javascript\\").getValue();
-      {
-        lastStatementResult = eval(\\"\\\\\\"ensure_builtins\\\\\\";\\");
-      }
-    }
-    return forceIt(lastStatementResult);
-  })();
-})();
+const globals = native.globals;
+{
+  const runtime = globals.previousScope.variables.get(\\"runtime\\").getValue();
+  const display = globals.previousScope.variables.get(\\"display\\").getValue();
+  const raw_display = globals.previousScope.variables.get(\\"raw_display\\").getValue();
+  const stringify = globals.previousScope.variables.get(\\"stringify\\").getValue();
+  const error = globals.previousScope.variables.get(\\"error\\").getValue();
+  const prompt = globals.previousScope.variables.get(\\"prompt\\").getValue();
+  const is_number = globals.previousScope.variables.get(\\"is_number\\").getValue();
+  const is_string = globals.previousScope.variables.get(\\"is_string\\").getValue();
+  const is_function = globals.previousScope.variables.get(\\"is_function\\").getValue();
+  const is_boolean = globals.previousScope.variables.get(\\"is_boolean\\").getValue();
+  const is_undefined = globals.previousScope.variables.get(\\"is_undefined\\").getValue();
+  const parse_int = globals.previousScope.variables.get(\\"parse_int\\").getValue();
+  const undefined = globals.previousScope.variables.get(\\"undefined\\").getValue();
+  const NaN = globals.previousScope.variables.get(\\"NaN\\").getValue();
+  const Infinity = globals.previousScope.variables.get(\\"Infinity\\").getValue();
+  const math_abs = globals.previousScope.variables.get(\\"math_abs\\").getValue();
+  const math_acos = globals.previousScope.variables.get(\\"math_acos\\").getValue();
+  const math_acosh = globals.previousScope.variables.get(\\"math_acosh\\").getValue();
+  const math_asin = globals.previousScope.variables.get(\\"math_asin\\").getValue();
+  const math_asinh = globals.previousScope.variables.get(\\"math_asinh\\").getValue();
+  const math_atan = globals.previousScope.variables.get(\\"math_atan\\").getValue();
+  const math_atanh = globals.previousScope.variables.get(\\"math_atanh\\").getValue();
+  const math_atan2 = globals.previousScope.variables.get(\\"math_atan2\\").getValue();
+  const math_ceil = globals.previousScope.variables.get(\\"math_ceil\\").getValue();
+  const math_cbrt = globals.previousScope.variables.get(\\"math_cbrt\\").getValue();
+  const math_expm1 = globals.previousScope.variables.get(\\"math_expm1\\").getValue();
+  const math_clz32 = globals.previousScope.variables.get(\\"math_clz32\\").getValue();
+  const math_cos = globals.previousScope.variables.get(\\"math_cos\\").getValue();
+  const math_cosh = globals.previousScope.variables.get(\\"math_cosh\\").getValue();
+  const math_exp = globals.previousScope.variables.get(\\"math_exp\\").getValue();
+  const math_floor = globals.previousScope.variables.get(\\"math_floor\\").getValue();
+  const math_fround = globals.previousScope.variables.get(\\"math_fround\\").getValue();
+  const math_hypot = globals.previousScope.variables.get(\\"math_hypot\\").getValue();
+  const math_imul = globals.previousScope.variables.get(\\"math_imul\\").getValue();
+  const math_log = globals.previousScope.variables.get(\\"math_log\\").getValue();
+  const math_log1p = globals.previousScope.variables.get(\\"math_log1p\\").getValue();
+  const math_log2 = globals.previousScope.variables.get(\\"math_log2\\").getValue();
+  const math_log10 = globals.previousScope.variables.get(\\"math_log10\\").getValue();
+  const math_max = globals.previousScope.variables.get(\\"math_max\\").getValue();
+  const math_min = globals.previousScope.variables.get(\\"math_min\\").getValue();
+  const math_pow = globals.previousScope.variables.get(\\"math_pow\\").getValue();
+  const math_random = globals.previousScope.variables.get(\\"math_random\\").getValue();
+  const math_round = globals.previousScope.variables.get(\\"math_round\\").getValue();
+  const math_sign = globals.previousScope.variables.get(\\"math_sign\\").getValue();
+  const math_sin = globals.previousScope.variables.get(\\"math_sin\\").getValue();
+  const math_sinh = globals.previousScope.variables.get(\\"math_sinh\\").getValue();
+  const math_sqrt = globals.previousScope.variables.get(\\"math_sqrt\\").getValue();
+  const math_tan = globals.previousScope.variables.get(\\"math_tan\\").getValue();
+  const math_tanh = globals.previousScope.variables.get(\\"math_tanh\\").getValue();
+  const math_trunc = globals.previousScope.variables.get(\\"math_trunc\\").getValue();
+  const math_E = globals.previousScope.variables.get(\\"math_E\\").getValue();
+  const math_LN10 = globals.previousScope.variables.get(\\"math_LN10\\").getValue();
+  const math_LN2 = globals.previousScope.variables.get(\\"math_LN2\\").getValue();
+  const math_LOG10E = globals.previousScope.variables.get(\\"math_LOG10E\\").getValue();
+  const math_LOG2E = globals.previousScope.variables.get(\\"math_LOG2E\\").getValue();
+  const math_PI = globals.previousScope.variables.get(\\"math_PI\\").getValue();
+  const math_SQRT1_2 = globals.previousScope.variables.get(\\"math_SQRT1_2\\").getValue();
+  const math_SQRT2 = globals.previousScope.variables.get(\\"math_SQRT2\\").getValue();
+  const pair = globals.previousScope.variables.get(\\"pair\\").getValue();
+  const is_pair = globals.previousScope.variables.get(\\"is_pair\\").getValue();
+  const head = globals.previousScope.variables.get(\\"head\\").getValue();
+  const tail = globals.previousScope.variables.get(\\"tail\\").getValue();
+  const is_null = globals.previousScope.variables.get(\\"is_null\\").getValue();
+  const list = globals.previousScope.variables.get(\\"list\\").getValue();
+  const draw_data = globals.previousScope.variables.get(\\"draw_data\\").getValue();
+  const set_head = globals.previousScope.variables.get(\\"set_head\\").getValue();
+  const set_tail = globals.previousScope.variables.get(\\"set_tail\\").getValue();
+  const array_length = globals.previousScope.variables.get(\\"array_length\\").getValue();
+  const is_array = globals.previousScope.variables.get(\\"is_array\\").getValue();
+  const stream_tail = globals.previousScope.variables.get(\\"stream_tail\\").getValue();
+  const stream = globals.previousScope.variables.get(\\"stream\\").getValue();
+  const list_to_stream = globals.previousScope.variables.get(\\"list_to_stream\\").getValue();
+  const parse = globals.previousScope.variables.get(\\"parse\\").getValue();
+  const apply_in_underlying_javascript = globals.previousScope.variables.get(\\"apply_in_underlying_javascript\\").getValue();
+  {
+    lastStatementResult = eval(\\"\\\\\\"ensure_builtins\\\\\\";\\");
+  }
+}
+forceIt(lastStatementResult);
 ",
 }
 `;

--- a/src/transpiler/__tests__/transpiled-code.ts
+++ b/src/transpiler/__tests__/transpiled-code.ts
@@ -11,7 +11,7 @@ import { transpile } from '../transpiler'
 test('builtins do get prepended', () => {
   const code = '"ensure_builtins";'
   const context = mockContext(4)
-  const transpiled = transpile(parse(code, context)!, context.contextId).transpiled
+  const transpiled = transpile(parse(code, context)!, context).transpiled
   // replace native[<number>] as they may be inconsistent
   const replacedNative = transpiled.replace(/native\[\d+]/g, 'native')
   // replace the line hiding globals as they may differ between environments
@@ -31,7 +31,7 @@ test('Ensure no name clashes', () => {
     const native = 123;
   `
   const context = mockContext(4)
-  const transpiled = transpile(parse(code, context)!, context.contextId).transpiled
+  const transpiled = transpile(parse(code, context)!, context).transpiled
   const replacedNative = transpiled.replace(/native0\[\d+]/g, 'native')
   const replacedGlobalsLine = replacedNative.replace(/\n\(\(.*\)/, '\n(( <globals redacted> )')
   expect(replacedGlobalsLine).toMatchSnapshot()

--- a/src/transpiler/evalContainer.ts
+++ b/src/transpiler/evalContainer.ts
@@ -1,5 +1,17 @@
-/* tslint:disable */
-export const sandboxedEval = (code: string) => {
-  const evalInGlobalScope = eval
-  return evalInGlobalScope(code)
-}
+import { NativeStorage } from '../types'
+import { NATIVE_STORAGE_ID } from '../constants'
+
+type Evaler = (code: string, nativeStorage: NativeStorage) => any
+
+/*
+  We need to use new Function here to ensure that the parameter names do not get
+  minified, as the transpiler uses NATIVE_STORAGE_ID for access
+ */
+
+export const sandboxedEval: Evaler = new Function(
+  'code',
+  NATIVE_STORAGE_ID,
+  `
+return eval(code)
+`
+) as Evaler

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,31 @@ export interface SourceLanguage {
   variant: Variant
 }
 
+export type ValueWrapper = LetWrapper | ConstWrapper
+
+export interface LetWrapper {
+  kind: 'let'
+  getValue: () => Value
+  assignNewValue: <T>(newValue: T) => T
+}
+
+export interface ConstWrapper {
+  kind: 'const'
+  getValue: () => Value
+}
+
+export interface Globals {
+  variables: Map<string, ValueWrapper>
+  previousScope: Globals | null
+}
+
+export interface NativeStorage {
+  globals: Globals | null
+  operators: Map<string, (...operands: Value[]) => Value>
+  gpu: Map<string, (...operands: Value[]) => Value>
+  maxExecTime: number
+}
+
 export interface Context<T = any> {
   /** The source version used */
   chapter: number
@@ -105,9 +130,9 @@ export interface Context<T = any> {
   externalContext?: T
 
   /**
-   * Used for storing id of the context to be referenced by native
+   * Used for storing the native context and other values
    */
-  contextId: number
+  nativeStorage: NativeStorage
 
   /**
    * Describes the language processor to be used for evaluation

--- a/src/utils/operators.ts
+++ b/src/utils/operators.ts
@@ -1,5 +1,4 @@
 import { BinaryOperator, UnaryOperator } from 'estree'
-import { JSSLANG_PROPERTIES } from '../constants'
 import {
   CallingNonFunctionValue,
   ExceptionError,
@@ -16,8 +15,14 @@ import * as create from './astCreator'
 import * as rttc from './rttc'
 import { LazyBuiltIn } from '../createContext'
 
-export function throwIfTimeout(start: number, current: number, line: number, column: number) {
-  if (current - start > JSSLANG_PROPERTIES.maxExecTime) {
+export function throwIfTimeout(
+  maxExecTime: number,
+  start: number,
+  current: number,
+  line: number,
+  column: number
+) {
+  if (current - start > maxExecTime) {
     throw new PotentialInfiniteLoopError(create.locationDummyNode(line, column))
   }
 }
@@ -184,10 +189,9 @@ export function evaluateBinaryExpression(operator: BinaryOperator, left: any, ri
  * as isTail and transformedFunctions are properties
  * and may be added by Source code.
  */
-export const callIteratively = (f: any, ...args: any[]) => {
+export const callIteratively = (f: any, maxExecTime: number, ...args: any[]) => {
   let line = -1
   let column = -1
-  const MAX_TIME = JSSLANG_PROPERTIES.maxExecTime
   const startTime = Date.now()
   const pastCalls: [string, any[]][] = []
   while (true) {
@@ -220,7 +224,7 @@ export const callIteratively = (f: any, ...args: any[]) => {
     let res
     try {
       res = f(...args)
-      if (Date.now() - startTime > MAX_TIME) {
+      if (Date.now() - startTime > maxExecTime) {
         throw new PotentialInfiniteRecursionError(dummy, pastCalls)
       }
     } catch (error) {
@@ -247,8 +251,8 @@ export const callIteratively = (f: any, ...args: any[]) => {
   }
 }
 
-export const wrap = (f: (...args: any[]) => any, stringified: string) => {
-  const wrapped = (...args: any[]) => callIteratively(f, ...args)
+export const wrap = (f: (...args: any[]) => any, stringified: string, maxExecTime: number) => {
+  const wrapped = (...args: any[]) => callIteratively(f, maxExecTime, ...args)
   wrapped.transformedFunction = f
   wrapped[Symbol.toStringTag] = () => stringified
   wrapped.toString = () => stringified

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -105,17 +105,11 @@ async function testInContext(code: string, options: TestOptions): Promise<TestRe
     try {
       const parsed = parse(code, nativeTestContext)!
       transpiled = transpile(parsed, nativeTestContext, true, options.variant).transpiled
-      // replace native[<number>] as they may be inconsistent
-      const replacedNative = transpiled.replace(/native\[\d+]/g, 'native')
-      // replace the line hiding globals as they may differ between environments
-      const replacedGlobalsLine = replacedNative.replace(/\n\(\(.*\)/, '\n(( <globals redacted> )')
       // replace declaration of builtins since they're repetitive
-      const replacedBuiltins = replacedGlobalsLine.replace(
-        /\n      const \w+ = globals\.(previousScope.)+variables.get\("\w+"\)\.getValue\(\);/g,
+      transpiled = transpiled.replace(
+        /\n  const \w+ = globals\.(previousScope.)+variables.get\("\w+"\)\.getValue\(\);/g,
         ''
       )
-      // replace the line globals = $$NATIVE_STORAGE[xxx].globals to remove [xxx]
-      transpiled = replacedBuiltins.replace(/\$\$NATIVE_STORAGE\[\d+]/, '$$NATIVE_STORAGE')
     } catch {
       transpiled = 'parseError'
     }

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -104,7 +104,7 @@ async function testInContext(code: string, options: TestOptions): Promise<TestRe
     let transpiled: string
     try {
       const parsed = parse(code, nativeTestContext)!
-      transpiled = transpile(parsed, nativeTestContext.contextId, true, options.variant).transpiled
+      transpiled = transpile(parsed, nativeTestContext, true, options.variant).transpiled
       // replace native[<number>] as they may be inconsistent
       const replacedNative = transpiled.replace(/native\[\d+]/g, 'native')
       // replace the line hiding globals as they may differ between environments

--- a/src/vm/svml-machine.ts
+++ b/src/vm/svml-machine.ts
@@ -10,7 +10,7 @@ import {
   INTERNAL_FUNCTIONS
 } from '../stdlib/vm.prelude'
 import { Context } from '../types'
-import { GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE, GLOBAL, JSSLANG_PROPERTIES } from '../constants'
+import { JSSLANG_PROPERTIES } from '../constants'
 import { stringify } from '../utils/stringify'
 import { PotentialInfiniteLoopError } from '../errors/timeoutErrors'
 import { locationDummyNode } from '../utils/astCreator'
@@ -1716,7 +1716,7 @@ export function runWithProgram(p: Program, context: Context): any {
   // setup externalBuiltins
   // certain functions are imported from cadet-frontend
   // so import them first every time
-  const externals = GLOBAL[GLOBAL_KEY_TO_ACCESS_NATIVE_STORAGE][context.contextId].globals.variables
+  const externals = context.nativeStorage.globals!.variables
   if (externals.size > 0) {
     EXTERNAL_PRIMITIVES.forEach(func => extractExternalBuiltin(func, externals))
   }


### PR DESCRIPTION
Native contexts were previously stored in a global array $$NATIIVE_STORAGE. Whenever a new context was created, a new entry is added to this array. This means that ALL contexts are stored there forever and never get garbage collected (we can't keep a rolling window of previous 10 elements or so, since there's no guarantee that older contexts are not still in use).

In the beginning, this was done for practical reasons. If we tried to `eval` code directly, it would have access to any variable that normal code would have access to.

```js
const outside = 123;
const transpiled = "outside";
eval(transpiled); // 123
```

This is obviously unwanted, since it's possible that variables might accidentally get accessed from Source code. evaluating transpiled code in the global scope solved this issue, since it can only access global variables, and global variables can easily be hidden with sandboxing: https://github.com/source-academy/js-slang/wiki/Transpiler#sandboxing

However, this means that in order to access the native context (previously declared variables etc) it would have to be stored somewhere in the global scope, hence leading to the $$NATIVE_STORAGE global solution.


Now, the problem of unintended outside variable access is solved by a context analyser that prevents the use of any undefined variables. So there is no need for the sandboxing anymore, and eval can be called directly, and we can access each context directly within the eval!


Together with this change is the refactoring of maxExecTime to also not be a global variable (which can cause clashes when two contexts are used to run code concurrently).

Small note here is that the eval is created using `new Function`, since it relies on the parameter name being exactly `nativeStorage` and code minification might minify a normal function's parameters. 


The diff here is massive since there is a slight change to the transpiled output (no more wrapping to prevent globals access), so ensure that no other part of the snapshot is changed other than the transpiled output.