### PR TITLE
Allow runInContext option to not re-declare variables

### DIFF
--- a/src/__tests__/__snapshots__/block-scoping.ts.snap
+++ b/src/__tests__/__snapshots__/block-scoping.ts.snap
@@ -255,27 +255,25 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      const x = true;
-      if (boolOrErr(true, 3, 2)) {
-        const x = false;
-      } else {
-        const x = false;
-      }
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function test() {\\\\n  const x = true;\\\\n  if (true) {\\\\n    const x = false;\\\\n  } else {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    const x = true;
+    if (boolOrErr(true, 3, 2)) {
+      const x = false;
+    } else {
+      const x = false;
+    }
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function test() {\\\\n  const x = true;\\\\n  if (true) {\\\\n    const x = false;\\\\n  } else {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -312,34 +310,32 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      let z = [];
-      const startTime = get_time();
-      for (let x = 0; boolOrErr(binaryOp(\\"<\\", 4, x, 10, 3, 18), 3, 2); x = binaryOp(\\"+\\", 4, x, 1, 3, 30)) {
-        throwIfTimeout(native, startTime, get_time(), 3, 2);
-        setProp(z, x, wrap(() => ({
-          isTail: false,
-          value: x
-        }), \\"() => x\\", native), 4, 4);
-      }
-      return {
-        isTail: true,
-        function: getProp(z, 1, 6, 9),
-        functionName: \\"<anonymous>\\",
-        arguments: [],
-        line: 6,
-        column: 9
-      };
-    }, \\"function test() {\\\\n  let z = [];\\\\n  for (let x = 0; x < 10; x = x + 1) {\\\\n    z[x] = () => x;\\\\n  }\\\\n  return z[1]();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    let z = [];
+    const startTime = get_time();
+    for (let x = 0; boolOrErr(binaryOp(\\"<\\", 4, x, 10, 3, 18), 3, 2); x = binaryOp(\\"+\\", 4, x, 1, 3, 30)) {
+      throwIfTimeout(native, startTime, get_time(), 3, 2);
+      setProp(z, x, wrap(() => ({
+        isTail: false,
+        value: x
+      }), \\"() => x\\", native), 4, 4);
+    }
+    return {
+      isTail: true,
+      function: getProp(z, 1, 6, 9),
+      functionName: \\"<anonymous>\\",
+      arguments: [],
+      line: 6,
+      column: 9
+    };
+  }, \\"function test() {\\\\n  let z = [];\\\\n  for (let x = 0; x < 10; x = x + 1) {\\\\n    z[x] = () => x;\\\\n  }\\\\n  return z[1]();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -375,26 +371,24 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      let x = true;
-      const startTime = get_time();
-      for (let x = 1; boolOrErr(binaryOp(\\">\\", 3, x, 0, 3, 18), 3, 2); x = binaryOp(\\"-\\", 3, x, 1, 3, 29)) {
-        throwIfTimeout(native, startTime, get_time(), 3, 2);
-      }
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function test() {\\\\n  let x = true;\\\\n  for (let x = 1; x > 0; x = x - 1) {}\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 7, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    let x = true;
+    const startTime = get_time();
+    for (let x = 1; boolOrErr(binaryOp(\\">\\", 3, x, 0, 3, 18), 3, 2); x = binaryOp(\\"-\\", 3, x, 1, 3, 29)) {
+      throwIfTimeout(native, startTime, get_time(), 3, 2);
+    }
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function test() {\\\\n  let x = true;\\\\n  for (let x = 1; x > 0; x = x - 1) {}\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 7, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -433,27 +427,25 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      let x = true;
-      if (boolOrErr(true, 3, 2)) {
-        let x = false;
-      } else {
-        let x = false;
-      }
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function test() {\\\\n  let x = true;\\\\n  if (true) {\\\\n    let x = false;\\\\n  } else {\\\\n    let x = false;\\\\n  }\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    let x = true;
+    if (boolOrErr(true, 3, 2)) {
+      let x = false;
+    } else {
+      let x = false;
+    }
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function test() {\\\\n  let x = true;\\\\n  if (true) {\\\\n    let x = false;\\\\n  } else {\\\\n    let x = false;\\\\n  }\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 10, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -490,25 +482,23 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      const x = true;
-      {
-        const x = false;
-      }
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function test() {\\\\n  const x = true;\\\\n  {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    const x = true;
+    {
+      const x = false;
+    }
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function test() {\\\\n  const x = true;\\\\n  {\\\\n    const x = false;\\\\n  }\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 8, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -546,28 +536,26 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      let x = true;
-      const startTime = get_time();
-      while (boolOrErr(true, 3, 2)) {
-        throwIfTimeout(native, startTime, get_time(), 3, 2);
-        let x = false;
-        break;
-      }
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function test() {\\\\n  let x = true;\\\\n  while (true) {\\\\n    let x = false;\\\\n    break;\\\\n  }\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 9, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    let x = true;
+    const startTime = get_time();
+    while (boolOrErr(true, 3, 2)) {
+      throwIfTimeout(native, startTime, get_time(), 3, 2);
+      let x = false;
+      break;
+    }
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function test() {\\\\n  let x = true;\\\\n  while (true) {\\\\n    let x = false;\\\\n    break;\\\\n  }\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 9, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/display.ts.snap
+++ b/src/__tests__/__snapshots__/display.ts.snap
@@ -24,9 +24,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -65,9 +63,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, [1, 2, [4, 5]]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, [1, 2, [4, 5]]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -117,11 +113,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    callIfFuncAndRightArgs(display, 1, 0, 1e38);
-    callIfFuncAndRightArgs(display, 1, 15, NaN);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 29, Infinity);\\");
-  }
+  callIfFuncAndRightArgs(display, 1, 0, 1e38);
+  callIfFuncAndRightArgs(display, 1, 15, NaN);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 29, Infinity);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -159,9 +153,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -193,9 +185,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -248,9 +238,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(raw_display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(raw_display, 1, 0, \\\\\\"Tom's assisstant said: \\\\\\\\\\\\\\"tuna.\\\\\\\\\\\\\\"\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/index.ts.snap
+++ b/src/__tests__/__snapshots__/index.ts.snap
@@ -23,16 +23,14 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = [];
-    lastStatementResult = eval(\\"getProp(a, 1, 2, 0);\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-  }
+  const a = [];
+  lastStatementResult = eval(\\"getProp(a, 1, 2, 0);\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -63,16 +61,14 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const o = {};
-    lastStatementResult = eval(\\"getProp(o, \\\\\\"nonexistent\\\\\\", 2, 0);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return o;
-      }
-    });
-  }
+  const o = {};
+  lastStatementResult = eval(\\"getProp(o, \\\\\\"nonexistent\\\\\\", 2, 0);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return o;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -117,9 +113,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, [1, 2]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, [1, 2]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -179,9 +173,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -213,9 +205,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, pair);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, pair);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -250,23 +240,21 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      let variable = false;
-      variable = true;
-      return {
-        isTail: false,
-        value: variable
-      };
-    }, \\"function test() {\\\\n  let variable = false;\\\\n  variable = true;\\\\n  return variable;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    let variable = false;
+    variable = true;
+    return {
+      isTail: false,
+      value: variable
+    };
+  }, \\"function test() {\\\\n  let variable = false;\\\\n  variable = true;\\\\n  return variable;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -317,23 +305,21 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap(() => {
-      const constant = 3;
-      constant = 4;
-      return {
-        isTail: false,
-        value: constant
-      };
-    }, \\"function test() {\\\\n  const constant = 3;\\\\n  constant = 4;\\\\n  return constant;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap(() => {
+    const constant = 3;
+    constant = 4;
+    return {
+      isTail: false,
+      value: constant
+    };
+  }, \\"function test() {\\\\n  const constant = 3;\\\\n  constant = 4;\\\\n  return constant;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 6, 0);\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -367,19 +353,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const o = {};
-    setProp(o, \\"a\\", {}, 2, 0);
-    setProp(getProp(o, \\"a\\", 3, 0), \\"b\\", {}, 3, 0);
-    setProp(getProp(getProp(o, \\"a\\", 4, 0), \\"b\\", 4, 0), \\"c\\", \\"string\\", 4, 0);
-    lastStatementResult = eval(\\"getProp(getProp(getProp(o, \\\\\\"a\\\\\\", 5, 0), \\\\\\"b\\\\\\", 5, 0), \\\\\\"c\\\\\\", 5, 0);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return o;
-      }
-    });
-  }
+  const o = {};
+  setProp(o, \\"a\\", {}, 2, 0);
+  setProp(getProp(o, \\"a\\", 3, 0), \\"b\\", {}, 3, 0);
+  setProp(getProp(getProp(o, \\"a\\", 4, 0), \\"b\\", 4, 0), \\"c\\", \\"string\\", 4, 0);
+  lastStatementResult = eval(\\"getProp(getProp(getProp(o, \\\\\\"a\\\\\\", 5, 0), \\\\\\"b\\\\\\", 5, 0), \\\\\\"c\\\\\\", 5, 0);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return o;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -423,22 +407,20 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const fac = wrap(i => boolOrErr(binaryOp(\\"===\\", 1, i, 1, 1, 19), 1, 19) ? {
-      isTail: false,
-      value: 1
-    } : {
-      isTail: false,
-      value: binaryOp(\\"*\\", 1, i, callIfFuncAndRightArgs(fac, 1, 37, binaryOp(\\"-\\", 1, i, 1, 1, 41)), 1, 33)
-    }, \\"i => i === 1 ? 1 : i * fac(i - 1)\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(fac, 2, 0, 5);\\");
-    globals.variables.set(\\"fac\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return fac;
-      }
-    });
-  }
+  const fac = wrap(i => boolOrErr(binaryOp(\\"===\\", 1, i, 1, 1, 19), 1, 19) ? {
+    isTail: false,
+    value: 1
+  } : {
+    isTail: false,
+    value: binaryOp(\\"*\\", 1, i, callIfFuncAndRightArgs(fac, 1, 37, binaryOp(\\"-\\", 1, i, 1, 1, 41)), 1, 33)
+  }, \\"i => i === 1 ? 1 : i * fac(i - 1)\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(fac, 2, 0, 5);\\");
+  globals.variables.set(\\"fac\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return fac;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -809,21 +791,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const t = wrap((x, y, z) => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"+\\", 3, binaryOp(\\"+\\", 3, x, y, 2, 9), z, 2, 9)
-      };
-    }, \\"function t(x, y, z) {\\\\n  return x + y + z;\\\\n}\\", native);
-    lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(identity, 4, 0, t), t, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(t, 4, 21, 1, 2, 3), 6, 4, 21);\\");
-    globals.variables.set(\\"t\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return t;
-      }
-    });
-  }
+  const t = wrap((x, y, z) => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"+\\", 3, binaryOp(\\"+\\", 3, x, y, 2, 9), z, 2, 9)
+    };
+  }, \\"function t(x, y, z) {\\\\n  return x + y + z;\\\\n}\\", native);
+  lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(identity, 4, 0, t), t, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(t, 4, 21, 1, 2, 3), 6, 4, 21);\\");
+  globals.variables.set(\\"t\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return t;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -853,9 +833,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, {   a: 1 });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(toString, 1, 0, {   a: 1 });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -921,17 +899,15 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const o = {};
-    setProp(o, \\"a\\", 1, 2, 0);
-    lastStatementResult = eval(\\"getProp(o, \\\\\\"a\\\\\\", 3, 0);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return o;
-      }
-    });
-  }
+  const o = {};
+  setProp(o, \\"a\\", 1, 2, 0);
+  lastStatementResult = eval(\\"getProp(o, \\\\\\"a\\\\\\", 3, 0);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return o;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1000,9 +976,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(apply_in_underlying_javascript, 1, 0, wrap((a, b, c) => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 4, binaryOp(\\\\\\"*\\\\\\", 4, a, b, 1, 44), c, 1, 44) }), \\\\\\"(a, b, c) => a * b * c\\\\\\", native), callIfFuncAndRightArgs(list, 1, 55, 2, 5, 6));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(apply_in_underlying_javascript, 1, 0, wrap((a, b, c) => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 4, binaryOp(\\\\\\"*\\\\\\", 4, a, b, 1, 44), c, 1, 44) }), \\\\\\"(a, b, c) => a * b * c\\\\\\", native), callIfFuncAndRightArgs(list, 1, 55, 2, 5, 6));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1037,32 +1011,30 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let i = 0;
-    const f = wrap(() => {
-      i = binaryOp(\\"+\\", 4, i, 1, 3, 6);
-      return {
-        isTail: false,
-        value: i
-      };
-    }, \\"function f() {\\\\n  i = i + 1;\\\\n  return i;\\\\n}\\", native);
-    lastStatementResult = eval(\\"i;\\");
-    globals.variables.set(\\"i\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return i;
-      },
-      assignNewValue: function (unique) {
-        return i = unique;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  let i = 0;
+  const f = wrap(() => {
+    i = binaryOp(\\"+\\", 4, i, 1, 3, 6);
+    return {
+      isTail: false,
+      value: i
+    };
+  }, \\"function f() {\\\\n  i = i + 1;\\\\n  return i;\\\\n}\\", native);
+  lastStatementResult = eval(\\"i;\\");
+  globals.variables.set(\\"i\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return i;
+    },
+    assignNewValue: function (unique) {
+      return i = unique;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1092,16 +1064,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    {
-      let i = globals.previousScope.variables.get(\\"i\\").getValue();
-      const f = globals.previousScope.variables.get(\\"f\\").getValue();
-      {
-        i = globals.previousScope.variables.get(\\"i\\").assignNewValue(100);
-        lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 1, 9);\\");
-      }
-    }
-  }
+  let i = globals.previousScope.variables.get(\\"i\\").getValue();
+  i = globals.previousScope.variables.get(\\"i\\").assignNewValue(100);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 1, 9);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1131,20 +1096,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    {
-      let i = globals.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
-      const f = globals.previousScope.previousScope.previousScope.variables.get(\\"f\\").getValue();
-      {
-        {
-          {
-            callIfFuncAndRightArgs(f, 1, 0);
-            lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
-          }
-        }
-      }
-    }
-  }
+  let i = globals.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
+  callIfFuncAndRightArgs(f, 1, 0);
+  lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1174,23 +1128,8 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    {
-      let i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
-      const f = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"f\\").getValue();
-      {
-        {
-          {
-            {
-              {
-                lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  let i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\"i\\").getValue();
+  lastStatementResult = eval(\\"i = globals.previousScope.previousScope.previousScope.previousScope.previousScope.variables.get(\\\\\\"i\\\\\\").getValue();\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1220,9 +1159,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 1, callIfFuncAndRightArgs(list, 1, 7, 1, 2), callIfFuncAndRightArgs(pair, 1, 19, 1, 2)), 1, 0), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 35, callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3), callIfFuncAndRightArgs(list, 1, 56, 1, callIfFuncAndRightArgs(list, 1, 64, 2, 3))), 1, 34);\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 1, callIfFuncAndRightArgs(list, 1, 7, 1, 2), callIfFuncAndRightArgs(pair, 1, 19, 1, 2)), 1, 0), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 35, callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3), callIfFuncAndRightArgs(list, 1, 56, 1, callIfFuncAndRightArgs(list, 1, 64, 2, 3))), 1, 34);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1252,9 +1189,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(list, 1, 6, 1, 2), callIfFuncAndRightArgs(pair, 1, 18, 1, callIfFuncAndRightArgs(pair, 1, 26, 2, null))), 1, 0) && callIfFuncAndRightArgs(equal, 1, 45, callIfFuncAndRightArgs(list, 1, 51, 1, 2, 3, 4), callIfFuncAndRightArgs(list, 1, 69, 1, 2, 3, 4));\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(list, 1, 6, 1, 2), callIfFuncAndRightArgs(pair, 1, 18, 1, callIfFuncAndRightArgs(pair, 1, 26, 2, null))), 1, 0) && callIfFuncAndRightArgs(equal, 1, 45, callIfFuncAndRightArgs(list, 1, 51, 1, 2, 3, 4), callIfFuncAndRightArgs(list, 1, 69, 1, 2, 3, 4));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1284,9 +1219,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, 1, 1), 1, 0) && callIfFuncAndRightArgs(equal, 1, 15, \\\\\\"str\\\\\\", \\\\\\"str\\\\\\"), 1, 0) && callIfFuncAndRightArgs(equal, 1, 38, null, null), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 60, 1, 2), 1, 59), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 76, \\\\\\"str\\\\\\", \\\\\\"\\\\\\"), 1, 75);\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(callIfFuncAndRightArgs(equal, 1, 0, 1, 1), 1, 0) && callIfFuncAndRightArgs(equal, 1, 15, \\\\\\"str\\\\\\", \\\\\\"str\\\\\\"), 1, 0) && callIfFuncAndRightArgs(equal, 1, 38, null, null), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 60, 1, 2), 1, 59), 1, 0) && unaryOp(\\\\\\"!\\\\\\", callIfFuncAndRightArgs(equal, 1, 76, \\\\\\"str\\\\\\", \\\\\\"\\\\\\"), 1, 75);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1318,9 +1251,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {}\\");
-  }
+  lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {}\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1353,9 +1284,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {   2; }\\");
-  }
+  lastStatementResult = eval(\\"if (boolOrErr(false, 1, 0)) {} else {   2; }\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1390,21 +1319,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(x => {
-      return {
-        isTail: false,
-        value: 5
-      };
-    }, \\"function f(x) {\\\\n  return 5;\\\\n}\\", native);
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 1, callIfFuncAndRightArgs(toString, 4, 0, wrap(a => ({   isTail: false,   value: a }), \\\\\\"a => a\\\\\\", native)), callIfFuncAndRightArgs(toString, 4, 17, f), 4, 0);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(x => {
+    return {
+      isTail: false,
+      value: 5
+    };
+  }, \\"function f(x) {\\\\n  return 5;\\\\n}\\", native);
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 1, callIfFuncAndRightArgs(toString, 4, 0, wrap(a => ({   isTail: false,   value: a }), \\\\\\"a => a\\\\\\", native)), callIfFuncAndRightArgs(toString, 4, 17, f), 4, 0);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1468,9 +1395,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(toString, 1, 0, true), callIfFuncAndRightArgs(toString, 2, 0, false), 1, 0), callIfFuncAndRightArgs(toString, 3, 0, 1), 1, 0), callIfFuncAndRightArgs(toString, 4, 0, 1.5), 1, 0), callIfFuncAndRightArgs(toString, 5, 0, null), 1, 0), callIfFuncAndRightArgs(toString, 6, 0, undefined), 1, 0), callIfFuncAndRightArgs(toString, 7, 0, NaN), 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(toString, 1, 0, true), callIfFuncAndRightArgs(toString, 2, 0, false), 1, 0), callIfFuncAndRightArgs(toString, 3, 0, 1), 1, 0), callIfFuncAndRightArgs(toString, 4, 0, 1.5), 1, 0), callIfFuncAndRightArgs(toString, 5, 0, null), 1, 0), callIfFuncAndRightArgs(toString, 6, 0, undefined), 1, 0), callIfFuncAndRightArgs(toString, 7, 0, NaN), 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1500,9 +1425,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && callIfFuncAndRightArgs(1, 1, 9);\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && callIfFuncAndRightArgs(1, 1, 9);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1532,9 +1455,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || callIfFuncAndRightArgs(1, 1, 8);\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || callIfFuncAndRightArgs(1, 1, 8);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1564,9 +1485,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1596,9 +1515,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && true;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(false, 1, 0) && true;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1628,9 +1545,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1660,9 +1575,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || true;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(false, 1, 0) || true;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1692,9 +1605,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(false, 1, 0) ? true : false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(false, 1, 0) ? true : false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1724,9 +1635,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1756,9 +1665,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && true;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) && true;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1788,9 +1695,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1820,9 +1725,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || true;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) || true;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1852,9 +1755,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? true : false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? true : false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1886,9 +1787,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {} else {}\\");
-  }
+  lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {} else {}\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1921,9 +1820,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {   1; } else {}\\");
-  }
+  lastStatementResult = eval(\\"if (boolOrErr(true, 1, 0)) {   1; } else {}\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/lazy.ts.snap
+++ b/src/__tests__/__snapshots__/lazy.ts.snap
@@ -22,21 +22,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const add = wrap((x, y) => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"+\\", 1, x, y, 1, 28)
-      };
-    }, \\"function add(x, y) {\\\\n  return x + y;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(add, 1, 37, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", native), 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", 1, x, 1, 1, 64)     }), \\\\\\"x => x + 1\\\\\\", native), 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     });   } });\\");
-    globals.variables.set(\\"add\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return add;
-      }
-    });
-  }
+  const add = wrap((x, y) => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"+\\", 1, x, y, 1, 28)
+    };
+  }, \\"function add(x, y) {\\\\n  return x + y;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(add, 1, 37, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", native), 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", 1, x, 1, 1, 64)     }), \\\\\\"x => x + 1\\\\\\", native), 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     });   } });\\");
+  globals.variables.set(\\"add\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return add;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -72,42 +70,40 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((a, b) => {
-      return boolOrErr(boolOrErr(a, 3, 10) ? true : callIfFuncAndRightArgs(head, 3, 21, {
+  const f = wrap((a, b) => {
+    return boolOrErr(boolOrErr(a, 3, 10) ? true : callIfFuncAndRightArgs(head, 3, 21, {
+      isThunk: true,
+      memoizedValue: 0,
+      isMemoized: false,
+      expr: () => {
+        return null;
+      }
+    }), 3, 9) && (boolOrErr(unaryOp(\\"!\\", b, 3, 37), 3, 37) ? {
+      isTail: false,
+      value: true
+    } : {
+      isTail: true,
+      function: head,
+      functionName: \\"head\\",
+      arguments: [{
         isThunk: true,
         memoizedValue: 0,
         isMemoized: false,
         expr: () => {
           return null;
         }
-      }), 3, 9) && (boolOrErr(unaryOp(\\"!\\", b, 3, 37), 3, 37) ? {
-        isTail: false,
-        value: true
-      } : {
-        isTail: true,
-        function: head,
-        functionName: \\"head\\",
-        arguments: [{
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return null;
-          }
-        }],
-        line: 3,
-        column: 49
-      });
-    }, \\"function f(a, b) {\\\\n  return (a ? true : head(null)) && (!b ? true : head(null));\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: b     }), \\\\\\"b => b\\\\\\", native), 6, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: unaryOp(\\\\\\"!\\\\\\", b, 6, 28)     }), \\\\\\"b => !b\\\\\\", native), 6, 20, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } });\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
+      }],
+      line: 3,
+      column: 49
     });
-  }
+  }, \\"function f(a, b) {\\\\n  return (a ? true : head(null)) && (!b ? true : head(null));\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: b     }), \\\\\\"b => b\\\\\\", native), 6, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(b => ({       isTail: false,       value: unaryOp(\\\\\\"!\\\\\\", b, 6, 28)     }), \\\\\\"b => !b\\\\\\", native), 6, 20, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return true;       }     });   } });\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -143,61 +139,59 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap((a, b) => {
-      return boolOrErr(binaryOp(\\"===\\", 2, a, 1, 2, 29), 2, 29) ? {
-        isTail: false,
-        value: a
-      } : {
-        isTail: false,
-        value: b
-      };
-    }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\", native);
-    const test2 = wrap(a => {
-      return {
-        isTail: true,
-        function: test,
-        functionName: \\"test\\",
-        arguments: [{
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return callIfFuncAndRightArgs(head, 4, 35, {
-              isThunk: true,
-              memoizedValue: 0,
-              isMemoized: false,
-              expr: () => {
-                return null;
-              }
-            });
-          }
-        }],
-        line: 4,
-        column: 27
-      };
-    }, \\"function test2(a) {\\\\n  return test(a, head(null));\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test2, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-    globals.variables.set(\\"test2\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test2;
-      }
-    });
-  }
+  const test = wrap((a, b) => {
+    return boolOrErr(binaryOp(\\"===\\", 2, a, 1, 2, 29), 2, 29) ? {
+      isTail: false,
+      value: a
+    } : {
+      isTail: false,
+      value: b
+    };
+  }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\", native);
+  const test2 = wrap(a => {
+    return {
+      isTail: true,
+      function: test,
+      functionName: \\"test\\",
+      arguments: [{
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return a;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return callIfFuncAndRightArgs(head, 4, 35, {
+            isThunk: true,
+            memoizedValue: 0,
+            isMemoized: false,
+            expr: () => {
+              return null;
+            }
+          });
+        }
+      }],
+      line: 4,
+      column: 27
+    };
+  }, \\"function test2(a) {\\\\n  return test(a, head(null));\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test2, 6, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
+  globals.variables.set(\\"test2\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test2;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -239,44 +233,42 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let x = 1;
-    const incX = wrap(() => {
-      x = binaryOp(\\"+\\", 3, x, 1, 5, 6);
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function incX() {\\\\n  x = x + 1;\\\\n  return x;\\\\n}\\", native);
-    const square = wrap(n => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"*\\", 3, n, n, 10, 9)
-      };
-    }, \\"function square(n) {\\\\n  return n * n;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(square, 13, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(incX, 13, 7);   } });\\");
-    globals.variables.set(\\"x\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return x;
-      },
-      assignNewValue: function (unique) {
-        return x = unique;
-      }
-    });
-    globals.variables.set(\\"incX\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return incX;
-      }
-    });
-    globals.variables.set(\\"square\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return square;
-      }
-    });
-  }
+  let x = 1;
+  const incX = wrap(() => {
+    x = binaryOp(\\"+\\", 3, x, 1, 5, 6);
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function incX() {\\\\n  x = x + 1;\\\\n  return x;\\\\n}\\", native);
+  const square = wrap(n => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"*\\", 3, n, n, 10, 9)
+    };
+  }, \\"function square(n) {\\\\n  return n * n;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(square, 13, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(incX, 13, 7);   } });\\");
+  globals.variables.set(\\"x\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return x;
+    },
+    assignNewValue: function (unique) {
+      return x = unique;
+    }
+  });
+  globals.variables.set(\\"incX\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return incX;
+    }
+  });
+  globals.variables.set(\\"square\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return square;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -315,39 +307,37 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const addSome = wrap(x => {
-      const y = binaryOp(\\"+\\", 1, x, 1, 3, 12);
-      return {
+  const addSome = wrap(x => {
+    const y = binaryOp(\\"+\\", 1, x, 1, 3, 12);
+    return {
+      isTail: false,
+      value: wrap(z => ({
         isTail: false,
-        value: wrap(z => ({
-          isTail: false,
-          value: binaryOp(\\"+\\", 1, y, z, 4, 14)
-        }), \\"z => y + z\\", native)
-      };
-    }, \\"function addSome(x) {\\\\n  const y = x + 1;\\\\n  return z => y + z;\\\\n}\\", native);
-    const addSome2 = callIfFuncAndRightArgs(addSome, 7, 17, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 2;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(addSome2, 9, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
-    globals.variables.set(\\"addSome\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return addSome;
-      }
-    });
-    globals.variables.set(\\"addSome2\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return addSome2;
-      }
-    });
-  }
+        value: binaryOp(\\"+\\", 1, y, z, 4, 14)
+      }), \\"z => y + z\\", native)
+    };
+  }, \\"function addSome(x) {\\\\n  const y = x + 1;\\\\n  return z => y + z;\\\\n}\\", native);
+  const addSome2 = callIfFuncAndRightArgs(addSome, 7, 17, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 2;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(addSome2, 9, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
+  globals.variables.set(\\"addSome\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return addSome;
+    }
+  });
+  globals.variables.set(\\"addSome2\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return addSome2;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -377,21 +367,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const neg = wrap(b => {
-      return {
-        isTail: false,
-        value: unaryOp(\\"!\\", b, 1, 25)
-      };
-    }, \\"function neg(b) {\\\\n  return !b;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(neg, 1, 31, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", native), 1, 35, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return false;       }     });   } });\\");
-    globals.variables.set(\\"neg\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return neg;
-      }
-    });
-  }
+  const neg = wrap(b => {
+    return {
+      isTail: false,
+      value: unaryOp(\\"!\\", b, 1, 25)
+    };
+  }, \\"function neg(b) {\\\\n  return !b;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(neg, 1, 31, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", native), 1, 35, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return false;       }     });   } });\\");
+  globals.variables.set(\\"neg\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return neg;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -421,24 +409,22 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const test = wrap((a, b) => {
-      return boolOrErr(binaryOp(\\"===\\", 2, a, 1, 1, 29), 1, 29) ? {
-        isTail: false,
-        value: a
-      } : {
-        isTail: false,
-        value: b
-      };
-    }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 1, 48, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     });   } });\\");
-    globals.variables.set(\\"test\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return test;
-      }
-    });
-  }
+  const test = wrap((a, b) => {
+    return boolOrErr(binaryOp(\\"===\\", 2, a, 1, 1, 29), 1, 29) ? {
+      isTail: false,
+      value: a
+    } : {
+      isTail: false,
+      value: b
+    };
+  }, \\"function test(a, b) {\\\\n  return a === 1 ? a : b;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(test, 1, 48, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 1, 56, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return null;       }     });   } });\\");
+  globals.variables.set(\\"test\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return test;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/return-regressions.ts.snap
+++ b/src/__tests__/__snapshots__/return-regressions.ts.snap
@@ -36,44 +36,42 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const f = wrap(() => {
+    const startTime = get_time();
+    for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 6, 22), 6, 6); i = binaryOp(\\"+\\", 3, i, 1, 6, 35)) {
+      throwIfTimeout(native, startTime, get_time(), 6, 6);
       return {
         isTail: false,
-        value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+        value: binaryOp(\\"+\\", 3, i, 1, 7, 15)
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const f = wrap(() => {
-      const startTime = get_time();
-      for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 6, 22), 6, 6); i = binaryOp(\\"+\\", 3, i, 1, 6, 35)) {
-        throwIfTimeout(native, startTime, get_time(), 6, 6);
-        return {
-          isTail: false,
-          value: binaryOp(\\"+\\", 3, i, 1, 7, 15)
-        };
-        callIfFuncAndRightArgs(unreachable, 8, 8);
-      }
-      callIfFuncAndRightArgs(unreachable, 10, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 12, 6);
-    }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return i + 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 8, 8);
+    }
+    callIfFuncAndRightArgs(unreachable, 10, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 12, 6);
+  }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return i + 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -117,42 +115,40 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const f = wrap(() => {
+    if (boolOrErr(true, 6, 6)) {
       return {
         isTail: false,
-        value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+        value: 1
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const f = wrap(() => {
-      if (boolOrErr(true, 6, 6)) {
-        return {
-          isTail: false,
-          value: 1
-        };
-        callIfFuncAndRightArgs(unreachable, 8, 8);
-      } else {}
-      callIfFuncAndRightArgs(unreachable, 10, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 12, 6);
-    }, \\"function f() {\\\\n  if (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 8, 8);
+    } else {}
+    callIfFuncAndRightArgs(unreachable, 10, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 12, 6);
+  }, \\"function f() {\\\\n  if (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -196,44 +192,42 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const f = wrap(() => {
+    const startTime = get_time();
+    while (boolOrErr(true, 6, 6)) {
+      throwIfTimeout(native, startTime, get_time(), 6, 6);
       return {
         isTail: false,
-        value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+        value: 1
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const f = wrap(() => {
-      const startTime = get_time();
-      while (boolOrErr(true, 6, 6)) {
-        throwIfTimeout(native, startTime, get_time(), 6, 6);
-        return {
-          isTail: false,
-          value: 1
-        };
-        callIfFuncAndRightArgs(unreachable, 8, 8);
-      }
-      callIfFuncAndRightArgs(unreachable, 10, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 12, 6);
-    }, \\"function f() {\\\\n  while (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 8, 8);
+    }
+    callIfFuncAndRightArgs(unreachable, 10, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 12, 6);
+  }, \\"function f() {\\\\n  while (true) {\\\\n    return 1;\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -274,39 +268,37 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
-      };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const f = wrap(() => {
-      return {
-        isTail: false,
-        value: 1
-      };
-      callIfFuncAndRightArgs(unreachable, 7, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 9, 6);
-    }, \\"function f() {\\\\n  return 1;\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 11, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const f = wrap(() => {
+    return {
+      isTail: false,
+      value: 1
+    };
+    callIfFuncAndRightArgs(unreachable, 7, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 9, 6);
+  }, \\"function f() {\\\\n  return 1;\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 11, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -390,53 +382,51 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    const startTime = get_time();
+    for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", 3, i, 1, 9, 35)) {
+      throwIfTimeout(native, startTime, get_time(), 9, 6);
       return {
         isTail: false,
-        value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+        value: binaryOp(\\"+\\", 3, callIfFuncAndRightArgs(id, 10, 15, binaryOp(\\"+\\", 3, i, 1, 10, 18)), callIfFuncAndRightArgs(id, 10, 25, binaryOp(\\"+\\", 3, i, 2, 10, 28)), 10, 15)
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      const startTime = get_time();
-      for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", 3, i, 1, 9, 35)) {
-        throwIfTimeout(native, startTime, get_time(), 9, 6);
-        return {
-          isTail: false,
-          value: binaryOp(\\"+\\", 3, callIfFuncAndRightArgs(id, 10, 15, binaryOp(\\"+\\", 3, i, 1, 10, 18)), callIfFuncAndRightArgs(id, 10, 25, binaryOp(\\"+\\", 3, i, 2, 10, 28)), 10, 15)
-        };
-      }
-      return {
-        isTail: false,
-        value: 0
-      };
-    }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1) + id(i + 2);\\\\n  }\\\\n  return 0;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+    }
+    return {
+      isTail: false,
+      value: 0
+    };
+  }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1) + id(i + 2);\\\\n  }\\\\n  return 0;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -483,54 +473,52 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    if (boolOrErr(true, 9, 6)) {
       return {
         isTail: false,
-        value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+        value: binaryOp(\\"+\\", 1, callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      if (boolOrErr(true, 9, 6)) {
-        return {
-          isTail: false,
-          value: binaryOp(\\"+\\", 1, callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
-        };
-        callIfFuncAndRightArgs(unreachable, 11, 8);
-      } else {}
-      callIfFuncAndRightArgs(unreachable, 13, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 15, 6);
-    }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 11, 8);
+    } else {}
+    callIfFuncAndRightArgs(unreachable, 13, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 15, 6);
+  }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -577,56 +565,54 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    const startTime = get_time();
+    while (boolOrErr(true, 9, 6)) {
+      throwIfTimeout(native, startTime, get_time(), 9, 6);
       return {
         isTail: false,
-        value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+        value: binaryOp(\\"+\\", 3, callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      const startTime = get_time();
-      while (boolOrErr(true, 9, 6)) {
-        throwIfTimeout(native, startTime, get_time(), 9, 6);
-        return {
-          isTail: false,
-          value: binaryOp(\\"+\\", 3, callIfFuncAndRightArgs(id, 10, 15, 1), callIfFuncAndRightArgs(id, 10, 23, 2), 10, 15)
-        };
-        callIfFuncAndRightArgs(unreachable, 11, 8);
-      }
-      callIfFuncAndRightArgs(unreachable, 13, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 15, 6);
-    }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 11, 8);
+    }
+    callIfFuncAndRightArgs(unreachable, 13, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 15, 6);
+  }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1) + id(2);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -670,51 +656,49 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
-      };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"+\\", 1, callIfFuncAndRightArgs(id, 9, 13, 1), callIfFuncAndRightArgs(id, 9, 21, 2), 9, 13)
-      };
-      callIfFuncAndRightArgs(unreachable, 10, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 12, 6);
-    }, \\"function f() {\\\\n  return id(1) + id(2);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"+\\", 1, callIfFuncAndRightArgs(id, 9, 13, 1), callIfFuncAndRightArgs(id, 9, 21, 2), 9, 13)
+    };
+    callIfFuncAndRightArgs(unreachable, 10, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 12, 6);
+  }, \\"function f() {\\\\n  return id(1) + id(2);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -761,60 +745,58 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    const startTime = get_time();
+    for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", 3, i, 1, 9, 35)) {
+      throwIfTimeout(native, startTime, get_time(), 9, 6);
       return {
-        isTail: false,
-        value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+        isTail: true,
+        function: id,
+        functionName: \\"id\\",
+        arguments: [binaryOp(\\"+\\", 3, i, 1, 10, 18)],
+        line: 10,
+        column: 15
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      const startTime = get_time();
-      for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 9, 22), 9, 6); i = binaryOp(\\"+\\", 3, i, 1, 9, 35)) {
-        throwIfTimeout(native, startTime, get_time(), 9, 6);
-        return {
-          isTail: true,
-          function: id,
-          functionName: \\"id\\",
-          arguments: [binaryOp(\\"+\\", 3, i, 1, 10, 18)],
-          line: 10,
-          column: 15
-        };
-        callIfFuncAndRightArgs(unreachable, 11, 8);
-      }
-      callIfFuncAndRightArgs(unreachable, 13, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 15, 6);
-    }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 11, 8);
+    }
+    callIfFuncAndRightArgs(unreachable, 13, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 15, 6);
+  }, \\"function f() {\\\\n  for (let i = 0; i < 100; i = i + 1) {\\\\n    return id(i + 1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -861,58 +843,56 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    if (boolOrErr(true, 9, 6)) {
       return {
-        isTail: false,
-        value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+        isTail: true,
+        function: id,
+        functionName: \\"id\\",
+        arguments: [1],
+        line: 10,
+        column: 15
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      if (boolOrErr(true, 9, 6)) {
-        return {
-          isTail: true,
-          function: id,
-          functionName: \\"id\\",
-          arguments: [1],
-          line: 10,
-          column: 15
-        };
-        callIfFuncAndRightArgs(unreachable, 11, 8);
-      } else {}
-      callIfFuncAndRightArgs(unreachable, 13, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 15, 6);
-    }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 11, 8);
+    } else {}
+    callIfFuncAndRightArgs(unreachable, 13, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 15, 6);
+  }, \\"function f() {\\\\n  if (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  } else {}\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -959,60 +939,58 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    const startTime = get_time();
+    while (boolOrErr(true, 9, 6)) {
+      throwIfTimeout(native, startTime, get_time(), 9, 6);
       return {
-        isTail: false,
-        value: binaryOp(\\"<\\", 3, 1, true, 3, 13)
+        isTail: true,
+        function: id,
+        functionName: \\"id\\",
+        arguments: [1],
+        line: 10,
+        column: 15
       };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      const startTime = get_time();
-      while (boolOrErr(true, 9, 6)) {
-        throwIfTimeout(native, startTime, get_time(), 9, 6);
-        return {
-          isTail: true,
-          function: id,
-          functionName: \\"id\\",
-          arguments: [1],
-          line: 10,
-          column: 15
-        };
-        callIfFuncAndRightArgs(unreachable, 11, 8);
-      }
-      callIfFuncAndRightArgs(unreachable, 13, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 15, 6);
-    }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+      callIfFuncAndRightArgs(unreachable, 11, 8);
+    }
+    callIfFuncAndRightArgs(unreachable, 13, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 15, 6);
+  }, \\"function f() {\\\\n  while (true) {\\\\n    return id(1);\\\\n    unreachable();\\\\n  }\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 17, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1056,55 +1034,53 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const unreachable = wrap(() => {
-      return {
-        isTail: false,
-        value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
-      };
-    }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
-    const id = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
-    const f = wrap(() => {
-      return {
-        isTail: true,
-        function: id,
-        functionName: \\"id\\",
-        arguments: [1],
-        line: 9,
-        column: 13
-      };
-      callIfFuncAndRightArgs(unreachable, 10, 6);
-      return {
-        isTail: false,
-        value: 0
-      };
-      callIfFuncAndRightArgs(unreachable, 12, 6);
-    }, \\"function f() {\\\\n  return id(1);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
-    globals.variables.set(\\"unreachable\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return unreachable;
-      }
-    });
-    globals.variables.set(\\"id\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return id;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const unreachable = wrap(() => {
+    return {
+      isTail: false,
+      value: binaryOp(\\"<\\", 1, 1, true, 3, 13)
+    };
+  }, \\"function unreachable() {\\\\n  return 1 < true;\\\\n}\\", native);
+  const id = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function id(x) {\\\\n  return x;\\\\n}\\", native);
+  const f = wrap(() => {
+    return {
+      isTail: true,
+      function: id,
+      functionName: \\"id\\",
+      arguments: [1],
+      line: 9,
+      column: 13
+    };
+    callIfFuncAndRightArgs(unreachable, 10, 6);
+    return {
+      isTail: false,
+      value: 0
+    };
+    callIfFuncAndRightArgs(unreachable, 12, 6);
+  }, \\"function f() {\\\\n  return id(1);\\\\n  unreachable();\\\\n  return 0;\\\\n  unreachable();\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 14, 4);\\");
+  globals.variables.set(\\"unreachable\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return unreachable;
+    }
+  });
+  globals.variables.set(\\"id\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return id;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/stdlib.ts.snap
+++ b/src/__tests__/__snapshots__/stdlib.ts.snap
@@ -24,9 +24,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 'message');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 1, 0, 'message');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -85,9 +83,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, undefined);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, undefined);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -117,9 +113,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, null);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_undefined, 1, 0, null);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -149,9 +143,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, undefined);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, undefined);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -181,9 +173,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, null);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_null, 1, 0, null);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -213,9 +203,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'string');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'string');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -245,9 +233,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'true');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 'true');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -277,9 +263,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, '1');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, '1');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -309,9 +293,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, true);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, true);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -341,9 +323,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_string, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -373,9 +353,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'string');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'string');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -405,9 +383,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'true');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 'true');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -437,9 +413,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, '1');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, '1');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -469,9 +443,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, true);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, true);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -501,9 +473,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -533,9 +503,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'string');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'string');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -565,9 +533,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'true');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 'true');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -597,9 +563,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, '1');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, '1');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -629,9 +593,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, true);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, true);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -661,9 +623,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_boolean, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -693,9 +653,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, display);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, display);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -725,9 +683,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -760,21 +716,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function f(x) {\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 4, 0, f);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function f(x) {\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 4, 0, f);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -804,9 +758,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_function, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -836,9 +788,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -868,9 +818,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, callIfFuncAndRightArgs(pair, 1, 9, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, callIfFuncAndRightArgs(pair, 1, 9, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -900,9 +848,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, [1]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_array, 1, 0, [1]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1140,9 +1086,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(array_length, 1, 0, [1]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(array_length, 1, 0, [1]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1172,9 +1116,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 10);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 10);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1204,9 +1146,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 2);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '10', 2);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1236,9 +1176,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, callIfFuncAndRightArgs(get_time, 1, 10));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, callIfFuncAndRightArgs(get_time, 1, 10));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1276,39 +1214,37 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const start = callIfFuncAndRightArgs(get_time, 1, 14);
-    const repeatUntilDifferentTime = wrap(() => {
-      if (boolOrErr(binaryOp(\\"===\\", 1, start, callIfFuncAndRightArgs(get_time, 3, 16), 3, 6), 3, 2)) {
-        return {
-          isTail: true,
-          function: repeatUntilDifferentTime,
-          functionName: \\"repeatUntilDifferentTime\\",
-          arguments: [],
-          line: 4,
-          column: 11
-        };
-      } else {
-        return {
-          isTail: false,
-          value: true
-        };
-      }
-    }, \\"function repeatUntilDifferentTime() {\\\\n  if (start === get_time()) {\\\\n    return repeatUntilDifferentTime();\\\\n  } else {\\\\n    return true;\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(repeatUntilDifferentTime, 9, 0);\\");
-    globals.variables.set(\\"start\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return start;
-      }
-    });
-    globals.variables.set(\\"repeatUntilDifferentTime\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return repeatUntilDifferentTime;
-      }
-    });
-  }
+  const start = callIfFuncAndRightArgs(get_time, 1, 14);
+  const repeatUntilDifferentTime = wrap(() => {
+    if (boolOrErr(binaryOp(\\"===\\", 1, start, callIfFuncAndRightArgs(get_time, 3, 16), 3, 6), 3, 2)) {
+      return {
+        isTail: true,
+        function: repeatUntilDifferentTime,
+        functionName: \\"repeatUntilDifferentTime\\",
+        arguments: [],
+        line: 4,
+        column: 11
+      };
+    } else {
+      return {
+        isTail: false,
+        value: true
+      };
+    }
+  }, \\"function repeatUntilDifferentTime() {\\\\n  if (start === get_time()) {\\\\n    return repeatUntilDifferentTime();\\\\n  } else {\\\\n    return true;\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(repeatUntilDifferentTime, 9, 0);\\");
+  globals.variables.set(\\"start\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return start;
+    }
+  });
+  globals.variables.set(\\"repeatUntilDifferentTime\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return repeatUntilDifferentTime;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1341,9 +1277,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 2);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 2);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1379,9 +1313,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1, 2);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1, 2);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1411,9 +1343,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1443,9 +1373,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(pair, 1, 8, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(pair, 1, 8, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1475,9 +1403,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 1, 0, callIfFuncAndRightArgs(list, 1, 8, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1507,9 +1433,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1539,9 +1463,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1687,9 +1609,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, callIfFuncAndRightArgs(list, 1, 7, 1, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, callIfFuncAndRightArgs(list, 1, 7, 1, 2));\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/stringify.ts.snap
+++ b/src/__tests__/__snapshots__/stringify.ts.snap
@@ -23,19 +23,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const xs = [1, 'true', true, wrap(() => ({
-      isTail: false,
-      value: 1
-    }), \\"() => 1\\", native)];
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
-    globals.variables.set(\\"xs\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return xs;
-      }
-    });
-  }
+  const xs = [1, 'true', true, wrap(() => ({
+    isTail: false,
+    value: 1
+  }), \\"() => 1\\", native)];
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
+  globals.variables.set(\\"xs\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return xs;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -66,19 +64,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => ({
-      isTail: false,
-      value: x
-    }), \\"(x, y) => x\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, f);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => ({
+    isTail: false,
+    value: x
+  }), \\"(x, y) => x\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, f);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -120,35 +116,33 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const o = {
-      a: 1,
-      b: true,
-      c: wrap(() => ({
-        isTail: false,
-        value: 1
-      }), \\"() => 1\\", native),
-      d: {
-        e: 5,
-        f: 6
-      },
-      g: 0,
-      h: 0,
-      i: 0,
-      j: 0,
-      k: 0,
-      l: 0,
-      m: 0,
-      n: 0
-    };
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return o;
-      }
-    });
-  }
+  const o = {
+    a: 1,
+    b: true,
+    c: wrap(() => ({
+      isTail: false,
+      value: 1
+    }), \\"() => 1\\", native),
+    d: {
+      e: 5,
+      f: 6
+    },
+    g: 0,
+    h: 0,
+    i: 0,
+    j: 0,
+    k: 0,
+    l: 0,
+    m: 0,
+    n: 0
+  };
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return o;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -178,9 +172,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'true');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'true');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -212,9 +204,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, pair);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -245,16 +235,14 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const xs = [];
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
-    globals.variables.set(\\"xs\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return xs;
-      }
-    });
-  }
+  const xs = [];
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
+  globals.variables.set(\\"xs\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return xs;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -289,21 +277,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function f(x, y) {\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 4, 0, f);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function f(x, y) {\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 4, 0, f);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -436,27 +422,25 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const arr = [];
-    const startTime = get_time();
-    for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 2, 16), 2, 0); i = binaryOp(\\"+\\", 3, i, 1, 2, 29)) {
-      throwIfTimeout(native, startTime, get_time(), 2, 0);
-      setProp(arr, i, i, 3, 2);
-    }
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 5, 0, arr);\\");
-    globals.variables.set(\\"arr\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return arr;
-      }
-    });
-    globals.variables.set(\\"startTime\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return startTime;
-      }
-    });
+  const arr = [];
+  const startTime = get_time();
+  for (let i = 0; boolOrErr(binaryOp(\\"<\\", 3, i, 100, 2, 16), 2, 0); i = binaryOp(\\"+\\", 3, i, 1, 2, 29)) {
+    throwIfTimeout(native, startTime, get_time(), 2, 0);
+    setProp(arr, i, i, 3, 2);
   }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 5, 0, arr);\\");
+  globals.variables.set(\\"arr\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return arr;
+    }
+  });
+  globals.variables.set(\\"startTime\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return startTime;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -574,9 +558,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 100));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 100));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -606,9 +588,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 10));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 10, 1, 10));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -639,19 +619,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const xs = [1, 'true', [true, wrap(() => ({
-      isTail: false,
-      value: 1
-    }), \\"() => 1\\", native), [[]]]];
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
-    globals.variables.set(\\"xs\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return xs;
-      }
-    });
-  }
+  const xs = [1, 'true', [true, wrap(() => ({
+    isTail: false,
+    value: 1
+  }), \\"() => 1\\", native), [[]]]];
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, xs);\\");
+  globals.variables.set(\\"xs\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return xs;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -682,27 +660,25 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const o = {
-      a: 1,
-      b: true,
-      c: wrap(() => ({
-        isTail: false,
-        value: 1
-      }), \\"() => 1\\", native),
-      d: {
-        e: 5,
-        f: 6
-      }
-    };
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return o;
-      }
-    });
-  }
+  const o = {
+    a: 1,
+    b: true,
+    c: wrap(() => ({
+      isTail: false,
+      value: 1
+    }), \\"() => 1\\", native),
+    d: {
+      e: 5,
+      f: 6
+    }
+  };
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return o;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -734,20 +710,18 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let o = {};
-    setProp(o, \\"o\\", o, 2, 0);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 3, 0, o);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return o;
-      },
-      assignNewValue: function (unique) {
-        return o = unique;
-      }
-    });
-  }
+  let o = {};
+  setProp(o, \\"o\\", o, 2, 0);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 3, 0, o);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return o;
+    },
+    assignNewValue: function (unique) {
+      return o = unique;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -777,9 +751,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, null);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, null);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -809,9 +781,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -842,23 +812,21 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const o = {
-      a: 1,
-      b: true,
-      c: wrap(() => ({
-        isTail: false,
-        value: 1
-      }), \\"() => 1\\", native)
-    };
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
-    globals.variables.set(\\"o\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return o;
-      }
-    });
-  }
+  const o = {
+    a: 1,
+    b: true,
+    c: wrap(() => ({
+      isTail: false,
+      value: 1
+    }), \\"() => 1\\", native)
+  };
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+  globals.variables.set(\\"o\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return o;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -888,9 +856,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'a string');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, 'a string');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -920,9 +886,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, undefined);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, undefined);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -954,9 +918,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -988,9 +950,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), ' ... ');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), ' ... ');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1022,9 +982,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1056,9 +1014,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), '.................................');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), '.................................');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1090,9 +1046,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 100);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 100);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1122,9 +1076,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 1, 0, callIfFuncAndRightArgs(parse, 1, 10, 'x=>x;'), 0);\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/__tests__/__snapshots__/tailcall-return.ts.snap
+++ b/src/__tests__/__snapshots__/tailcall-return.ts.snap
@@ -29,32 +29,30 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
-        return {
-          isTail: false,
-          value: y
-        };
-      } else {
-        return {
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, 1, 5, 18)],
-          line: 5,
-          column: 11
-        };
-      }
-    }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
+      return {
+        isTail: false,
+        value: y
+      };
+    } else {
+      return {
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, 1, 5, 18)],
+        line: 5,
+        column: 11
+      };
+    }
+  }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -91,32 +89,30 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
-        return {
-          isTail: false,
-          value: y
-        };
-      } else {
-        return boolOrErr(false, 5, 11) || ({
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 22), binaryOp(\\"+\\", 1, y, 1, 5, 27)],
-          line: 5,
-          column: 20
-        });
-      }
-    }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return false || f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
+      return {
+        isTail: false,
+        value: y
+      };
+    } else {
+      return boolOrErr(false, 5, 11) || ({
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 22), binaryOp(\\"+\\", 1, y, 1, 5, 27)],
+        line: 5,
+        column: 20
+      });
+    }
+  }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return false || f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -149,28 +145,26 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      return boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 9), 2, 9) ? {
-        isTail: false,
-        value: y
-      } : {
-        isTail: true,
-        function: f,
-        functionName: \\"f\\",
-        arguments: [binaryOp(\\"-\\", 1, x, 1, 2, 24), binaryOp(\\"+\\", 1, y, 1, 2, 29)],
-        line: 2,
-        column: 22
-      };
-    }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : f(x - 1, y + 1);\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    return boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 9), 2, 9) ? {
+      isTail: false,
+      value: y
+    } : {
+      isTail: true,
+      function: f,
+      functionName: \\"f\\",
+      arguments: [binaryOp(\\"-\\", 1, x, 1, 2, 24), binaryOp(\\"+\\", 1, y, 1, 2, 29)],
+      line: 2,
+      column: 22
+    };
+  }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : f(x - 1, y + 1);\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -203,31 +197,29 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      return boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 9), 2, 9) ? {
-        isTail: false,
-        value: y
-      } : boolOrErr(boolOrErr(false, 2, 22) || binaryOp(\\">\\", 1, x, 0, 2, 31), 2, 22) ? {
-        isTail: true,
-        function: f,
-        functionName: \\"f\\",
-        arguments: [binaryOp(\\"-\\", 1, x, 1, 2, 41), binaryOp(\\"+\\", 1, y, 1, 2, 46)],
-        line: 2,
-        column: 39
-      } : {
-        isTail: false,
-        value: 'unreachable'
-      };
-    }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : false || x > 0 ? f(x - 1, y + 1) : 'unreachable';\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    return boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 9), 2, 9) ? {
+      isTail: false,
+      value: y
+    } : boolOrErr(boolOrErr(false, 2, 22) || binaryOp(\\">\\", 1, x, 0, 2, 31), 2, 22) ? {
+      isTail: true,
+      function: f,
+      functionName: \\"f\\",
+      arguments: [binaryOp(\\"-\\", 1, x, 1, 2, 41), binaryOp(\\"+\\", 1, y, 1, 2, 46)],
+      line: 2,
+      column: 39
+    } : {
+      isTail: false,
+      value: 'unreachable'
+    };
+  }, \\"function f(x, y) {\\\\n  return x <= 0 ? y : false || x > 0 ? f(x - 1, y + 1) : 'unreachable';\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -264,32 +256,30 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
-        return {
-          isTail: false,
-          value: y
-        };
-      } else {
-        return {
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, 1, 5, 18)],
-          line: 5,
-          column: 11
-        };
-      }
-    }, \\"(x, y) => {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
+      return {
+        isTail: false,
+        value: y
+      };
+    } else {
+      return {
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, 1, 5, 18)],
+        line: 5,
+        column: 11
+      };
+    }
+  }, \\"(x, y) => {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -320,26 +310,24 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 1, 20), 1, 20) ? {
-      isTail: false,
-      value: y
-    } : {
-      isTail: true,
-      function: f,
-      functionName: \\"f\\",
-      arguments: [binaryOp(\\"-\\", 1, x, 1, 1, 35), binaryOp(\\"+\\", 1, y, 1, 1, 40)],
-      line: 1,
-      column: 33
-    }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 1, 20), 1, 20) ? {
+    isTail: false,
+    value: y
+  } : {
+    isTail: true,
+    function: f,
+    functionName: \\"f\\",
+    arguments: [binaryOp(\\"-\\", 1, x, 1, 1, 35), binaryOp(\\"+\\", 1, y, 1, 1, 40)],
+    line: 1,
+    column: 33
+  }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -376,32 +364,30 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y, z) => {
-      if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
-        return {
-          isTail: false,
-          value: y
-        };
-      } else {
-        return {
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, callIfFuncAndRightArgs(f, 5, 20, 0, z, 0), 5, 18), z],
-          line: 5,
-          column: 11
-        };
-      }
-    }, \\"function f(x, y, z) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + f(0, z, 0), z);\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000, 2);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap((x, y, z) => {
+    if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
+      return {
+        isTail: false,
+        value: y
+      };
+    } else {
+      return {
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, callIfFuncAndRightArgs(f, 5, 20, 0, z, 0), 5, 18), z],
+        line: 5,
+        column: 11
+      };
+    }
+  }, \\"function f(x, y, z) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + f(0, z, 0), z);\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 8, 0, 5000, 5000, 2);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -433,43 +419,41 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 1, 20), 1, 20) ? {
-      isTail: false,
-      value: y
-    } : {
-      isTail: true,
-      function: g,
-      functionName: \\"g\\",
-      arguments: [binaryOp(\\"-\\", 1, x, 1, 1, 35), binaryOp(\\"+\\", 1, y, 1, 1, 40)],
-      line: 1,
-      column: 33
-    }, \\"(x, y) => x <= 0 ? y : g(x - 1, y + 1)\\", native);
-    const g = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 20), 2, 20) ? {
-      isTail: false,
-      value: y
-    } : {
-      isTail: true,
-      function: f,
-      functionName: \\"f\\",
-      arguments: [binaryOp(\\"-\\", 1, x, 1, 2, 35), binaryOp(\\"+\\", 1, y, 1, 2, 40)],
-      line: 2,
-      column: 33
-    }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-    globals.variables.set(\\"g\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return g;
-      }
-    });
-  }
+  const f = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 1, 20), 1, 20) ? {
+    isTail: false,
+    value: y
+  } : {
+    isTail: true,
+    function: g,
+    functionName: \\"g\\",
+    arguments: [binaryOp(\\"-\\", 1, x, 1, 1, 35), binaryOp(\\"+\\", 1, y, 1, 1, 40)],
+    line: 1,
+    column: 33
+  }, \\"(x, y) => x <= 0 ? y : g(x - 1, y + 1)\\", native);
+  const g = wrap((x, y) => boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 20), 2, 20) ? {
+    isTail: false,
+    value: y
+  } : {
+    isTail: true,
+    function: f,
+    functionName: \\"f\\",
+    arguments: [binaryOp(\\"-\\", 1, x, 1, 2, 35), binaryOp(\\"+\\", 1, y, 1, 2, 40)],
+    line: 2,
+    column: 33
+  }, \\"(x, y) => x <= 0 ? y : f(x - 1, y + 1)\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
+  globals.variables.set(\\"g\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return g;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -513,55 +497,53 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap((x, y) => {
-      if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
-        return {
-          isTail: false,
-          value: y
-        };
-      } else {
-        return {
-          isTail: true,
-          function: g,
-          functionName: \\"g\\",
-          arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, 1, 5, 18)],
-          line: 5,
-          column: 11
-        };
-      }
-    }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return g(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
-    const g = wrap((x, y) => {
-      if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 9, 6), 9, 2)) {
-        return {
-          isTail: false,
-          value: y
-        };
-      } else {
-        return {
-          isTail: true,
-          function: f,
-          functionName: \\"f\\",
-          arguments: [binaryOp(\\"-\\", 1, x, 1, 12, 13), binaryOp(\\"+\\", 1, y, 1, 12, 18)],
-          line: 12,
-          column: 11
-        };
-      }
-    }, \\"function g(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 15, 0, 5000, 5000);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-    globals.variables.set(\\"g\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return g;
-      }
-    });
-  }
+  const f = wrap((x, y) => {
+    if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 2, 6), 2, 2)) {
+      return {
+        isTail: false,
+        value: y
+      };
+    } else {
+      return {
+        isTail: true,
+        function: g,
+        functionName: \\"g\\",
+        arguments: [binaryOp(\\"-\\", 1, x, 1, 5, 13), binaryOp(\\"+\\", 1, y, 1, 5, 18)],
+        line: 5,
+        column: 11
+      };
+    }
+  }, \\"function f(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return g(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
+  const g = wrap((x, y) => {
+    if (boolOrErr(binaryOp(\\"<=\\", 1, x, 0, 9, 6), 9, 2)) {
+      return {
+        isTail: false,
+        value: y
+      };
+    } else {
+      return {
+        isTail: true,
+        function: f,
+        functionName: \\"f\\",
+        arguments: [binaryOp(\\"-\\", 1, x, 1, 12, 13), binaryOp(\\"+\\", 1, y, 1, 12, 18)],
+        line: 12,
+        column: 11
+      };
+    }
+  }, \\"function g(x, y) {\\\\n  if (x <= 0) {\\\\n    return y;\\\\n  } else {\\\\n    return f(x - 1, y + 1);\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 15, 0, 5000, 5000);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
+  globals.variables.set(\\"g\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return g;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,7 +378,8 @@ export function getTypeInformation(
 export async function runInContext(
   code: string,
   context: Context,
-  options: Partial<IOptions> = {}
+  options: Partial<IOptions> = {},
+  useSameEnv: boolean = false
 ): Promise<Result> {
   function getFirstLine(theCode: string) {
     const theProgramFirstExpression = parseAt(theCode, 0)
@@ -447,8 +448,8 @@ export async function runInContext(
   if (context.prelude !== null) {
     const prelude = context.prelude
     context.prelude = null
-    await runInContext(prelude, context, { ...options, isPrelude: true })
-    return runInContext(code, context, options)
+    await runInContext(prelude, context, { ...options, isPrelude: true }, useSameEnv)
+    return runInContext(code, context, options, useSameEnv)
   }
   if (isNativeRunnable) {
     if (previousCode === code && isPreviousCodeTimeoutError) {
@@ -463,7 +464,7 @@ export async function runInContext(
     let sourceMapJson: RawSourceMap | undefined
     let lastStatementSourceMapJson: RawSourceMap | undefined
     try {
-      const temp = transpile(program, context, false, context.variant)
+      const temp = transpile(program, context, false, context.variant, !useSameEnv)
       // some issues with formatting and semicolons and tslint so no destructure
       transpiled = temp.transpiled
       sourceMapJson = temp.codeMap

--- a/src/interpreter/__tests__/__snapshots__/interpreter-errors.ts.snap
+++ b/src/interpreter/__tests__/__snapshots__/interpreter-errors.ts.snap
@@ -22,9 +22,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"getProp({   a: 0 }, \\\\\\"a\\\\\\", 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"getProp({   a: 0 }, \\\\\\"a\\\\\\", 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -97,7 +95,8 @@ eval_stream(make_alternating_stream(enum_stream(1, 9)), 9);",
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 8: Error: head(xs) expects a pair as argument xs, but encountered null",
+  "parsedErrors": "native:\\"Line 12: Name eval_stream not declared.\\"
+interpreted:\\"Line 8: Error: head(xs) expects a pair as argument xs, but encountered null\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -113,65 +112,63 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const make_alternating_stream = wrap(stream => {
-      return {
+  const make_alternating_stream = wrap(stream => {
+    return {
+      isTail: true,
+      function: pair,
+      functionName: \\"pair\\",
+      arguments: [callIfFuncAndRightArgs(head, 2, 14, stream), wrap(() => ({
         isTail: true,
-        function: pair,
-        functionName: \\"pair\\",
-        arguments: [callIfFuncAndRightArgs(head, 2, 14, stream), wrap(() => ({
-          isTail: true,
-          function: make_alternating_stream,
-          functionName: \\"make_alternating_stream\\",
-          arguments: [callIfFuncAndRightArgs(negate_whole_stream, 3, 36, callIfFuncAndRightArgs(stream_tail, 4, 40, stream))],
-          line: 2,
-          column: 34
-        }), \\"() => make_alternating_stream(negate_whole_stream(stream_tail(stream)))\\", native)],
+        function: make_alternating_stream,
+        functionName: \\"make_alternating_stream\\",
+        arguments: [callIfFuncAndRightArgs(negate_whole_stream, 3, 36, callIfFuncAndRightArgs(stream_tail, 4, 40, stream))],
         line: 2,
-        column: 9
-      };
-    }, \\"function make_alternating_stream(stream) {\\\\n  return pair(head(stream), () => make_alternating_stream(negate_whole_stream(stream_tail(stream))));\\\\n}\\", native);
-    const negate_whole_stream = wrap(stream => {
-      return {
+        column: 34
+      }), \\"() => make_alternating_stream(negate_whole_stream(stream_tail(stream)))\\", native)],
+      line: 2,
+      column: 9
+    };
+  }, \\"function make_alternating_stream(stream) {\\\\n  return pair(head(stream), () => make_alternating_stream(negate_whole_stream(stream_tail(stream))));\\\\n}\\", native);
+  const negate_whole_stream = wrap(stream => {
+    return {
+      isTail: true,
+      function: pair,
+      functionName: \\"pair\\",
+      arguments: [unaryOp(\\"-\\", callIfFuncAndRightArgs(head, 8, 17, stream), 8, 16), wrap(() => ({
         isTail: true,
-        function: pair,
-        functionName: \\"pair\\",
-        arguments: [unaryOp(\\"-\\", callIfFuncAndRightArgs(head, 8, 17, stream), 8, 16), wrap(() => ({
-          isTail: true,
-          function: negate_whole_stream,
-          functionName: \\"negate_whole_stream\\",
-          arguments: [callIfFuncAndRightArgs(stream_tail, 8, 57, stream)],
-          line: 8,
-          column: 37
-        }), \\"() => negate_whole_stream(stream_tail(stream))\\", native)],
+        function: negate_whole_stream,
+        functionName: \\"negate_whole_stream\\",
+        arguments: [callIfFuncAndRightArgs(stream_tail, 8, 57, stream)],
         line: 8,
-        column: 11
-      };
-    }, \\"function negate_whole_stream(stream) {\\\\n  return pair(-head(stream), () => negate_whole_stream(stream_tail(stream)));\\\\n}\\", native);
-    const ones = callIfFuncAndRightArgs(pair, 11, 13, 1, wrap(() => ({
-      isTail: false,
-      value: ones
-    }), \\"() => ones\\", native));
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(eval_stream, 12, 0, callIfFuncAndRightArgs(make_alternating_stream, 12, 12, callIfFuncAndRightArgs(enum_stream, 12, 36, 1, 9)), 9);\\");
-    globals.variables.set(\\"make_alternating_stream\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return make_alternating_stream;
-      }
-    });
-    globals.variables.set(\\"negate_whole_stream\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return negate_whole_stream;
-      }
-    });
-    globals.variables.set(\\"ones\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return ones;
-      }
-    });
-  }
+        column: 37
+      }), \\"() => negate_whole_stream(stream_tail(stream))\\", native)],
+      line: 8,
+      column: 11
+    };
+  }, \\"function negate_whole_stream(stream) {\\\\n  return pair(-head(stream), () => negate_whole_stream(stream_tail(stream)));\\\\n}\\", native);
+  const ones = callIfFuncAndRightArgs(pair, 11, 13, 1, wrap(() => ({
+    isTail: false,
+    value: ones
+  }), \\"() => ones\\", native));
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(eval_stream, 12, 0, callIfFuncAndRightArgs(make_alternating_stream, 12, 12, callIfFuncAndRightArgs(enum_stream, 12, 36, 1, 9)), 9);\\");
+  globals.variables.set(\\"make_alternating_stream\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return make_alternating_stream;
+    }
+  });
+  globals.variables.set(\\"negate_whole_stream\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return negate_whole_stream;
+    }
+  });
+  globals.variables.set(\\"ones\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return ones;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -221,25 +218,23 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const h = wrap(p => {
-      return {
-        isTail: true,
-        function: head,
-        functionName: \\"head\\",
-        arguments: [p],
-        line: 2,
-        column: 9
-      };
-    }, \\"function h(p) {\\\\n  return head(p);\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(h, 5, 0, null);\\");
-    globals.variables.set(\\"h\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return h;
-      }
-    });
-  }
+  const h = wrap(p => {
+    return {
+      isTail: true,
+      function: head,
+      functionName: \\"head\\",
+      arguments: [p],
+      line: 2,
+      column: 9
+    };
+  }, \\"function h(p) {\\\\n  return head(p);\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(h, 5, 0, null);\\");
+  globals.variables.set(\\"h\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return h;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -286,9 +281,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"getProp({}, \\\\\\"valueOf\\\\\\", 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"getProp({}, \\\\\\"valueOf\\\\\\", 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -496,33 +489,31 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const g = wrap(() => ({
-      isTail: false,
-      value: 1
-    }), \\"() => 1\\", native);
-    const f = wrap(x => ({
-      isTail: true,
-      function: g,
-      functionName: \\"g\\",
-      arguments: [x],
-      line: 2,
-      column: 15
-    }), \\"x => g(x)\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 1);\\");
-    globals.variables.set(\\"g\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return g;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const g = wrap(() => ({
+    isTail: false,
+    value: 1
+  }), \\"() => 1\\", native);
+  const f = wrap(x => ({
+    isTail: true,
+    function: g,
+    functionName: \\"g\\",
+    arguments: [x],
+    line: 2,
+    column: 15
+  }), \\"x => g(x)\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 3, 0, 1);\\");
+  globals.variables.set(\\"g\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return g;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -606,19 +597,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(x => ({
-      isTail: false,
-      value: x
-    }), \\"x => x\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(x => ({
+    isTail: false,
+    value: x
+  }), \\"x => x\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -702,19 +691,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(x => ({
-      isTail: false,
-      value: x
-    }), \\"x => x\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 1, 2);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(x => ({
+    isTail: false,
+    value: x
+  }), \\"x => x\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 2, 0, 1, 2);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -762,9 +749,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, \\\\\\"\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, \\\\\\"\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -812,9 +797,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 1, 2, 3);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_number, 1, 0, 1, 2, 3);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -898,19 +881,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = [wrap(x => ({
-      isTail: false,
-      value: x
-    }), \\"x => x\\", native)];
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(getProp(f, 0, 2, 0), 2, 0, 1, 2);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = [wrap(x => ({
+    isTail: false,
+    value: x
+  }), \\"x => x\\", native)];
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(getProp(f, 0, 2, 0), 2, 0, 1, 2);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -998,21 +979,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function f(x) {\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function f(x) {\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1100,21 +1079,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(x => {
-      return {
-        isTail: false,
-        value: x
-      };
-    }, \\"function f(x) {\\\\n  return x;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 1, 2);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(x => {
+    return {
+      isTail: false,
+      value: x
+    };
+  }, \\"function f(x) {\\\\n  return x;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(f, 4, 0, 1, 2);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1280,9 +1257,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs('string', 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs('string', 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1448,9 +1423,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(0, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(0, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1670,9 +1643,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs([1], 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs([1], 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2298,9 +2269,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(true, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(true, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2701,9 +2670,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(undefined, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(undefined, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3248,11 +3215,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    callIfFuncAndRightArgs(display, 1, 0);
-    callIfFuncAndRightArgs(display, 2, 0, 1, 2);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 3, 0, 1, 2, 3);\\");
-  }
+  callIfFuncAndRightArgs(display, 1, 0);
+  callIfFuncAndRightArgs(display, 2, 0, 1, 2);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(display, 3, 0, 1, 2, 3);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3306,12 +3271,10 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    callIfFuncAndRightArgs(list, 1, 0);
-    callIfFuncAndRightArgs(list, 2, 0, 1);
-    callIfFuncAndRightArgs(list, 3, 0, 1, 2, 3);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 4, 0, 1, 2, 3, 4, 5, 6, 6);\\");
-  }
+  callIfFuncAndRightArgs(list, 1, 0);
+  callIfFuncAndRightArgs(list, 2, 0, 1);
+  callIfFuncAndRightArgs(list, 3, 0, 1, 2, 3);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 4, 0, 1, 2, 3, 4, 5, 6, 6);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3343,11 +3306,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    callIfFuncAndRightArgs(math_max, 1, 0);
-    callIfFuncAndRightArgs(math_max, 2, 0, 1, 2);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(math_max, 3, 0, 1, 2, 3);\\");
-  }
+  callIfFuncAndRightArgs(math_max, 1, 0);
+  callIfFuncAndRightArgs(math_max, 2, 0, 1, 2);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(math_max, 3, 0, 1, 2, 3);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3379,11 +3340,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    callIfFuncAndRightArgs(math_min, 1, 0);
-    callIfFuncAndRightArgs(math_min, 2, 0, 1, 2);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(math_min, 3, 0, 1, 2, 3);\\");
-  }
+  callIfFuncAndRightArgs(math_min, 1, 0);
+  callIfFuncAndRightArgs(math_min, 2, 0, 1, 2);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(math_min, 3, 0, 1, 2, 3);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3415,11 +3374,9 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    callIfFuncAndRightArgs(stringify, 1, 0);
-    callIfFuncAndRightArgs(stringify, 2, 0, 1, 2);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 3, 0, 1, 2, 3);\\");
-  }
+  callIfFuncAndRightArgs(stringify, 1, 0);
+  callIfFuncAndRightArgs(stringify, 2, 0, 1, 2);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 3, 0, 1, 2, 3);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3470,21 +3427,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(() => {
-      return {
-        isTail: false,
-        value: 1
-      };
-    }, \\"function f() {\\\\n  return 1;\\\\n}\\", native);
-    lastStatementResult = eval(\\"getProp(f, \\\\\\"prototype\\\\\\", 4, 0);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(() => {
+    return {
+      isTail: false,
+      value: 1
+    };
+  }, \\"function f() {\\\\n  return 1;\\\\n}\\", native);
+  lastStatementResult = eval(\\"getProp(f, \\\\\\"prototype\\\\\\", 4, 0);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -3532,9 +3487,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"getProp(null, \\\\\\"prop\\\\\\", 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"getProp(null, \\\\\\"prop\\\\\\", 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3582,9 +3535,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"getProp('hi', \\\\\\"length\\\\\\", 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"getProp('hi', \\\\\\"length\\\\\\", 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3635,21 +3586,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(() => {
-      return {
-        isTail: false,
-        value: 1
-      };
-    }, \\"function f() {\\\\n  return 1;\\\\n}\\", native);
-    lastStatementResult = eval(\\"setProp(f, \\\\\\"prop\\\\\\", 5, 4, 0);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(() => {
+    return {
+      isTail: false,
+      value: 1
+    };
+  }, \\"function f() {\\\\n  return 1;\\\\n}\\", native);
+  lastStatementResult = eval(\\"setProp(f, \\\\\\"prop\\\\\\", 5, 4, 0);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -3697,9 +3646,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"setProp('hi', \\\\\\"prop\\\\\\", 5, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"setProp('hi', \\\\\\"prop\\\\\\", 5, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3749,9 +3696,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"*\\\\\\", 1, 12, 'string', 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"*\\\\\\", 1, 12, 'string', 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3803,9 +3748,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"if (boolOrErr(1, 1, 0)) {   2; } else {}\\");
-  }
+  lastStatementResult = eval(\\"if (boolOrErr(1, 1, 0)) {   2; } else {}\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/interpreter/__tests__/interpreter-errors.ts
+++ b/src/interpreter/__tests__/interpreter-errors.ts
@@ -24,8 +24,7 @@ test('Undefined variable error is thrown', () => {
 test('Undefined variable error is thrown - verbose', () => {
   return expectParsedError(undefinedVariableVerbose).toMatchInlineSnapshot(`
             "Line 2, Column 0: Name im_undefined not declared.
-            Before you can read the value of im_undefined, you need to declare it as a variable or a constant. You can do this \
-            using the let or const keywords.
+            Before you can read the value of im_undefined, you need to declare it as a variable or a constant. You can do this using the let or const keywords.
             "
           `)
 })
@@ -355,8 +354,7 @@ test('Error when calling non function value 0', () => {
 test('Error when calling non function value 0 - verbose', () => {
   return expectParsedError(callingNonFunctionValue0Verbose).toMatchInlineSnapshot(`
             "Line 2, Column 2: Calling non-function value 0.
-            Because 0 is not a function, you cannot run 0(). If you were planning to perform multiplication by 0, you need to use \
-            the * operator.
+            Because 0 is not a function, you cannot run 0(). If you were planning to perform multiplication by 0, you need to use the * operator.
             "
           `)
 })

--- a/src/interpreter/__tests__/interpreter-errors.ts
+++ b/src/interpreter/__tests__/interpreter-errors.ts
@@ -23,11 +23,11 @@ test('Undefined variable error is thrown', () => {
 
 test('Undefined variable error is thrown - verbose', () => {
   return expectParsedError(undefinedVariableVerbose).toMatchInlineSnapshot(`
-"Line 2, Column 0: Name im_undefined not declared.
-Before you can read the value of im_undefined, you need to declare it as a variable or a constant. You can do this \
-using the let or const keywords.
-"
-`)
+            "Line 2, Column 0: Name im_undefined not declared.
+            Before you can read the value of im_undefined, you need to declare it as a variable or a constant. You can do this \
+            using the let or const keywords.
+            "
+          `)
 })
 
 test('Undefined variable error message differs from verbose version', () => {
@@ -51,10 +51,10 @@ test('Error when assigning to builtin', () => {
 
 test('Error when assigning to builtin - verbose', () => {
   return expectParsedError(assignToBuiltinVerbose, { chapter: 3 }).toMatchInlineSnapshot(`
-"Line 2, Column 0: Cannot assign new value to constant map.
-As map was declared as a constant, its value cannot be changed. You will have to declare a new variable.
-"
-`)
+            "Line 2, Column 0: Cannot assign new value to constant map.
+            As map was declared as a constant, its value cannot be changed. You will have to declare a new variable.
+            "
+          `)
 })
 
 test('Assigning to builtin error message differs from verbose version', () => {
@@ -78,10 +78,10 @@ test('Error when assigning to builtin', () => {
 
 test('Error when assigning to builtin - verbose', () => {
   return expectParsedError(assignToBuiltinVerbose1, { chapter: 3 }).toMatchInlineSnapshot(`
-"Line 2, Column 0: Cannot assign new value to constant undefined.
-As undefined was declared as a constant, its value cannot be changed. You will have to declare a new variable.
-"
-`)
+            "Line 2, Column 0: Cannot assign new value to constant undefined.
+            As undefined was declared as a constant, its value cannot be changed. You will have to declare a new variable.
+            "
+          `)
 })
 
 test('Assigning to builtin error message differs from verbose version', () => {
@@ -235,10 +235,10 @@ test('Error when calling non function value undefined', () => {
 
 test('Error when calling non function value undefined - verbose', () => {
   return expectParsedError(callingNonFunctionValueUndefinedVerbose).toMatchInlineSnapshot(`
-"Line 2, Column 2: Calling non-function value undefined.
-Because undefined is not a function, you cannot run undefined().
-"
-`)
+            "Line 2, Column 2: Calling non-function value undefined.
+            Because undefined is not a function, you cannot run undefined().
+            "
+          `)
 })
 
 test('Calling non function value undefined error message differs from verbose version', () => {
@@ -265,10 +265,10 @@ test('Error when calling non function value undefined with arguments', () => {
 
 test('Error when calling non function value undefined with arguments - verbose', () => {
   return expectParsedError(callingNonFunctionValueUndefinedArgsVerbose).toMatchInlineSnapshot(`
-"Line 2, Column 2: Calling non-function value undefined.
-Because undefined is not a function, you cannot run undefined(1, true).
-"
-`)
+            "Line 2, Column 2: Calling non-function value undefined.
+            Because undefined is not a function, you cannot run undefined(1, true).
+            "
+          `)
 })
 
 test('Calling non function value undefined with arguments error message differs from verbose version', () => {
@@ -295,10 +295,10 @@ test('Error when calling non function value null', () => {
 
 test('Error when calling non function value null - verbose', () => {
   return expectParsedError(callingNonFunctionValueNullVerbose).toMatchInlineSnapshot(`
-"Line 2, Column 2: null literals are not allowed.
-They're not part of the Source §1 specs.
-"
-`)
+            "Line 2, Column 2: null literals are not allowed.
+            They're not part of the Source §1 specs.
+            "
+          `)
 })
 
 test('Calling non function value null error message differs from verbose version', () => {
@@ -324,10 +324,10 @@ test('Error when calling non function value true', () => {
 
 test('Error when calling non function value true - verbose', () => {
   return expectParsedError(callingNonFunctionValueTrueVerbose).toMatchInlineSnapshot(`
-"Line 2, Column 2: Calling non-function value true.
-Because true is not a function, you cannot run true().
-"
-`)
+            "Line 2, Column 2: Calling non-function value true.
+            Because true is not a function, you cannot run true().
+            "
+          `)
 })
 
 test('Calling non function value true error message differs from verbose version', () => {
@@ -354,11 +354,11 @@ test('Error when calling non function value 0', () => {
 
 test('Error when calling non function value 0 - verbose', () => {
   return expectParsedError(callingNonFunctionValue0Verbose).toMatchInlineSnapshot(`
-"Line 2, Column 2: Calling non-function value 0.
-Because 0 is not a function, you cannot run 0(). If you were planning to perform multiplication by 0, you need to use \
-the * operator.
-"
-`)
+            "Line 2, Column 2: Calling non-function value 0.
+            Because 0 is not a function, you cannot run 0(). If you were planning to perform multiplication by 0, you need to use \
+            the * operator.
+            "
+          `)
 })
 
 test('Calling non function value 0 error message differs from verbose version', () => {
@@ -385,10 +385,10 @@ test('Error when calling non function value "string"', () => {
 
 test('Error when calling non function value "string" - verbose', () => {
   return expectParsedError(callingNonFunctionValueStringVerbose).toMatchInlineSnapshot(`
-"Line 2, Column 2: Calling non-function value \\"string\\".
-Because \\"string\\" is not a function, you cannot run \\"string\\"().
-"
-`)
+            "Line 2, Column 2: Calling non-function value \\"string\\".
+            Because \\"string\\" is not a function, you cannot run \\"string\\"().
+            "
+          `)
 })
 
 test('Calling non function value string error message differs from verbose version', () => {
@@ -417,10 +417,10 @@ test('Error when calling non function value array', () => {
 test('Error when calling non function value array - verbose', () => {
   return expectParsedError(callingNonFunctionValueArrayVerbose, { chapter: 3 })
     .toMatchInlineSnapshot(`
-"Line 2, Column 0: Calling non-function value [1].
-Because [1] is not a function, you cannot run [1]().
-"
-`)
+            "Line 2, Column 0: Calling non-function value [1].
+            Because [1] is not a function, you cannot run [1]().
+            "
+          `)
 })
 
 test('Calling non function value array error message differs from verbose version', () => {
@@ -448,10 +448,10 @@ test('Error when calling non function value object', () => {
 test('Error when calling non function value object - verbose', () => {
   return expectParsedError(callingNonFunctionValueObjectVerbose, { chapter: 100 })
     .toMatchInlineSnapshot(`
-"Line 2, Column 0: Calling non-function value {\\"a\\": 1}.
-Because {\\"a\\": 1} is not a function, you cannot run {\\"a\\": 1}().
-"
-`)
+            "Line 2, Column 0: Calling non-function value {\\"a\\": 1}.
+            Because {\\"a\\": 1} is not a function, you cannot run {\\"a\\": 1}().
+            "
+          `)
 })
 
 test('Calling non function value object error message differs from verbose version', () => {
@@ -469,10 +469,10 @@ test('Error when calling non function value object - verbose', () => {
     `,
     { chapter: 100 }
   ).toMatchInlineSnapshot(`
-"Line 2, Column 0: Calling non-function value {\\"a\\": 1}.
-Because {\\"a\\": 1} is not a function, you cannot run {\\"a\\": 1}().
-"
-`)
+            "Line 2, Column 0: Calling non-function value {\\"a\\": 1}.
+            Because {\\"a\\": 1} is not a function, you cannot run {\\"a\\": 1}().
+            "
+          `)
 })
 
 test('Error when calling function with too few arguments', () => {
@@ -495,10 +495,10 @@ test('Error when calling function with too few arguments - verbose', () => {
       }
       f();
     `).toMatchInlineSnapshot(`
-"Line 5, Column 2: Expected 1 arguments, but got 0.
-Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
-"
-`)
+            "Line 5, Column 2: Expected 1 arguments, but got 0.
+            Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
+            "
+          `)
 })
 
 test('Error when calling function with too many arguments', () => {
@@ -521,10 +521,10 @@ test('Error when calling function with too many arguments - verbose', () => {
       }
       f(1, 2);
     `).toMatchInlineSnapshot(`
-"Line 5, Column 2: Expected 1 arguments, but got 2.
-Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
-"
-`)
+            "Line 5, Column 2: Expected 1 arguments, but got 2.
+            Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
+            "
+          `)
 })
 
 test('Error when calling arrow function with too few arguments', () => {
@@ -543,10 +543,10 @@ test('Error when calling arrow function with too few arguments - verbose', () =>
     const f = x => x;
     f();
   `).toMatchInlineSnapshot(`
-"Line 3, Column 2: Expected 1 arguments, but got 0.
-Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
-"
-`)
+            "Line 3, Column 2: Expected 1 arguments, but got 0.
+            Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
+            "
+          `)
 })
 
 test('Error when calling arrow function with too many arguments', () => {
@@ -565,10 +565,10 @@ test('Error when calling arrow function with too many arguments - verbose', () =
       const f = x => x;
       f(1, 2);
     `).toMatchInlineSnapshot(`
-"Line 3, Column 2: Expected 1 arguments, but got 2.
-Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
-"
-`)
+            "Line 3, Column 2: Expected 1 arguments, but got 2.
+            Try calling function f again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
+            "
+          `)
 })
 
 test('Error when calling function from member expression with too many arguments', () => {
@@ -590,10 +590,10 @@ test('Error when calling function from member expression with too many arguments
     `,
     { chapter: 3 }
   ).toMatchInlineSnapshot(`
-"Line 3, Column 2: Expected 1 arguments, but got 2.
-Try calling function f[0] again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
-"
-`)
+            "Line 3, Column 2: Expected 1 arguments, but got 2.
+            Try calling function f[0] again, but with 1 argument instead. Remember that arguments are separated by a ',' (comma).
+            "
+          `)
 })
 
 test('Error when calling arrow function in tail call with too many arguments - verbose', () => {
@@ -605,10 +605,10 @@ test('Error when calling arrow function in tail call with too many arguments - v
     f(1);
   `
   ).toMatchInlineSnapshot(`
-"Line 3, Column 15: Expected 0 arguments, but got 1.
-Try calling function g again, but with 0 arguments instead. Remember that arguments are separated by a ',' (comma).
-"
-`)
+            "Line 3, Column 15: Expected 0 arguments, but got 1.
+            Try calling function g again, but with 0 arguments instead. Remember that arguments are separated by a ',' (comma).
+            "
+          `)
 })
 
 test('Error when calling arrow function in tail call with too many arguments', () => {
@@ -650,29 +650,29 @@ test('No error when calling list function in with variable arguments', () => {
   `,
     { native: true, chapter: 2 }
   ).toMatchInlineSnapshot(`
-Array [
-  1,
-  Array [
-    2,
-    Array [
-      3,
-      Array [
-        4,
-        Array [
-          5,
-          Array [
-            6,
             Array [
-              6,
-              null,
-            ],
-          ],
-        ],
-      ],
-    ],
-  ],
-]
-`)
+              1,
+              Array [
+                2,
+                Array [
+                  3,
+                  Array [
+                    4,
+                    Array [
+                      5,
+                      Array [
+                        6,
+                        Array [
+                          6,
+                          null,
+                        ],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ]
+          `)
 })
 
 test('No error when calling display function in with variable arguments', () => {
@@ -778,10 +778,10 @@ test('Error when redeclaring function after let --verbose', () => {
   `,
     { chapter: 3, native: true }
   ).toMatchInlineSnapshot(`
-"Line 3, Column 9: SyntaxError: Identifier 'f' has already been declared (3:9)
-There is a syntax error in your program
-"
-`)
+            "Line 3, Column 9: SyntaxError: Identifier 'f' has already been declared (3:9)
+            There is a syntax error in your program
+            "
+          `)
 })
 
 test('Error when redeclaring function after function', () => {
@@ -803,10 +803,10 @@ test('Error when redeclaring function after function --verbose', () => {
   `,
     { chapter: 3, native: true }
   ).toMatchInlineSnapshot(`
-"Line 3, Column 9: SyntaxError: Identifier 'f' has already been declared (3:9)
-There is a syntax error in your program
-"
-`)
+            "Line 3, Column 9: SyntaxError: Identifier 'f' has already been declared (3:9)
+            There is a syntax error in your program
+            "
+          `)
 })
 
 test('Error when redeclaring function after const', () => {
@@ -828,10 +828,10 @@ test('Error when redeclaring function after const --verbose', () => {
   `,
     { chapter: 3, native: true }
   ).toMatchInlineSnapshot(`
-"Line 3, Column 9: SyntaxError: Identifier 'f' has already been declared (3:9)
-There is a syntax error in your program
-"
-`)
+            "Line 3, Column 9: SyntaxError: Identifier 'f' has already been declared (3:9)
+            There is a syntax error in your program
+            "
+          `)
 })
 
 test('Error when redeclaring const after function', () => {
@@ -853,10 +853,10 @@ test('Error when redeclaring const after function --verbose', () => {
   `,
     { chapter: 3, native: true }
   ).toMatchInlineSnapshot(`
-"Line 3, Column 6: SyntaxError: Identifier 'f' has already been declared (3:6)
-There is a syntax error in your program
-"
-`)
+            "Line 3, Column 6: SyntaxError: Identifier 'f' has already been declared (3:6)
+            There is a syntax error in your program
+            "
+          `)
 })
 
 test('Error when redeclaring let after function', () => {
@@ -878,10 +878,10 @@ test('Error when redeclaring let after function --verbose', () => {
   `,
     { chapter: 3, native: true }
   ).toMatchInlineSnapshot(`
-"Line 3, Column 4: SyntaxError: Identifier 'f' has already been declared (3:4)
-There is a syntax error in your program
-"
-`)
+            "Line 3, Column 4: SyntaxError: Identifier 'f' has already been declared (3:4)
+            There is a syntax error in your program
+            "
+          `)
 })
 
 // NOTE: Obsoleted due to strict types on member access
@@ -912,10 +912,10 @@ test.skip('Error when accessing inherited property of builtin', () => {
   `,
     { chapter: 100, native: true }
   ).toMatchInlineSnapshot(`
-"Line 1: Cannot read inherited property constructor of function pair(left, right) {
-	[implementation hidden]
-}"
-`)
+            "Line 1: Cannot read inherited property constructor of function pair(left, right) {
+            	[implementation hidden]
+            }"
+          `)
 })
 
 // NOTE: Obsoleted due to strict types on member access
@@ -1079,9 +1079,10 @@ test('Cascading js errors work properly 1', () => {
     eval_stream(make_alternating_stream(enum_stream(1, 9)), 9);
     `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(
-    `"Line 8: Error: head(xs) expects a pair as argument xs, but encountered null"`
-  )
+  ).toMatchInlineSnapshot(`
+            "native:\\"Line 12: Name eval_stream not declared.\\"
+            interpreted:\\"Line 8: Error: head(xs) expects a pair as argument xs, but encountered null\\""
+          `)
 })
 
 test('Cascading js errors work properly', () => {

--- a/src/parser/__tests__/__snapshots__/allowed-syntax.ts.snap
+++ b/src/parser/__tests__/__snapshots__/allowed-syntax.ts.snap
@@ -28,9 +28,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -485,9 +483,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"function name(a, b) {\\\\\\\\n  const sum = a + b;\\\\\\\\n  if (sum > 1) {\\\\\\\\n    return sum;\\\\\\\\n  } else {\\\\\\\\n    if (a % 2 === 0) {\\\\\\\\n      return -1;\\\\\\\\n    } else if (b % 2 === 0) {\\\\\\\\n      return 1;\\\\\\\\n    } else {\\\\\\\\n      return a > b ? 0 : -2;\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\nname(1, 2);\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"function name(a, b) {\\\\\\\\n  const sum = a + b;\\\\\\\\n  if (sum > 1) {\\\\\\\\n    return sum;\\\\\\\\n  } else {\\\\\\\\n    if (a % 2 === 0) {\\\\\\\\n      return -1;\\\\\\\\n    } else if (b % 2 === 0) {\\\\\\\\n      return 1;\\\\\\\\n    } else {\\\\\\\\n      return a > b ? 0 : -2;\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\nname(1, 2);\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -531,44 +527,42 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const name = wrap((a, b) => {
-      const sum = binaryOp(\\"+\\", 1, a, b, 2, 14);
-      if (boolOrErr(binaryOp(\\">\\", 1, sum, 1, 3, 6), 3, 2)) {
+  const name = wrap((a, b) => {
+    const sum = binaryOp(\\"+\\", 1, a, b, 2, 14);
+    if (boolOrErr(binaryOp(\\">\\", 1, sum, 1, 3, 6), 3, 2)) {
+      return {
+        isTail: false,
+        value: sum
+      };
+    } else {
+      if (boolOrErr(binaryOp(\\"===\\", 1, binaryOp(\\"%\\", 1, a, 2, 6, 8), 0, 6, 8), 6, 4)) {
         return {
           isTail: false,
-          value: sum
+          value: unaryOp(\\"-\\", 1, 7, 13)
+        };
+      } else if (boolOrErr(binaryOp(\\"===\\", 1, binaryOp(\\"%\\", 1, b, 2, 8, 15), 0, 8, 15), 8, 11)) {
+        return {
+          isTail: false,
+          value: 1
         };
       } else {
-        if (boolOrErr(binaryOp(\\"===\\", 1, binaryOp(\\"%\\", 1, a, 2, 6, 8), 0, 6, 8), 6, 4)) {
-          return {
-            isTail: false,
-            value: unaryOp(\\"-\\", 1, 7, 13)
-          };
-        } else if (boolOrErr(binaryOp(\\"===\\", 1, binaryOp(\\"%\\", 1, b, 2, 8, 15), 0, 8, 15), 8, 11)) {
-          return {
-            isTail: false,
-            value: 1
-          };
-        } else {
-          return boolOrErr(binaryOp(\\">\\", 1, a, b, 11, 13), 11, 13) ? {
-            isTail: false,
-            value: 0
-          } : {
-            isTail: false,
-            value: unaryOp(\\"-\\", 2, 11, 25)
-          };
-        }
+        return boolOrErr(binaryOp(\\">\\", 1, a, b, 11, 13), 11, 13) ? {
+          isTail: false,
+          value: 0
+        } : {
+          isTail: false,
+          value: unaryOp(\\"-\\", 2, 11, 25)
+        };
       }
-    }, \\"function name(a, b) {\\\\n  const sum = a + b;\\\\n  if (sum > 1) {\\\\n    return sum;\\\\n  } else {\\\\n    if (a % 2 === 0) {\\\\n      return -1;\\\\n    } else if (b % 2 === 0) {\\\\n      return 1;\\\\n    } else {\\\\n      return a > b ? 0 : -2;\\\\n    }\\\\n  }\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(name, 15, 0, 1, 2);\\");
-    globals.variables.set(\\"name\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return name;
-      }
-    });
-  }
+    }
+  }, \\"function name(a, b) {\\\\n  const sum = a + b;\\\\n  if (sum > 1) {\\\\n    return sum;\\\\n  } else {\\\\n    if (a % 2 === 0) {\\\\n      return -1;\\\\n    } else if (b % 2 === 0) {\\\\n      return 1;\\\\n    } else {\\\\n      return a > b ? 0 : -2;\\\\n    }\\\\n  }\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(name, 15, 0, 1, 2);\\");
+  globals.variables.set(\\"name\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return name;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -622,9 +616,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"(() => true)();\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"(() => true)();\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -654,9 +646,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap(() => ({   isTail: false,   value: true }), \\\\\\"() => true\\\\\\", native), 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap(() => ({   isTail: false,   value: true }), \\\\\\"() => true\\\\\\", native), 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -767,9 +757,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"((x, y) => { return x + y; })(1, 2);\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"((x, y) => { return x + y; })(1, 2);\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -799,9 +787,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap((x, y) => {   return {     isTail: false,     value: binaryOp(\\\\\\"+\\\\\\", 1, x, y, 1, 20)   }; }, \\\\\\"(x, y) => {\\\\\\\\n  return x + y;\\\\\\\\n}\\\\\\", native), 1, 0, 1, 2);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(wrap((x, y) => {   return {     isTail: false,     value: binaryOp(\\\\\\"+\\\\\\", 1, x, y, 1, 20)   }; }, \\\\\\"(x, y) => {\\\\\\\\n  return x + y;\\\\\\\\n}\\\\\\", native), 1, 0, 1, 2);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -831,9 +817,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -863,9 +847,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"true;\\");
-  }
+  lastStatementResult = eval(\\"true;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -895,9 +877,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"false;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"false;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -927,9 +907,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"false;\\");
-  }
+  lastStatementResult = eval(\\"false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -959,9 +937,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"'a string \\\\\\\\\\\\\\"\\\\\\\\\\\\\\" \\\\\\\\\\\\\\\\'\\\\\\\\\\\\\\\\'';\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"'a string \\\\\\\\\\\\\\"\\\\\\\\\\\\\\" \\\\\\\\\\\\\\\\'\\\\\\\\\\\\\\\\'';\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -991,9 +967,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"'a string \\\\\\"\\\\\\" \\\\\\\\'\\\\\\\\'';\\");
-  }
+  lastStatementResult = eval(\\"'a string \\\\\\"\\\\\\" \\\\\\\\'\\\\\\\\'';\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1143,9 +1117,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"31.4 + (-3.14e10) * -1 % 2 / 1.5;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"31.4 + (-3.14e10) * -1 % 2 / 1.5;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1175,9 +1147,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 1, 31.4, binaryOp(\\\\\\"/\\\\\\", 1, binaryOp(\\\\\\"%\\\\\\", 1, binaryOp(\\\\\\"*\\\\\\", 1, unaryOp(\\\\\\"-\\\\\\", 3.14e10, 1, 8), unaryOp(\\\\\\"-\\\\\\", 1, 1, 20), 1, 7), 2, 1, 7), 1.5, 1, 7), 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 1, 31.4, binaryOp(\\\\\\"/\\\\\\", 1, binaryOp(\\\\\\"%\\\\\\", 1, binaryOp(\\\\\\"*\\\\\\", 1, unaryOp(\\\\\\"-\\\\\\", 3.14e10, 1, 8), unaryOp(\\\\\\"-\\\\\\", 1, 1, 20), 1, 7), 2, 1, 7), 1.5, 1, 7), 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1417,9 +1387,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"1 === 1 && 1 < 2 && 1 <= 2 && 2 >= 1 && 2 > 1 || false;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"1 === 1 && 1 < 2 && 1 <= 2 && 2 >= 1 && 2 > 1 || false;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1449,9 +1417,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", 1, 1, 1, 1, 0), 1, 0) && binaryOp(\\\\\\"<\\\\\\", 1, 1, 2, 1, 11), 1, 0) && binaryOp(\\\\\\"<=\\\\\\", 1, 1, 2, 1, 20), 1, 0) && binaryOp(\\\\\\">=\\\\\\", 1, 2, 1, 1, 30), 1, 0) && binaryOp(\\\\\\">\\\\\\", 1, 2, 1, 1, 40), 1, 0) || false;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(boolOrErr(boolOrErr(boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", 1, 1, 1, 1, 0), 1, 0) && binaryOp(\\\\\\"<\\\\\\", 1, 1, 2, 1, 11), 1, 0) && binaryOp(\\\\\\"<=\\\\\\", 1, 1, 2, 1, 20), 1, 0) && binaryOp(\\\\\\">=\\\\\\", 1, 2, 1, 1, 30), 1, 0) && binaryOp(\\\\\\">\\\\\\", 1, 2, 1, 1, 40), 1, 0) || false;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1493,9 +1459,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true ? 1 : 2;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"true ? 1 : 2;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1525,9 +1489,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? 1 : 2;\\");
-  }
+  lastStatementResult = eval(\\"boolOrErr(true, 1, 0) ? 1 : 2;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1592,9 +1554,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"null;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"null;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1624,9 +1584,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"null;\\");
-  }
+  lastStatementResult = eval(\\"null;\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1712,9 +1670,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"pair(1, null);\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"pair(1, null);\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1747,9 +1703,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, null);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, null);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1826,9 +1780,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"list(1);\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"list(1);\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1861,9 +1813,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0, 1);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2365,9 +2315,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nwhile (i < 5) {\\\\\\\\n  i = i + 1;\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nwhile (i < 5) {\\\\\\\\n  i = i + 1;\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2401,30 +2349,28 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let i = 1;
-    const startTime = get_time();
-    while (boolOrErr(binaryOp(\\"<\\", 3, i, 5, 2, 7), 2, 0)) {
-      throwIfTimeout(native, startTime, get_time(), 2, 0);
-      i = binaryOp(\\"+\\", 3, i, 1, 3, 6);
-    }
-    lastStatementResult = eval(\\"i;\\");
-    globals.variables.set(\\"i\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return i;
-      },
-      assignNewValue: function (unique) {
-        return i = unique;
-      }
-    });
-    globals.variables.set(\\"startTime\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return startTime;
-      }
-    });
+  let i = 1;
+  const startTime = get_time();
+  while (boolOrErr(binaryOp(\\"<\\", 3, i, 5, 2, 7), 2, 0)) {
+    throwIfTimeout(native, startTime, get_time(), 2, 0);
+    i = binaryOp(\\"+\\", 3, i, 1, 3, 6);
   }
+  lastStatementResult = eval(\\"i;\\");
+  globals.variables.set(\\"i\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return i;
+    },
+    assignNewValue: function (unique) {
+      return i = unique;
+    }
+  });
+  globals.variables.set(\\"startTime\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return startTime;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -3040,9 +2986,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (i = 1; i < 5; i = i + 1) {\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (i = 1; i < 5; i = i + 1) {\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -3075,29 +3019,27 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let i = 1;
-    const startTime = get_time();
-    for (i = 1; boolOrErr(binaryOp(\\"<\\", 3, i, 5, 2, 12), 2, 0); i = binaryOp(\\"+\\", 3, i, 1, 2, 23)) {
-      throwIfTimeout(native, startTime, get_time(), 2, 0);
-    }
-    lastStatementResult = eval(\\"i;\\");
-    globals.variables.set(\\"i\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return i;
-      },
-      assignNewValue: function (unique) {
-        return i = unique;
-      }
-    });
-    globals.variables.set(\\"startTime\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return startTime;
-      }
-    });
+  let i = 1;
+  const startTime = get_time();
+  for (i = 1; boolOrErr(binaryOp(\\"<\\", 3, i, 5, 2, 12), 2, 0); i = binaryOp(\\"+\\", 3, i, 1, 2, 23)) {
+    throwIfTimeout(native, startTime, get_time(), 2, 0);
   }
+  lastStatementResult = eval(\\"i;\\");
+  globals.variables.set(\\"i\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return i;
+    },
+    assignNewValue: function (unique) {
+      return i = unique;
+    }
+  });
+  globals.variables.set(\\"startTime\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return startTime;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -4348,9 +4290,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (let j = 0; j < 5; j = j + 1) {\\\\\\\\n  if (j < 1) {\\\\\\\\n    continue;\\\\\\\\n  } else {\\\\\\\\n    i = i + 1;\\\\\\\\n    if (j > 2) {\\\\\\\\n      break;\\\\\\\\n    } else {\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let i = 1;\\\\\\\\nfor (let j = 0; j < 5; j = j + 1) {\\\\\\\\n  if (j < 1) {\\\\\\\\n    continue;\\\\\\\\n  } else {\\\\\\\\n    i = i + 1;\\\\\\\\n    if (j > 2) {\\\\\\\\n      break;\\\\\\\\n    } else {\\\\\\\\n    }\\\\\\\\n  }\\\\\\\\n}\\\\\\\\ni;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -4392,37 +4332,35 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let i = 1;
-    const startTime = get_time();
-    for (let j = 0; boolOrErr(binaryOp(\\"<\\", 3, j, 5, 2, 16), 2, 0); j = binaryOp(\\"+\\", 3, j, 1, 2, 27)) {
-      throwIfTimeout(native, startTime, get_time(), 2, 0);
-      if (boolOrErr(binaryOp(\\"<\\", 3, j, 1, 3, 6), 3, 2)) {
-        continue;
-      } else {
-        i = binaryOp(\\"+\\", 3, i, 1, 6, 8);
-        if (boolOrErr(binaryOp(\\">\\", 3, j, 2, 7, 8), 7, 4)) {
-          break;
-        } else {}
-      }
+  let i = 1;
+  const startTime = get_time();
+  for (let j = 0; boolOrErr(binaryOp(\\"<\\", 3, j, 5, 2, 16), 2, 0); j = binaryOp(\\"+\\", 3, j, 1, 2, 27)) {
+    throwIfTimeout(native, startTime, get_time(), 2, 0);
+    if (boolOrErr(binaryOp(\\"<\\", 3, j, 1, 3, 6), 3, 2)) {
+      continue;
+    } else {
+      i = binaryOp(\\"+\\", 3, i, 1, 6, 8);
+      if (boolOrErr(binaryOp(\\">\\", 3, j, 2, 7, 8), 7, 4)) {
+        break;
+      } else {}
     }
-    lastStatementResult = eval(\\"i;\\");
-    globals.variables.set(\\"i\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return i;
-      },
-      assignNewValue: function (unique) {
-        return i = unique;
-      }
-    });
-    globals.variables.set(\\"startTime\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return startTime;
-      }
-    });
   }
+  lastStatementResult = eval(\\"i;\\");
+  globals.variables.set(\\"i\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return i;
+    },
+    assignNewValue: function (unique) {
+      return i = unique;
+    }
+  });
+  globals.variables.set(\\"startTime\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return startTime;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -4493,9 +4431,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -4525,9 +4461,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"[];\\");
-  }
+  lastStatementResult = eval(\\"[];\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -4659,9 +4593,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -4695,9 +4627,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"[1, 2, 3];\\");
-  }
+  lastStatementResult = eval(\\"[1, 2, 3];\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -4945,9 +4875,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3][1];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"[1, 2, 3][1];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -4977,9 +4905,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"getProp([1, 2, 3], 1, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"getProp([1, 2, 3], 1, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -5331,9 +5257,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -5364,19 +5288,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let x = [1, 2, 3];
-    lastStatementResult = eval(\\"getProp(x, 1, 2, 0);\\");
-    globals.variables.set(\\"x\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return x;
-      },
-      assignNewValue: function (unique) {
-        return x = unique;
-      }
-    });
-  }
+  let x = [1, 2, 3];
+  lastStatementResult = eval(\\"getProp(x, 1, 2, 0);\\");
+  globals.variables.set(\\"x\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return x;
+    },
+    assignNewValue: function (unique) {
+      return x = unique;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -5825,9 +5747,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1] = 4;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = [1, 2, 3];\\\\\\\\nx[1] = 4;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -5858,19 +5778,17 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let x = [1, 2, 3];
-    lastStatementResult = eval(\\"setProp(x, 1, 4, 2, 0);\\");
-    globals.variables.set(\\"x\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return x;
-      },
-      assignNewValue: function (unique) {
-        return x = unique;
-      }
-    });
-  }
+  let x = [1, 2, 3];
+  lastStatementResult = eval(\\"setProp(x, 1, 4, 2, 0);\\");
+  globals.variables.set(\\"x\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return x;
+    },
+    assignNewValue: function (unique) {
+      return x = unique;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -5941,9 +5859,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({});\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({});\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -6156,9 +6072,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2});\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2});\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -6383,9 +6297,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2})['a'];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2})['a'];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -6771,9 +6683,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2}).a;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({a: 1, b: 2}).a;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -7151,9 +7061,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({'a': 1, 'b': 2}).a;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({'a': 1, 'b': 2}).a;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -7365,9 +7273,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({1: 1, 2: 2})['1'];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"({1: 1, 2: 2})['1'];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -7623,9 +7529,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"const key = 'a';\\\\\\\\n({a: 1, b: 2})[key];\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"const key = 'a';\\\\\\\\n({a: 1, b: 2})[key];\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -7950,9 +7854,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx.a = 3;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx.a = 3;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -8218,9 +8120,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx['a'] = 3;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nx['a'] = 3;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -8511,9 +8411,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nconst key = 'a';\\\\\\\\nx[key] = 3;\\\\\\");\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse, 1, 0, \\\\\\"let x = {a: 1, b: 2};\\\\\\\\nconst key = 'a';\\\\\\\\nx[key] = 3;\\\\\\");\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/stdlib/__tests__/__snapshots__/lazyLists.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/lazyLists.ts.snap
@@ -22,9 +22,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap((curr, acc) => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", 2, curr, acc, 1, 26)     }), \\\\\\"(curr, acc) => curr + acc\\\\\\", native);   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 0;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap((curr, acc) => ({       isTail: false,       value: binaryOp(\\\\\\"+\\\\\\", 2, curr, acc, 1, 26)     }), \\\\\\"(curr, acc) => curr + acc\\\\\\", native);   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 0;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 41, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -56,65 +54,63 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    const b = callIfFuncAndRightArgs(append, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return callIfFuncAndRightArgs(list, 2, 20, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 3;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 4;
-          }
-        });
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  const b = callIfFuncAndRightArgs(append, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return callIfFuncAndRightArgs(list, 2, 20, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 3;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 4;
+        }
+      });
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -146,65 +142,63 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    const b = callIfFuncAndRightArgs(append, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return callIfFuncAndRightArgs(list, 2, 17, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 3;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 4;
-          }
-        });
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  const b = callIfFuncAndRightArgs(append, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return callIfFuncAndRightArgs(list, 2, 17, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 3;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 4;
+        }
+      });
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -234,9 +228,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(append, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 13, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 29, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 51, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(append, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 13, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 29, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 51, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -266,9 +258,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -298,9 +288,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(head, 1, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return null;           }         });       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -346,9 +334,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 3;   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -394,9 +380,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return unaryOp(\\\\\\"-\\\\\\", 1, 1, 24);   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return unaryOp(\\\\\\"-\\\\\\", 1, 1, 24);   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -442,9 +426,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1.5;   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1.5;   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -492,9 +474,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -542,9 +522,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", native);   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return wrap(x => ({       isTail: false,       value: x     }), \\\\\\"x => x\\\\\\", native);   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -592,9 +570,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -642,9 +618,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 5;   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '1';   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 5;   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -692,9 +666,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return '5';   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -724,9 +696,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(build_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", 2, x, x, 1, 25)         }), \\\\\\"x => x * x\\\\\\", native);       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 33, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 0;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 16;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(build_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", 2, x, x, 1, 25)         }), \\\\\\"x => x * x\\\\\\", native);       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 33, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 0;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 9;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 16;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -756,9 +726,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -788,9 +756,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 25, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4.5;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 25, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3.5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4.5;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -820,9 +786,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 23, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(enum_list, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 23, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -854,68 +818,66 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return callIfFuncAndRightArgs(pair, 1, 17, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 2;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-      }
-    });
-    const b = callIfFuncAndRightArgs(filter, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return wrap(x => ({
-          isTail: false,
-          value: binaryOp(\\"===\\", 2, binaryOp(\\"%\\", 2, x, 2, 2, 22), 0, 2, 22)
-        }), \\"x => x % 2 === 0\\", native);
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return callIfFuncAndRightArgs(pair, 1, 17, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 2;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return a;
+        }
+      });
+    }
+  });
+  const b = callIfFuncAndRightArgs(filter, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return wrap(x => ({
+        isTail: false,
+        value: binaryOp(\\"===\\", 2, binaryOp(\\"%\\", 2, x, 2, 2, 22), 0, 2, 22)
+      }), \\"x => x % 2 === 0\\", native);
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -945,9 +907,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(filter, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"<=\\\\\\", 2, x, 4, 1, 18)         }), \\\\\\"x => x <= 4\\\\\\", native);       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 26, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 10;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 100;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 72, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(filter, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"<=\\\\\\", 2, x, 4, 1, 18)         }), \\\\\\"x => x <= 4\\\\\\", native);       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 26, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 10;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 100;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1000;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 72, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -965,8 +925,10 @@ for_each(x => {
 sum;",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": 6,
+  "parsedErrors": "native:\\"Line 2: Name for_each not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:6",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -981,57 +943,55 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let sum = 0;
-    callIfFuncAndRightArgs(for_each, 2, 0, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return wrap(x => {
-          sum = binaryOp(\\"+\\", 3, sum, x, 3, 8);
-        }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", native);
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return callIfFuncAndRightArgs(list, 4, 3, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 1;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 2;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 3;
-          }
-        });
-      }
-    });
-    lastStatementResult = eval(\\"sum;\\");
-    globals.variables.set(\\"sum\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return sum;
-      },
-      assignNewValue: function (unique) {
-        return sum = unique;
-      }
-    });
-  }
+  let sum = 0;
+  callIfFuncAndRightArgs(for_each, 2, 0, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return wrap(x => {
+        sum = binaryOp(\\"+\\", 3, sum, x, 3, 8);
+      }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", native);
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return callIfFuncAndRightArgs(list, 4, 3, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 1;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 2;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 3;
+        }
+      });
+    }
+  });
+  lastStatementResult = eval(\\"sum;\\");
+  globals.variables.set(\\"sum\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return sum;
+    },
+    assignNewValue: function (unique) {
+      return sum = unique;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1061,9 +1021,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1094,30 +1052,28 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(list, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(list, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_list, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1148,30 +1104,28 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1201,9 +1155,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"4\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 4;   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"4\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 4;   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1233,9 +1185,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1267,54 +1217,52 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    const b = callIfFuncAndRightArgs(map, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return wrap(x => ({
-          isTail: false,
-          value: binaryOp(\\"*\\", 2, 2, x, 2, 19)
-        }), \\"x => 2 * x\\", native);
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  const b = callIfFuncAndRightArgs(map, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return wrap(x => ({
+        isTail: false,
+        value: binaryOp(\\"*\\", 2, 2, x, 2, 19)
+      }), \\"x => 2 * x\\", native);
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1346,54 +1294,52 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    const b = callIfFuncAndRightArgs(map, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return wrap(x => ({
-          isTail: false,
-          value: binaryOp(\\"*\\", 2, 2, x, 2, 19)
-        }), \\"x => 2 * x\\", native);
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  const b = callIfFuncAndRightArgs(map, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return wrap(x => ({
+        isTail: false,
+        value: binaryOp(\\"*\\", 2, 2, x, 2, 19)
+      }), \\"x => 2 * x\\", native);
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1423,9 +1369,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(map, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", 2, 2, x, 1, 15)         }), \\\\\\"x => 2 * x\\\\\\", native);       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 22, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 12;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 11;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 40, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 24;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 22;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(map, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return wrap(x => ({           isTail: false,           value: binaryOp(\\\\\\"*\\\\\\", 2, 2, x, 1, 15)         }), \\\\\\"x => 2 * x\\\\\\", native);       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 22, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 12;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 11;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 40, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 24;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 22;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1457,9 +1401,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(member, 2, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 2, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 789;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 3, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 789;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(member, 2, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 2, 12, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 456;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 789;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 3, 2, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 456;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 789;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1489,9 +1431,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_pair, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(is_pair, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 9, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1522,30 +1462,28 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(list, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(tail, 2, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return a;           }         });       }     });   } }), 2, 0);\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(list, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(tail, 2, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return a;           }         });       }     });   } }), 2, 0);\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1576,30 +1514,28 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    });
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(tail, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(tail, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  });
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(tail, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(tail, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(head, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1630,30 +1566,28 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(tail, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"binaryOp(\\\\\\"+\\\\\\", 2, callIfFuncAndRightArgs(head, 2, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return a;   } }), callIfFuncAndRightArgs(head, 2, 10, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(tail, 2, 15, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return a;       }     });   } }), 2, 0);\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1685,65 +1619,63 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return callIfFuncAndRightArgs(pair, 1, 17, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return 2;
-          }
-        }, {
-          isThunk: true,
-          memoizedValue: 0,
-          isMemoized: false,
-          expr: () => {
-            return a;
-          }
-        });
-      }
-    });
-    const b = callIfFuncAndRightArgs(remove_all, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return callIfFuncAndRightArgs(pair, 1, 17, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return 2;
+        }
+      }, {
+        isThunk: true,
+        memoizedValue: 0,
+        isMemoized: false,
+        expr: () => {
+          return a;
+        }
+      });
+    }
+  });
+  const b = callIfFuncAndRightArgs(remove_all, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1773,9 +1705,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove, 1, 7, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 17, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 26, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove, 1, 7, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 17, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 26, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1807,51 +1737,49 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const a = callIfFuncAndRightArgs(pair, 1, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    const b = callIfFuncAndRightArgs(remove, 2, 10, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return 1;
-      }
-    }, {
-      isThunk: true,
-      memoizedValue: 0,
-      isMemoized: false,
-      expr: () => {
-        return a;
-      }
-    });
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
-    globals.variables.set(\\"a\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return a;
-      }
-    });
-    globals.variables.set(\\"b\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return b;
-      }
-    });
-  }
+  const a = callIfFuncAndRightArgs(pair, 1, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  const b = callIfFuncAndRightArgs(remove, 2, 10, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return 1;
+    }
+  }, {
+    isThunk: true,
+    memoizedValue: 0,
+    isMemoized: false,
+    expr: () => {
+      return a;
+    }
+  });
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 3, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return b;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 200;   } });\\");
+  globals.variables.set(\\"a\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return a;
+    }
+  });
+  globals.variables.set(\\"b\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return b;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1881,9 +1809,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 10, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return 1;   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 10, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1913,9 +1839,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 36, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 36, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1945,9 +1869,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 6;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 60, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(remove_all, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 20, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 2;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 3;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 4;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 5;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 1;           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 6;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 60, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 2;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 3;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 4;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 5;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 6;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1977,9 +1899,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(reverse, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 14, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"null\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"undefined\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"null\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 65, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"null\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"undefined\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"null\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(reverse, 1, 6, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return callIfFuncAndRightArgs(list, 1, 14, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"string\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"null\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"undefined\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return \\\\\\"null\\\\\\";           }         }, {           isThunk: true,           memoizedValue: 0,           isMemoized: false,           expr: () => {             return 123;           }         });       }     });   } }, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 65, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 123;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"null\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"undefined\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"null\\\\\\";       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return \\\\\\"string\\\\\\";       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2009,9 +1929,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(list, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2041,9 +1959,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, {   isThunk: true,   memoizedValue: 0,   isMemoized: false,   expr: () => {     return callIfFuncAndRightArgs(pair, 1, 5, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 1;       }     }, {       isThunk: true,       memoizedValue: 0,       isMemoized: false,       expr: () => {         return 'a string \\\\\\"\\\\\\"';       }     });   } });\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/stdlib/__tests__/__snapshots__/list.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/list.ts.snap
@@ -38,9 +38,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 3);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 3);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -86,9 +84,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), unaryOp(\\\\\\"-\\\\\\", 1, 1, 24));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), unaryOp(\\\\\\"-\\\\\\", 1, 1, 24));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -134,9 +130,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 1.5);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), 1.5);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -184,9 +178,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), '1');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3), '1');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -234,9 +226,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, '1', wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(build_list, 1, 0, '1', wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -284,9 +274,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', '5');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', '5');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -334,9 +322,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', 5);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, '1', 5);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -384,9 +370,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, 1, '5');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(enum_list, 1, 0, 1, '5');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -418,7 +402,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 1: Expected 3 arguments, but got 2.",
+  "parsedErrors": "native:\\"Line 1: Name accumulate not declared.\\"
+interpreted:\\"Line 1: Expected 3 arguments, but got 2.\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -434,9 +419,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", 3, x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\", native), [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", 3, x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\", native), [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -468,7 +451,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 1: Expected 3 arguments, but got 2.",
+  "parsedErrors": "native:\\"Line 1: Name accumulate not declared.\\"
+interpreted:\\"Line 1: Expected 3 arguments, but got 2.\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -484,9 +468,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", 3, x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\", native), [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((x, y) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", 3, x, y, 1, 21) }), \\\\\\"(x, y) => x + y\\\\\\", native), [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -516,7 +498,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 101: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name append not declared.\\"
+interpreted:\\"Line 101: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -532,9 +515,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(append, 1, 0, [1, 2, 3], callIfFuncAndRightArgs(list, 1, 18, 1, 2, 3));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(append, 1, 0, [1, 2, 3], callIfFuncAndRightArgs(list, 1, 18, 1, 2, 3));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -593,7 +574,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 139: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name filter not declared.\\"
+interpreted:\\"Line 139: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -609,9 +591,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(filter, 1, 0, wrap(x => ({   isTail: false,   value: true }), \\\\\\"x => true\\\\\\", native), [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(filter, 1, 0, wrap(x => ({   isTail: false,   value: true }), \\\\\\"x => true\\\\\\", native), [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -641,7 +621,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 68: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name for_each not declared.\\"
+interpreted:\\"Line 68: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -657,9 +638,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(for_each, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native), [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(for_each, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native), [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -689,7 +668,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 34: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name length not declared.\\"
+interpreted:\\"Line 34: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -705,9 +685,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(length, 1, 0, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -737,7 +715,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 43: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name map not declared.\\"
+interpreted:\\"Line 43: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -753,9 +732,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(map, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native), [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(map, 1, 0, wrap(x => ({   isTail: false,   value: x }), \\\\\\"x => x\\\\\\", native), [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -785,7 +762,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 110: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name member not declared.\\"
+interpreted:\\"Line 110: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -801,9 +779,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(member, 1, 0, 1, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(member, 1, 0, 1, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -833,7 +809,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 118: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name remove not declared.\\"
+interpreted:\\"Line 118: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -849,9 +826,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -881,7 +856,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 127: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name remove_all not declared.\\"
+interpreted:\\"Line 127: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -897,9 +873,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove_all, 1, 0, 1, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove_all, 1, 0, 1, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -929,7 +903,8 @@ Object {
       "type": "Runtime",
     },
   ],
-  "parsedErrors": "Line 90: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]",
+  "parsedErrors": "native:\\"Line 1: Name reverse not declared.\\"
+interpreted:\\"Line 90: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\"",
   "result": undefined,
   "resultStatus": "error",
   "transpiled": "const native = nativeStorage;
@@ -945,9 +920,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(reverse, 1, 0, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(reverse, 1, 0, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -993,9 +966,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_head, 1, 0, [1, 2, 3], 4);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_head, 1, 0, [1, 2, 3], 4);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1041,9 +1012,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_tail, 1, 0, [1, 2, 3], 4);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(set_tail, 1, 0, [1, 2, 3], 4);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1073,9 +1042,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((curr, acc) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", 2, curr, acc, 1, 26) }), \\\\\\"(curr, acc) => curr + acc\\\\\\", native), 0, callIfFuncAndRightArgs(list, 1, 41, 2, 3, 4, 1));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(accumulate, 1, 0, wrap((curr, acc) => ({   isTail: false,   value: binaryOp(\\\\\\"+\\\\\\", 2, curr, acc, 1, 26) }), \\\\\\"(curr, acc) => curr + acc\\\\\\", native), 0, callIfFuncAndRightArgs(list, 1, 41, 2, 3, 4, 1));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1105,9 +1072,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(append, 1, 6, callIfFuncAndRightArgs(list, 1, 13, 123, 123), callIfFuncAndRightArgs(list, 1, 29, 456, 456, 456)), callIfFuncAndRightArgs(list, 1, 51, 123, 123, 456, 456, 456));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(append, 1, 6, callIfFuncAndRightArgs(list, 1, 13, 123, 123), callIfFuncAndRightArgs(list, 1, 29, 456, 456, 456)), callIfFuncAndRightArgs(list, 1, 51, 123, 123, 456, 456, 456));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1137,9 +1102,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(build_list, 1, 6, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, x, x, 1, 25) }), \\\\\\"x => x * x\\\\\\", native)), callIfFuncAndRightArgs(list, 1, 33, 0, 1, 4, 9, 16));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(build_list, 1, 6, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, x, x, 1, 25) }), \\\\\\"x => x * x\\\\\\", native)), callIfFuncAndRightArgs(list, 1, 33, 0, 1, 4, 9, 16));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1169,9 +1132,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1201,9 +1162,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1.5, 5), callIfFuncAndRightArgs(list, 1, 25, 1.5, 2.5, 3.5, 4.5));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1.5, 5), callIfFuncAndRightArgs(list, 1, 25, 1.5, 2.5, 3.5, 4.5));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1233,9 +1192,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1, 5), callIfFuncAndRightArgs(list, 1, 23, 1, 2, 3, 4, 5));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(enum_list, 1, 6, 1, 5), callIfFuncAndRightArgs(list, 1, 23, 1, 2, 3, 4, 5));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1265,9 +1222,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(filter, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", 2, x, 4, 1, 18) }), \\\\\\"x => x <= 4\\\\\\", native), callIfFuncAndRightArgs(list, 1, 26, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000)), callIfFuncAndRightArgs(list, 1, 72, 2, 1, 3, 4, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(filter, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", 2, x, 4, 1, 18) }), \\\\\\"x => x <= 4\\\\\\", native), callIfFuncAndRightArgs(list, 1, 26, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000)), callIfFuncAndRightArgs(list, 1, 72, 2, 1, 3, 4, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1285,8 +1240,10 @@ for_each(x => {
 sum;",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": 6,
+  "parsedErrors": "native:\\"Line 2: Name for_each not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:6",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -1301,22 +1258,20 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let sum = 0;
-    callIfFuncAndRightArgs(for_each, 2, 0, wrap(x => {
-      sum = binaryOp(\\"+\\", 3, sum, x, 3, 8);
-    }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", native), callIfFuncAndRightArgs(list, 4, 3, 1, 2, 3));
-    lastStatementResult = eval(\\"sum;\\");
-    globals.variables.set(\\"sum\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return sum;
-      },
-      assignNewValue: function (unique) {
-        return sum = unique;
-      }
-    });
-  }
+  let sum = 0;
+  callIfFuncAndRightArgs(for_each, 2, 0, wrap(x => {
+    sum = binaryOp(\\"+\\", 3, sum, x, 3, 8);
+  }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", native), callIfFuncAndRightArgs(list, 4, 3, 1, 2, 3));
+  lastStatementResult = eval(\\"sum;\\");
+  globals.variables.set(\\"sum\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return sum;
+    },
+    assignNewValue: function (unique) {
+      return sum = unique;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1346,9 +1301,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1397,21 +1350,19 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const f = wrap(() => {
-      return {
-        isTail: false,
-        value: 1
-      };
-    }, \\"function f() {\\\\n  return 1;\\\\n}\\", native);
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 2, 0, 1, 'a string \\\\\\"\\\\\\"', wrap(() => ({   isTail: false,   value: f }), \\\\\\"() => f\\\\\\", native), f, true, 3.14);\\");
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-  }
+  const f = wrap(() => {
+    return {
+      isTail: false,
+      value: 1
+    };
+  }, \\"function f() {\\\\n  return 1;\\\\n}\\", native);
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list, 2, 0, 1, 'a string \\\\\\"\\\\\\"', wrap(() => ({   isTail: false,   value: f }), \\\\\\"() => f\\\\\\", native), f, true, 3.14);\\");
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1441,9 +1392,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_ref, 1, 0, callIfFuncAndRightArgs(list, 1, 9, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1473,9 +1422,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, callIfFuncAndRightArgs(list, 1, 15, 1, 2, 3));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(list_to_string, 1, 0, callIfFuncAndRightArgs(list, 1, 15, 1, 2, 3));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1505,9 +1452,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(map, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, 2, x, 1, 15) }), \\\\\\"x => 2 * x\\\\\\", native), callIfFuncAndRightArgs(list, 1, 22, 12, 11, 3)), callIfFuncAndRightArgs(list, 1, 40, 24, 22, 6));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(map, 1, 6, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 2, 2, x, 1, 15) }), \\\\\\"x => 2 * x\\\\\\", native), callIfFuncAndRightArgs(list, 1, 22, 12, 11, 3)), callIfFuncAndRightArgs(list, 1, 40, 24, 22, 6));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1539,9 +1484,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(member, 2, 2, 4, callIfFuncAndRightArgs(list, 2, 12, 1, 2, 3, 4, 123, 456, 789)), callIfFuncAndRightArgs(list, 3, 2, 4, 123, 456, 789));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(member, 2, 2, 4, callIfFuncAndRightArgs(list, 2, 12, 1, 2, 3, 4, 123, 456, 789)), callIfFuncAndRightArgs(list, 3, 2, 4, 123, 456, 789));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1587,9 +1530,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1635,9 +1576,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, [1, 2, 3]);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, [1, 2, 3]);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1670,9 +1609,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 'a string \\\\\\"\\\\\\"');\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(pair, 1, 0, 1, 'a string \\\\\\"\\\\\\"');\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1705,9 +1642,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 2, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 2, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1737,9 +1672,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(remove, 1, 0, 1, callIfFuncAndRightArgs(list, 1, 10, 1));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1769,9 +1702,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 2, 3, 4)), callIfFuncAndRightArgs(list, 1, 36, 2, 3, 4));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 2, 3, 4)), callIfFuncAndRightArgs(list, 1, 36, 2, 3, 4));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1801,9 +1732,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 1, 2, 3, 4, 1, 1, 1, 5, 1, 1, 6)), callIfFuncAndRightArgs(list, 1, 60, 2, 3, 4, 5, 6));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(remove_all, 1, 6, 1, callIfFuncAndRightArgs(list, 1, 20, 1, 2, 3, 4, 1, 1, 1, 5, 1, 1, 6)), callIfFuncAndRightArgs(list, 1, 60, 2, 3, 4, 5, 6));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1833,9 +1762,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(reverse, 1, 6, callIfFuncAndRightArgs(list, 1, 14, \\\\\\"string\\\\\\", \\\\\\"null\\\\\\", \\\\\\"undefined\\\\\\", \\\\\\"null\\\\\\", 123)), callIfFuncAndRightArgs(list, 1, 65, 123, \\\\\\"null\\\\\\", \\\\\\"undefined\\\\\\", \\\\\\"null\\\\\\", \\\\\\"string\\\\\\"));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(reverse, 1, 6, callIfFuncAndRightArgs(list, 1, 14, \\\\\\"string\\\\\\", \\\\\\"null\\\\\\", \\\\\\"undefined\\\\\\", \\\\\\"null\\\\\\", 123)), callIfFuncAndRightArgs(list, 1, 65, 123, \\\\\\"null\\\\\\", \\\\\\"undefined\\\\\\", \\\\\\"null\\\\\\", \\\\\\"string\\\\\\"));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -1852,8 +1779,10 @@ set_head(p, 3);
 p === q && equal(p, pair(3, 2));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 4: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -1868,27 +1797,25 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
-    const q = p;
-    callIfFuncAndRightArgs(set_head, 3, 0, p, 3);
-    lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 3, 2));\\");
-    globals.variables.set(\\"p\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return p;
-      },
-      assignNewValue: function (unique) {
-        return p = unique;
-      }
-    });
-    globals.variables.set(\\"q\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return q;
-      }
-    });
-  }
+  let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
+  const q = p;
+  callIfFuncAndRightArgs(set_head, 3, 0, p, 3);
+  lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 3, 2));\\");
+  globals.variables.set(\\"p\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return p;
+    },
+    assignNewValue: function (unique) {
+      return p = unique;
+    }
+  });
+  globals.variables.set(\\"q\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return q;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1905,8 +1832,10 @@ set_tail(p, 3);
 p === q && equal(p, pair(1, 3));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 4: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -1921,27 +1850,25 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
-    const q = p;
-    callIfFuncAndRightArgs(set_tail, 3, 0, p, 3);
-    lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 1, 3));\\");
-    globals.variables.set(\\"p\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return p;
-      },
-      assignNewValue: function (unique) {
-        return p = unique;
-      }
-    });
-    globals.variables.set(\\"q\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return q;
-      }
-    });
-  }
+  let p = callIfFuncAndRightArgs(pair, 1, 8, 1, 2);
+  const q = p;
+  callIfFuncAndRightArgs(set_tail, 3, 0, p, 3);
+  lastStatementResult = eval(\\"boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, p, q, 4, 0), 4, 0) && callIfFuncAndRightArgs(equal, 4, 11, p, callIfFuncAndRightArgs(pair, 4, 20, 1, 3));\\");
+  globals.variables.set(\\"p\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return p;
+    },
+    assignNewValue: function (unique) {
+      return p = unique;
+    }
+  });
+  globals.variables.set(\\"q\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return q;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -1971,9 +1898,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(list, 1, 5, 1));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(list, 1, 5, 1));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -2003,9 +1928,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(tail, 1, 0, callIfFuncAndRightArgs(pair, 1, 5, 1, 'a string \\\\\\"\\\\\\"'));\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/stdlib/__tests__/__snapshots__/misc.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/misc.ts.snap
@@ -167,9 +167,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 2);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 2);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -199,9 +197,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '1100101010101', 2);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, '1100101010101', 2);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -231,9 +227,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 36);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(parse_int, 1, 0, 'uu1', 36);\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/stdlib/__tests__/__snapshots__/stream.ts.snap
+++ b/src/stdlib/__tests__/__snapshots__/stream.ts.snap
@@ -7,8 +7,10 @@ Object {
   , list(\\"string\\", 123, 456, null, undefined));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -23,9 +25,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_append, 1, 21, callIfFuncAndRightArgs(stream, 1, 35, \\\\\\"string\\\\\\", 123), callIfFuncAndRightArgs(stream, 1, 58, 456, null, undefined))), callIfFuncAndRightArgs(list, 2, 4, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_append, 1, 21, callIfFuncAndRightArgs(stream, 1, 35, \\\\\\"string\\\\\\", 123), callIfFuncAndRightArgs(stream, 1, 58, 456, null, undefined))), callIfFuncAndRightArgs(list, 2, 4, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -39,8 +39,10 @@ Object {
   "code": "equal(stream_to_list(build_stream(5, x => x * x)), list(0, 1, 4, 9, 16));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -55,9 +57,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(build_stream, 1, 21, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 3, x, x, 1, 42) }), \\\\\\"x => x * x\\\\\\", native))), callIfFuncAndRightArgs(list, 1, 51, 0, 1, 4, 9, 16));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(build_stream, 1, 21, 5, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 3, x, x, 1, 42) }), \\\\\\"x => x * x\\\\\\", native))), callIfFuncAndRightArgs(list, 1, 51, 0, 1, 4, 9, 16));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -71,8 +71,10 @@ Object {
   "code": "equal(stream_to_list(enum_stream(1.5, 5)), list(1.5, 2.5, 3.5, 4.5));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -87,9 +89,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1.5, 5)), callIfFuncAndRightArgs(list, 1, 43, 1.5, 2.5, 3.5, 4.5));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1.5, 5)), callIfFuncAndRightArgs(list, 1, 43, 1.5, 2.5, 3.5, 4.5));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -103,8 +103,10 @@ Object {
   "code": "equal(stream_to_list(enum_stream(1, 5)), list(1, 2, 3, 4, 5));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -119,9 +121,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1, 5)), callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3, 4, 5));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(enum_stream, 1, 21, 1, 5)), callIfFuncAndRightArgs(list, 1, 41, 1, 2, 3, 4, 5));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -139,8 +139,10 @@ Object {
 , list(2, 1, 3, 4, 2));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -155,9 +157,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_filter, 3, 4, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", 3, x, 4, 3, 23) }), \\\\\\"x => x <= 4\\\\\\", native), callIfFuncAndRightArgs(stream, 3, 31, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000))), callIfFuncAndRightArgs(list, 5, 2, 2, 1, 3, 4, 2));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_filter, 3, 4, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"<=\\\\\\", 3, x, 4, 3, 23) }), \\\\\\"x => x <= 4\\\\\\", native), callIfFuncAndRightArgs(stream, 3, 31, 2, 10, 1000, 1, 3, 100, 4, 5, 2, 1000))), callIfFuncAndRightArgs(list, 5, 2, 2, 1, 3, 4, 2));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -175,8 +175,10 @@ stream_for_each(x => {
 sum;",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": 6,
+  "parsedErrors": "native:\\"Line 2: Name stream_for_each not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:6",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -191,22 +193,20 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    let sum = 0;
-    callIfFuncAndRightArgs(stream_for_each, 2, 0, wrap(x => {
-      sum = binaryOp(\\"+\\", 3, sum, x, 3, 8);
-    }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", native), callIfFuncAndRightArgs(stream, 4, 3, 1, 2, 3));
-    lastStatementResult = eval(\\"sum;\\");
-    globals.variables.set(\\"sum\\", {
-      kind: \\"let\\",
-      getValue: () => {
-        return sum;
-      },
-      assignNewValue: function (unique) {
-        return sum = unique;
-      }
-    });
-  }
+  let sum = 0;
+  callIfFuncAndRightArgs(stream_for_each, 2, 0, wrap(x => {
+    sum = binaryOp(\\"+\\", 3, sum, x, 3, 8);
+  }, \\"x => {\\\\n  sum = sum + x;\\\\n}\\", native), callIfFuncAndRightArgs(stream, 4, 3, 1, 2, 3));
+  lastStatementResult = eval(\\"sum;\\");
+  globals.variables.set(\\"sum\\", {
+    kind: \\"let\\",
+    getValue: () => {
+      return sum;
+    },
+    assignNewValue: function (unique) {
+      return sum = unique;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -220,8 +220,10 @@ Object {
   "code": "stream_ref(stream(1, 2, 3, \\"4\\", 4), 4);",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": 4,
+  "parsedErrors": "native:\\"Line 1: Name stream_ref not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:4",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -236,9 +238,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_ref, 1, 0, callIfFuncAndRightArgs(stream, 1, 11, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_ref, 1, 0, callIfFuncAndRightArgs(stream, 1, 11, 1, 2, 3, \\\\\\"4\\\\\\", 4), 4);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -252,8 +252,10 @@ Object {
   "code": "equal(stream_to_list(stream_map(x => 2 * x, stream(12, 11, 3))), list(24, 22, 6));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -268,9 +270,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_map, 1, 21, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 3, 2, x, 1, 37) }), \\\\\\"x => 2 * x\\\\\\", native), callIfFuncAndRightArgs(stream, 1, 44, 12, 11, 3))), callIfFuncAndRightArgs(list, 1, 65, 24, 22, 6));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_map, 1, 21, wrap(x => ({   isTail: false,   value: binaryOp(\\\\\\"*\\\\\\", 3, 2, x, 1, 37) }), \\\\\\"x => 2 * x\\\\\\", native), callIfFuncAndRightArgs(stream, 1, 44, 12, 11, 3))), callIfFuncAndRightArgs(list, 1, 65, 24, 22, 6));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -286,8 +286,10 @@ Object {
   list(\\"string\\", 123, 456, null, undefined));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -302,9 +304,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_member, 2, 17, \\\\\\"string\\\\\\", callIfFuncAndRightArgs(stream, 2, 41, 1, 2, 3, \\\\\\"string\\\\\\", 123, 456, null, undefined))), callIfFuncAndRightArgs(list, 3, 2, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 2, 2, callIfFuncAndRightArgs(stream_member, 2, 17, \\\\\\"string\\\\\\", callIfFuncAndRightArgs(stream, 2, 41, 1, 2, 3, \\\\\\"string\\\\\\", 123, 456, null, undefined))), callIfFuncAndRightArgs(list, 3, 2, \\\\\\"string\\\\\\", 123, 456, null, undefined));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -334,9 +334,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream, 1, 0);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream, 1, 0);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -353,8 +351,10 @@ stream_for_each(item => {result[array_length(result)] = item;}, s);
 stream_ref(s,4)(22) === 22 && stream_ref(s,7)(pair('', '1')) === '1' && result;",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": false,
+  "parsedErrors": "native:\\"Line 3: Name stream_for_each not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:false",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -369,29 +369,27 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    const s = callIfFuncAndRightArgs(stream, 1, 10, true, false, undefined, 1, wrap(x => ({
-      isTail: false,
-      value: x
-    }), \\"x => x\\", native), null, unaryOp(\\"-\\", 123, 1, 56), head);
-    const result = [];
-    callIfFuncAndRightArgs(stream_for_each, 3, 0, wrap(item => {
-      setProp(result, callIfFuncAndRightArgs(array_length, 3, 32, result), item, 3, 25);
-    }, \\"item => {\\\\n  result[array_length(result)] = item;\\\\n}\\", native), s);
-    lastStatementResult = eval(\\"boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 0, s, 4), 4, 0, 22), 22, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 30, s, 7), 4, 30, callIfFuncAndRightArgs(pair, 4, 46, '', '1')), '1', 4, 30), 4, 0) && result;\\");
-    globals.variables.set(\\"s\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return s;
-      }
-    });
-    globals.variables.set(\\"result\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return result;
-      }
-    });
-  }
+  const s = callIfFuncAndRightArgs(stream, 1, 10, true, false, undefined, 1, wrap(x => ({
+    isTail: false,
+    value: x
+  }), \\"x => x\\", native), null, unaryOp(\\"-\\", 123, 1, 56), head);
+  const result = [];
+  callIfFuncAndRightArgs(stream_for_each, 3, 0, wrap(item => {
+    setProp(result, callIfFuncAndRightArgs(array_length, 3, 32, result), item, 3, 25);
+  }, \\"item => {\\\\n  result[array_length(result)] = item;\\\\n}\\", native), s);
+  lastStatementResult = eval(\\"boolOrErr(boolOrErr(binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 0, s, 4), 4, 0, 22), 22, 4, 0), 4, 0) && binaryOp(\\\\\\"===\\\\\\", 3, callIfFuncAndRightArgs(callIfFuncAndRightArgs(stream_ref, 4, 30, s, 7), 4, 30, callIfFuncAndRightArgs(pair, 4, 46, '', '1')), '1', 4, 30), 4, 0) && result;\\");
+  globals.variables.set(\\"s\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return s;
+    }
+  });
+  globals.variables.set(\\"result\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return result;
+    }
+  });
 }
 forceIt(lastStatementResult);
 ",
@@ -405,11 +403,10 @@ Object {
   "code": "stream_tail(integers_from(0));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": Array [
-    1,
-    [Function],
-  ],
+  "parsedErrors": "native:\\"Line 1: Name integers_from not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:[1, () => integers_from(n + 1)]",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -424,9 +421,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_tail, 1, 0, callIfFuncAndRightArgs(integers_from, 1, 12, 0));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_tail, 1, 0, callIfFuncAndRightArgs(integers_from, 1, 12, 0));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -456,9 +451,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(stream_tail, 1, 5, callIfFuncAndRightArgs(stream, 1, 17, 1, 2)));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(head, 1, 0, callIfFuncAndRightArgs(stream_tail, 1, 5, callIfFuncAndRightArgs(stream, 1, 17, 1, 2)));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -472,8 +465,10 @@ Object {
   "code": "stream_to_list(null);",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": null,
+  "parsedErrors": "native:\\"Line 1: Name stream_to_list not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:null",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -488,9 +483,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, null);\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, null);\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -504,26 +497,10 @@ Object {
   "code": "stream_to_list(stream(1, true, 3, 4.4, [1, 2]));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": Array [
-    1,
-    Array [
-      true,
-      Array [
-        3,
-        Array [
-          4.4,
-          Array [
-            Array [
-              1,
-              2,
-            ],
-            null,
-          ],
-        ],
-      ],
-    ],
-  ],
+  "parsedErrors": "native:\\"Line 1: Name stream_to_list not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:[1, [true, [3, [4.4, [[1, 2], null]]]]]",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -538,9 +515,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream, 1, 15, 1, true, 3, 4.4, [1, 2]));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream, 1, 15, 1, true, 3, 4.4, [1, 2]));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -554,11 +529,10 @@ Object {
   "code": "stream_to_list(stream_remove(2, stream(1)));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": Array [
-    1,
-    null,
-  ],
+  "parsedErrors": "native:\\"Line 1: Name stream_to_list not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:[1, null]",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -573,9 +547,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream_remove, 1, 15, 2, callIfFuncAndRightArgs(stream, 1, 32, 1)));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_to_list, 1, 0, callIfFuncAndRightArgs(stream_remove, 1, 15, 2, callIfFuncAndRightArgs(stream, 1, 32, 1)));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -589,8 +561,10 @@ Object {
   "code": "stream_remove(1, stream(1));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": null,
+  "parsedErrors": "native:\\"Line 1: Name stream_remove not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:null",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -605,9 +579,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_remove, 1, 0, 1, callIfFuncAndRightArgs(stream, 1, 17, 1));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(stream_remove, 1, 0, 1, callIfFuncAndRightArgs(stream, 1, 17, 1));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -621,8 +593,10 @@ Object {
   "code": "equal(stream_to_list(stream_remove_all(1, stream(2, 3, \\"1\\"))), list(2, 3, \\"1\\"));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -637,9 +611,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 2, 3, \\\\\\"1\\\\\\"))), callIfFuncAndRightArgs(list, 1, 63, 2, 3, \\\\\\"1\\\\\\"));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 2, 3, \\\\\\"1\\\\\\"))), callIfFuncAndRightArgs(list, 1, 63, 2, 3, \\\\\\"1\\\\\\"));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -654,8 +626,10 @@ Object {
   list(2, 3, 4, \\"1\\", 5, 6));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -670,9 +644,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 1, 2, 3, 4, 1, 1, \\\\\\"1\\\\\\", 5, 1, 1, 6))), callIfFuncAndRightArgs(list, 2, 2, 2, 3, 4, \\\\\\"1\\\\\\", 5, 6));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_remove_all, 1, 21, 1, callIfFuncAndRightArgs(stream, 1, 42, 1, 2, 3, 4, 1, 1, \\\\\\"1\\\\\\", 5, 1, 1, 6))), callIfFuncAndRightArgs(list, 2, 2, 2, 3, 4, \\\\\\"1\\\\\\", 5, 6));\\");
 }
 forceIt(lastStatementResult);
 ",
@@ -689,8 +661,10 @@ Object {
 list(123, null, undefined, null, \\"string\\"));",
   "displayResult": Array [],
   "errors": Array [],
-  "parsedErrors": "",
-  "result": true,
+  "parsedErrors": "native:\\"Line 1: Name equal not declared.\\"
+interpreted:\\"\\"",
+  "result": "native:undefined
+interpreted:true",
   "resultStatus": "finished",
   "transpiled": "const native = nativeStorage;
 const forceIt = native.operators.get(\\"forceIt\\");
@@ -705,9 +679,7 @@ const getProp = native.operators.get(\\"getProp\\");
 let lastStatementResult = undefined;
 const globals = native.globals;
 {
-  {
-    lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_reverse, 2, 2, callIfFuncAndRightArgs(stream, 3, 4, \\\\\\"string\\\\\\", null, undefined, null, 123))), callIfFuncAndRightArgs(list, 4, 0, 123, null, undefined, null, \\\\\\"string\\\\\\"));\\");
-  }
+  lastStatementResult = eval(\\"callIfFuncAndRightArgs(equal, 1, 0, callIfFuncAndRightArgs(stream_to_list, 1, 6, callIfFuncAndRightArgs(stream_reverse, 2, 2, callIfFuncAndRightArgs(stream, 3, 4, \\\\\\"string\\\\\\", null, undefined, null, 123))), callIfFuncAndRightArgs(list, 4, 0, 123, null, undefined, null, \\\\\\"string\\\\\\"));\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/stdlib/__tests__/lazyLists.ts
+++ b/src/stdlib/__tests__/lazyLists.ts
@@ -56,7 +56,10 @@ test('for_each', () => {
     sum;
   `,
     { chapter: 3, native: true, variant: 'lazy' }
-  ).toMatchInlineSnapshot(`6`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:6"
+          `)
 })
 
 test('map', () => {

--- a/src/stdlib/__tests__/list.ts
+++ b/src/stdlib/__tests__/list.ts
@@ -91,7 +91,10 @@ test('for_each', () => {
     sum;
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`6`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:6"
+          `)
 })
 
 test('map', () => {
@@ -264,7 +267,10 @@ test('set_head', () => {
     p === q && equal(p, pair(3, 2));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('set_tail', () => {
@@ -276,7 +282,10 @@ test('set_tail', () => {
     p === q && equal(p, pair(1, 3));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('non-list error head', () => {
@@ -308,9 +317,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     length([1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 34: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name length not declared.\\"
+              interpreted:\\"Line 34: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error map', () => {
@@ -319,9 +329,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     map(x=>x, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 43: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name map not declared.\\"
+              interpreted:\\"Line 43: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error for_each', () => {
@@ -330,9 +341,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     for_each(x=>x, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 68: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name for_each not declared.\\"
+              interpreted:\\"Line 68: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error reverse', () => {
@@ -341,9 +353,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     reverse([1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 90: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name reverse not declared.\\"
+              interpreted:\\"Line 90: Error: tail(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error append', () => {
@@ -352,9 +365,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     append([1, 2, 3], list(1, 2, 3));
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 101: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name append not declared.\\"
+              interpreted:\\"Line 101: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error member', () => {
@@ -363,9 +377,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     member(1, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 110: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name member not declared.\\"
+              interpreted:\\"Line 110: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error remove', () => {
@@ -374,9 +389,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     remove(1, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 118: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name remove not declared.\\"
+              interpreted:\\"Line 118: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error remove_all', () => {
@@ -385,9 +401,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     remove_all(1, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 127: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name remove_all not declared.\\"
+              interpreted:\\"Line 127: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error assoc', () => {
@@ -405,9 +422,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     filter(x => true, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(
-      `"Line 139: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]"`
-    )
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name filter not declared.\\"
+              interpreted:\\"Line 139: Error: head(xs) expects a pair as argument xs, but encountered [1, 2, 3]\\""
+            `)
   })
 
   test('non-list error accumulate', () => {
@@ -416,7 +434,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     accumulate((x, y) => x + y, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(`"Line 1: Expected 3 arguments, but got 2."`)
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name accumulate not declared.\\"
+              interpreted:\\"Line 1: Expected 3 arguments, but got 2.\\""
+            `)
   })
 
   test('non-list error accumulate', () => {
@@ -425,7 +446,10 @@ describe('These tests are reporting weird line numbers, as list functions are no
     accumulate((x, y) => x + y, [1, 2, 3]);
   `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(`"Line 1: Expected 3 arguments, but got 2."`)
+    ).toMatchInlineSnapshot(`
+              "native:\\"Line 1: Name accumulate not declared.\\"
+              interpreted:\\"Line 1: Expected 3 arguments, but got 2.\\""
+            `)
   })
 
   test('non-list error set_head', () => {

--- a/src/stdlib/__tests__/stream.ts
+++ b/src/stdlib/__tests__/stream.ts
@@ -17,11 +17,9 @@ describe('primitive stream functions', () => {
     `),
       { chapter: 3, native: true }
     ).toMatchInlineSnapshot(`
-Array [
-  1,
-  [Function],
-]
-`)
+              "native:undefined
+              interpreted:[1, () => integers_from(n + 1)]"
+            `)
   })
 
   test('infinite stream is infinite', () => {
@@ -42,14 +40,20 @@ Array [
     stream_ref(s,4)(22) === 22 && stream_ref(s,7)(pair('', '1')) === '1' && result;
     `,
       { chapter: 3, native: true }
-    ).toMatchInlineSnapshot(`false`)
+    ).toMatchInlineSnapshot(`
+              "native:undefined
+              interpreted:false"
+            `)
   })
 
   test('stream_to_list works for null', () => {
     return expectResult(`stream_to_list(null);`, {
       chapter: 3,
       native: true
-    }).toMatchInlineSnapshot(`null`)
+    }).toMatchInlineSnapshot(`
+              "native:undefined
+              interpreted:null"
+            `)
   })
 
   test('stream_to_list works', () => {
@@ -57,26 +61,9 @@ Array [
       chapter: 3,
       native: true
     }).toMatchInlineSnapshot(`
-Array [
-  1,
-  Array [
-    true,
-    Array [
-      3,
-      Array [
-        4.4,
-        Array [
-          Array [
-            1,
-            2,
-          ],
-          null,
-        ],
-      ],
-    ],
-  ],
-]
-`)
+              "native:undefined
+              interpreted:[1, [true, [3, [4.4, [[1, 2], null]]]]]"
+            `)
   })
 })
 
@@ -90,7 +77,10 @@ test('for_each', () => {
     sum;
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`6`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:6"
+          `)
 })
 
 test('map', () => {
@@ -99,7 +89,10 @@ test('map', () => {
     equal(stream_to_list(stream_map(x => 2 * x, stream(12, 11, 3))), list(24, 22, 6));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('filter', () => {
@@ -112,7 +105,10 @@ test('filter', () => {
     , list(2, 1, 3, 4, 2));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('build_list', () => {
@@ -121,7 +117,10 @@ test('build_list', () => {
     equal(stream_to_list(build_stream(5, x => x * x)), list(0, 1, 4, 9, 16));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('reverse', () => {
@@ -133,7 +132,10 @@ test('reverse', () => {
     list(123, null, undefined, null, "string"));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('append', () => {
@@ -143,7 +145,10 @@ test('append', () => {
       , list("string", 123, 456, null, undefined));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('member', () => {
@@ -154,7 +159,10 @@ test('member', () => {
       list("string", 123, 456, null, undefined));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('remove', () => {
@@ -163,7 +171,10 @@ test('remove', () => {
     stream_remove(1, stream(1));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`null`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:null"
+          `)
 })
 
 test('remove not found', () => {
@@ -173,11 +184,9 @@ test('remove not found', () => {
   `,
     { chapter: 3, native: true }
   ).toMatchInlineSnapshot(`
-Array [
-  1,
-  null,
-]
-`)
+            "native:undefined
+            interpreted:[1, null]"
+          `)
 })
 
 test('remove_all', () => {
@@ -187,7 +196,10 @@ test('remove_all', () => {
       list(2, 3, 4, "1", 5, 6));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('remove_all not found', () => {
@@ -196,7 +208,10 @@ test('remove_all not found', () => {
     equal(stream_to_list(stream_remove_all(1, stream(2, 3, "1"))), list(2, 3, "1"));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('enum_list', () => {
@@ -205,7 +220,10 @@ test('enum_list', () => {
     equal(stream_to_list(enum_stream(1, 5)), list(1, 2, 3, 4, 5));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('enum_list with floats', () => {
@@ -214,7 +232,10 @@ test('enum_list with floats', () => {
     equal(stream_to_list(enum_stream(1.5, 5)), list(1.5, 2.5, 3.5, 4.5));
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`true`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:true"
+          `)
 })
 
 test('list_ref', () => {
@@ -223,5 +244,8 @@ test('list_ref', () => {
     stream_ref(stream(1, 2, 3, "4", 4), 4);
   `,
     { chapter: 3, native: true }
-  ).toMatchInlineSnapshot(`4`)
+  ).toMatchInlineSnapshot(`
+            "native:undefined
+            interpreted:4"
+          `)
 })

--- a/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
@@ -88,42 +88,40 @@ const globals = native0.globals;
   const list_to_stream = globals.previousScope.variables.get(\\"list_to_stream\\").getValue();
   const parse = globals.previousScope.variables.get(\\"parse\\").getValue();
   const apply_in_underlying_javascript = globals.previousScope.variables.get(\\"apply_in_underlying_javascript\\").getValue();
-  {
-    const boolOrErr = 1;
-    setProp(boolOrErr, 123, 1, 2, 0);
-    const f = wrap90((callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) => {
-      let wrap = 2;
-      wrap0;
-      wrap1;
-      wrap2;
-      wrap3;
-      wrap4;
-      wrap5;
-      wrap6;
-      wrap7;
-      wrap8;
-      wrap9;
-    }, \\"function f(callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) {\\\\n  let wrap = 2;\\\\n  wrap0;\\\\n  wrap1;\\\\n  wrap2;\\\\n  wrap3;\\\\n  wrap4;\\\\n  wrap5;\\\\n  wrap6;\\\\n  wrap7;\\\\n  wrap8;\\\\n  wrap9;\\\\n}\\", native0);
-    const native = 123;
-    globals.variables.set(\\"boolOrErr\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return boolOrErr;
-      }
-    });
-    globals.variables.set(\\"f\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return f;
-      }
-    });
-    globals.variables.set(\\"native\\", {
-      kind: \\"const\\",
-      getValue: () => {
-        return native;
-      }
-    });
-  }
+  const boolOrErr = 1;
+  setProp(boolOrErr, 123, 1, 2, 0);
+  const f = wrap90((callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) => {
+    let wrap = 2;
+    wrap0;
+    wrap1;
+    wrap2;
+    wrap3;
+    wrap4;
+    wrap5;
+    wrap6;
+    wrap7;
+    wrap8;
+    wrap9;
+  }, \\"function f(callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) {\\\\n  let wrap = 2;\\\\n  wrap0;\\\\n  wrap1;\\\\n  wrap2;\\\\n  wrap3;\\\\n  wrap4;\\\\n  wrap5;\\\\n  wrap6;\\\\n  wrap7;\\\\n  wrap8;\\\\n  wrap9;\\\\n}\\", native0);
+  const native = 123;
+  globals.variables.set(\\"boolOrErr\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return boolOrErr;
+    }
+  });
+  globals.variables.set(\\"f\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return f;
+    }
+  });
+  globals.variables.set(\\"native\\", {
+    kind: \\"const\\",
+    getValue: () => {
+      return native;
+    }
+  });
 }
 forceIt(lastStatementResult);
 "
@@ -219,9 +217,7 @@ const globals = native.globals;
   const list_to_stream = globals.previousScope.variables.get(\\"list_to_stream\\").getValue();
   const parse = globals.previousScope.variables.get(\\"parse\\").getValue();
   const apply_in_underlying_javascript = globals.previousScope.variables.get(\\"apply_in_underlying_javascript\\").getValue();
-  {
-    lastStatementResult = eval(\\"\\\\\\"ensure_builtins\\\\\\";\\");
-  }
+  lastStatementResult = eval(\\"\\\\\\"ensure_builtins\\\\\\";\\");
 }
 forceIt(lastStatementResult);
 ",

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -133,9 +133,9 @@ function wrapWithPreviouslyDeclaredGlobals(
   nativeStorage: NativeStorage,
   globalIds: NativeIds
 ) {
-  let currentVariableScope = nativeStorage.globals!.previousScope
-  let timesToGoUp = 1
-  let wrapped = create.blockStatement(statements)
+  let currentVariableScope = nativeStorage.globals!
+  let timesToGoUp = 0
+  let wrapped = statements
   while (currentVariableScope !== null) {
     const initialisingStatements: es.Statement[] = []
     currentVariableScope.variables.forEach(({ kind }: ValueWrapper, name: string) => {
@@ -156,10 +156,10 @@ function wrapWithPreviouslyDeclaredGlobals(
       initialisingStatements.push(create.declaration(name, kind, unwrappedValueAst))
     })
     timesToGoUp += 1
-    currentVariableScope = currentVariableScope.previousScope
-    wrapped = create.blockStatement([...initialisingStatements, wrapped])
+    currentVariableScope = currentVariableScope.previousScope!
+    wrapped = [...initialisingStatements, ...wrapped]
   }
-  return wrapped
+  return create.blockStatement(wrapped)
 }
 
 function createStatementsToStoreCurrentlyDeclaredGlobals(
@@ -806,13 +806,16 @@ export function transpile(
   program: es.Program,
   context: Context,
   skipUndefinedVariableErrors = false,
-  variant: Variant = 'default'
+  variant: Variant = 'default',
+  redeclareVariables: boolean = true
 ) {
   const usedIdentifiers = getAllIdentifiersUsed(program, context.nativeStorage)
   const globalIds = getNativeIds(program, usedIdentifiers)
-  context.nativeStorage.globals = {
-    variables: new Map(),
-    previousScope: context.nativeStorage.globals
+  if (redeclareVariables) {
+    context.nativeStorage.globals = {
+      variables: new Map(),
+      previousScope: context.nativeStorage.globals
+    }
   }
   if (program.body.length === 0) {
     return { transpiled: '' }


### PR DESCRIPTION
`runInContext` to accept a fourth parameter, where it allows no creation of new variables. Technical changes mirrors [Native Same Env](https://github.com/source-academy/js-slang/tree/native_same_env) branch.