### PR TITLE
Refactor GPU into a Source -> Source transformation 

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -249,6 +249,15 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       // tslint:disable-next-line:ban-types
       (fun: Function, args: Value) => fun.apply(fun, list_to_vector(args))
     )
+
+    if (context.variant === 'gpu') {
+      defineBuiltin(context, '__clearKernelCache()', gpu_lib.__clearKernelCache)
+      defineBuiltin(
+        context,
+        '__createKernelSource(shape, extern, localNames, output, fun, kernelId)',
+        gpu_lib.__createKernelSource
+      )
+    }
   }
 
   if (context.chapter >= 100) {

--- a/src/gpu/__tests__/noTranspile.ts
+++ b/src/gpu/__tests__/noTranspile.ts
@@ -1,17 +1,20 @@
+import { generate } from 'astring'
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
 import { stripIndent } from '../../utils/formatters'
-import { transpile } from '../../transpiler/transpiler'
+import { transpileToGPU } from '../../gpu/gpu'
 
 test('empty for loop does not get transpiled', () => {
   const code = stripIndent`
     for (let i = 0; i < 10; i = i + 1) {}
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with different update does not get transpiled', () => {
@@ -22,10 +25,12 @@ test('simple for loop with different update does not get transpiled', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with different loop variables does not get transpiled', () => {
@@ -37,10 +42,12 @@ test('simple for loop with different loop variables does not get transpiled', ()
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with const initialization does not get transpiled', () => {
@@ -52,10 +59,12 @@ test('simple for loop with const initialization does not get transpiled', () => 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with non-zero initialization does not get transpiled', () => {
@@ -66,10 +75,12 @@ test('simple for loop with non-zero initialization does not get transpiled', () 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with a function end counter does not get transpiled', () => {
@@ -81,10 +92,12 @@ test('simple for loop with a function end counter does not get transpiled', () =
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with different initialization does not get transpiled', () => {
@@ -96,10 +109,12 @@ test('simple for loop with different initialization does not get transpiled', ()
       }
       `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with global variable update does not get transpiled', () => {
@@ -112,10 +127,12 @@ test('simple for loop with global variable update does not get transpiled', () =
       }
       `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with function call does not get transpiled', () => {
@@ -128,10 +145,12 @@ test('simple for loop with function call does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('simple for loop with double update does not get transpiled', () => {
@@ -143,10 +162,12 @@ test('simple for loop with double update does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('2 for loops with wrong indice order does not get transpiled', () => {
@@ -159,10 +180,12 @@ test('2 for loops with wrong indice order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('2 for loops with wrong indices order does not get transpiled', () => {
@@ -175,10 +198,12 @@ test('2 for loops with wrong indices order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('2 for loop case with 2 indices being written + use of result variable[i-1][j] does not get transpiled', () => {
@@ -200,9 +225,11 @@ test('2 for loop case with 2 indices being written + use of result variable[i-1]
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('3 for loops with wrong indice order does not get transpiled', () => {
@@ -217,10 +244,12 @@ test('3 for loops with wrong indice order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })
 
 test('3 for loops with wrong indice order does not get transpiled', () => {
@@ -235,8 +264,10 @@ test('3 for loops with wrong indice order does not get transpiled', () => {
         }
         `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(2)
+  const cnt = transpiled.match(/__createKernelSource/g)
+  expect(cnt).toEqual(null)
 })

--- a/src/gpu/__tests__/transpile.ts
+++ b/src/gpu/__tests__/transpile.ts
@@ -1,7 +1,8 @@
+import { generate } from 'astring'
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
 import { stripIndent } from '../../utils/formatters'
-import { transpile } from '../../transpiler/transpiler'
+import { transpileToGPU } from '../../gpu/gpu'
 
 test('simple for loop gets transpiled correctly', () => {
   const code = stripIndent`
@@ -11,10 +12,12 @@ test('simple for loop gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('many simple for loop gets transpiled correctly', () => {
@@ -30,10 +33,12 @@ test('many simple for loop gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(4)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(2)
 })
 
 test('simple for loop with constant condition transpiled correctly', () => {
@@ -45,9 +50,12 @@ test('simple for loop with constant condition transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
+
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('simple for loop with let condition transpiled correctly', () => {
@@ -59,10 +67,12 @@ test('simple for loop with let condition transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('simple for loop with math function call transpiled correctly', () => {
@@ -74,10 +84,12 @@ test('simple for loop with math function call transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('simple for loop with different end condition transpiled correctly', () => {
@@ -90,10 +102,12 @@ test('simple for loop with different end condition transpiled correctly', () => 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('2 for loop case gets transpiled correctly', () => {
@@ -106,10 +120,12 @@ test('2 for loop case gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('2 for loop case with body gets transpiled correctly', () => {
@@ -124,10 +140,12 @@ test('2 for loop case with body gets transpiled correctly', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('2 for loop case with 2 indices being written to gets transpiled correctly', () => {
@@ -140,10 +158,12 @@ test('2 for loop case with 2 indices being written to gets transpiled correctly'
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('2 for loop case with 2 indices being written + local updates to gets transpiled correctly', () => {
@@ -166,10 +186,12 @@ test('2 for loop case with 2 indices being written + local updates to gets trans
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('2 for loop case with 2 indices being written + use of result variable[i][j] gets transpiled', () => {
@@ -191,9 +213,12 @@ test('2 for loop case with 2 indices being written + use of result variable[i][j
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
+
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('3 for loop case with 1 index being written to gets transpiled correctly', () => {
@@ -208,10 +233,12 @@ test('3 for loop case with 1 index being written to gets transpiled correctly', 
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('3 for loop case with 2 indices being written to gets transpiled correctly', () => {
@@ -226,10 +253,12 @@ test('3 for loop case with 2 indices being written to gets transpiled correctly'
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('3 for loop case with 3 indices being written to gets transpiled correctly', () => {
@@ -244,10 +273,12 @@ test('3 for loop case with 3 indices being written to gets transpiled correctly'
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(3)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
 })
 
 test('many for loop case - matrix multiplication (2 transpilations)', () => {
@@ -280,15 +311,17 @@ test('many for loop case - matrix multiplication (2 transpilations)', () => {
     }
   `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  const cnt = transpiled.match(/__createKernel/g)?.length
-  expect(cnt).toEqual(4)
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(2)
 })
 
-test('resolve naming conflicts if __createKernel is used', () => {
+test('resolve naming conflicts by disabling automatic optimizations', () => {
   const code = stripIndent`
-    const __createKernel = 10;
+    const __createKernelSource = 10;
 
     let res = [];
     for (let i = 0; i < 5; i = i + 1) {
@@ -296,9 +329,15 @@ test('resolve naming conflicts if __createKernel is used', () => {
     }
     `
   const context = mockContext(4, 'gpu')
-  const transpiled = transpile(parse(code, context)!, context, false, context.variant).transpiled
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
 
-  // a new kernel function with name __createKernel0 should be created here
-  const cntNewName = transpiled.match(/__createKernel0/g)?.length
-  expect(cntNewName).toEqual(2)
+  // a new kernel function with name __createKernelSource0 should be created here
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1) // Occurrence comes from the warning below
+  const cntWarnings = transpiled.match(
+    /display\("Manual use of GPU library symbols detected, turning off automatic GPU optimizations."\)/g
+  )?.length
+  expect(cntWarnings).toEqual(1)
 })

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -4,24 +4,25 @@ import * as create from '../utils/astCreator'
 import GPULoopVerifier from './verification/loopVerifier'
 import GPUBodyVerifier from './verification/bodyVerifier'
 
+let currentKernelId = 0
 /*
  * GPU Transformer runs through the program and transpiles for loops to GPU code
  * Upon termination, the AST would be mutated accordingly
  * e.g.
- * let res = 0;
+ * let res = [];
  * for (let i = 0; i < 5; i = i + 1) {
  *    res[i] = 5;
  * }
  * would become:
  * let res = 0;
- * __createKernel(....)
+ * __createKernelSource(....)
  */
 class GPUTransformer {
   // program to mutate
   program: es.Program
 
   // helps reference the main function
-  globalIds: { __createKernel: es.Identifier }
+  globalIds: { __createKernelSource: es.Identifier }
 
   outputArray: es.Identifier
   innerBody: any
@@ -32,10 +33,10 @@ class GPUTransformer {
   outerVariables: any
   targetBody: any
 
-  constructor(program: es.Program, createKernel: es.Identifier) {
+  constructor(program: es.Program, createKernelSource: es.Identifier) {
     this.program = program
     this.globalIds = {
-      __createKernel: createKernel
+      __createKernelSource: createKernelSource
     }
   }
 
@@ -68,10 +69,7 @@ class GPUTransformer {
    * 2. Get external variables + target body (body to be run across gpu threads)
    * 3. Build a AST Node for (2) - this will be given to (8)
    * 4. Change assignment in body to a return statement
-   * 5. In body, update all math_* calls to become Math.* calls
-   * 6. In body, update all external variable references
-   * 7. In body, update reference to counters
-   * 8. Call __createKernel and assign it to our external variable
+   * 5. Call __createKernelSource and assign it to our external variable
    */
   gpuTranspile = (node: es.ForStatement): number => {
     // initialize our class variables
@@ -100,14 +98,14 @@ class GPUTransformer {
     this.getTargetBody(node)
 
     // 3. Build a AST Node of all outer variables
-    const externObject: es.Property[] = []
+    const externEntries: [es.Literal, es.Expression][] = []
     for (const key in this.outerVariables) {
       if (this.outerVariables.hasOwnProperty(key)) {
         const val = this.outerVariables[key]
 
         // push in a deep copy of the identifier
         // this is needed cos we modify it later
-        externObject.push(create.property(key, JSON.parse(JSON.stringify(val))))
+        externEntries.push([create.literal(key), JSON.parse(JSON.stringify(val))])
       }
     }
 
@@ -140,100 +138,26 @@ class GPUTransformer {
     for (let i = 0; i < this.state; i++) {
       params.push(create.identifier(this.counters[i]))
     }
-    const tempNode = create.functionExpression(params, JSON.parse(JSON.stringify(this.targetBody)))
 
-    // 5. Update all math_* calls to become Math.*
-    simple(this.targetBody, {
-      CallExpression(nx: es.CallExpression) {
-        if (nx.callee.type !== 'Identifier') {
-          return
-        }
-
-        const functionName = nx.callee.name
-        const term = functionName.split('_')[1]
-        const args: es.Expression[] = nx.arguments as any
-
-        create.mutateToCallExpression(
-          nx,
-          create.memberExpression(create.identifier('Math'), term),
-          args
-        )
-      }
-    })
-
-    // 6. Update all external variable references in body
-    // e.g. let res = 1 + y; where y is an external variable
-    // becomes let res = 1 + this.constants.y;
-
-    const names = [this.outputArray.name, ...this.counters, 'Math']
-    simple(this.targetBody, {
-      Identifier(nx: es.Identifier) {
-        // ignore these names
-        if (names.includes(nx.name) || locals.has(nx.name)) {
-          return
-        }
-
-        create.mutateToMemberExpression(
-          nx,
-          create.memberExpression(create.identifier('this'), 'constants'),
-          create.identifier(nx.name)
-        )
-      }
-    })
-
-    // 7. Update reference to counters
-    // e.g. let res = 1 + i; where i is a counter
-    // becomes let res = 1 + this.thread.x;
-
-    // depending on state the mappings will change
-    let threads = ['x']
-    if (this.state === 2) threads = ['y', 'x']
-    if (this.state === 3) threads = ['z', 'y', 'x']
-
-    const counters: string[] = []
-    for (let i = 0; i < this.state; i = i + 1) {
-      counters.push(this.counters[i])
-    }
-
-    simple(this.targetBody, {
-      Identifier(nx: es.Identifier) {
-        let x = -1
-        for (let i = 0; i < counters.length; i = i + 1) {
-          if (nx.name === counters[i]) {
-            x = i
-            break
-          }
-        }
-
-        if (x === -1) {
-          return
-        }
-
-        const id = threads[x]
-        create.mutateToMemberExpression(
-          nx,
-          create.memberExpression(create.identifier('this'), 'thread'),
-          create.identifier(id)
-        )
-      }
-    })
-
-    // 8. we transpile the loop to a function call, __createKernel
-    const kernelFunction = create.functionExpression([], this.targetBody)
-    create.mutateToExpressionStatement(
-      node,
-      create.callExpression(
-        this.globalIds.__createKernel,
-        [
-          create.arrayExpression(this.end),
-          create.objectExpression(externObject),
-          kernelFunction,
-          this.outputArray,
-          tempNode
-        ],
-        node.loc!
-      )
+    // 5. we transpile the loop to a function call, __createKernelSource
+    const kernelFunction = create.blockArrowFunction(
+      this.counters.map(create.identifier),
+      this.targetBody
     )
+    const createKernelSourceCall = create.callExpression(
+      this.globalIds.__createKernelSource,
+      [
+        create.arrayExpression(this.end),
+        create.arrayExpression(externEntries.map(create.arrayExpression)),
+        create.arrayExpression(Array.from(locals.values()).map(v => create.literal(v))),
+        this.outputArray,
+        kernelFunction,
+        create.literal(currentKernelId++)
+      ],
+      node.loc!
+    )
+
+    create.mutateToExpressionStatement(node, createKernelSourceCall)
 
     return this.state
   }
@@ -316,6 +240,100 @@ class GPUTransformer {
     })
     this.outerVariables = varDefinitions
   }
+}
+
+/*
+ * Here we transpile a source-syntax kernel function to a gpu.js kernel function
+ * 0. No need for validity checks, as that is done at compile time in gpuTranspile
+ * 1. In body, update all math_* calls to become Math.* calls
+ * 2. In body, update all external variable references
+ * 3. In body, update reference to counters
+ */
+export function gpuRuntimeTranspile(
+  node: es.ArrowFunctionExpression,
+  localNames: Set<string>
+): es.BlockStatement {
+  // Contains counters
+  const params = (node.params as es.Identifier[]).map(v => v.name)
+
+  // body here is the loop body transformed into a function of the indices.
+  // We need to finish the transformation to a gpu.js kernel function by renaming stuff.
+  const body = node.body as es.BlockStatement
+
+  // 1. Update all math_* calls to become Math.*
+  simple(body, {
+    CallExpression(nx: es.CallExpression) {
+      if (nx.callee.type !== 'Identifier') {
+        return
+      }
+
+      const functionName = nx.callee.name
+      const term = functionName.split('_')[1]
+      const args: es.Expression[] = nx.arguments as any
+
+      create.mutateToCallExpression(
+        nx,
+        create.memberExpression(create.identifier('Math'), term),
+        args
+      )
+    }
+  })
+
+  // 2. Update all external variable references in body
+  // e.g. let res = 1 + y; where y is an external variable
+  // becomes let res = 1 + this.constants.y;
+
+  const ignoredNames: Set<string> = new Set([...params, 'Math'])
+  simple(body, {
+    Identifier(nx: es.Identifier) {
+      // ignore these names
+      if (ignoredNames.has(nx.name) || localNames.has(nx.name)) {
+        return
+      }
+
+      create.mutateToMemberExpression(
+        nx,
+        create.memberExpression(create.identifier('this'), 'constants'),
+        create.identifier(nx.name)
+      )
+    }
+  })
+
+  // 3. Update reference to counters
+  // e.g. let res = 1 + i; where i is a counter
+  // becomes let res = 1 + this.thread.x;
+
+  // depending on state the mappings will change
+  let threads = ['x']
+  if (params.length === 2) threads = ['y', 'x']
+  if (params.length === 3) threads = ['z', 'y', 'x']
+
+  const counters: string[] = params.slice()
+
+  simple(body, {
+    Identifier(nx: es.Identifier) {
+      let x = -1
+      for (let i = 0; i < counters.length; i = i + 1) {
+        if (nx.name === counters[i]) {
+          x = i
+          break
+        }
+      }
+
+      if (x === -1) {
+        return
+      }
+
+      const id = threads[x]
+      create.mutateToMemberExpression(
+        nx,
+        create.memberExpression(create.identifier('this'), 'thread'),
+        create.identifier(id)
+      )
+    }
+  })
+
+  return body
 }
 
 export default GPUTransformer

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
 import { redexify, getEvaluationSteps, IStepperPropContents } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
 import { transpile } from './transpiler/transpiler'
+import { transpileToGPU } from './gpu/gpu'
 import {
   Context,
   Error as ResultError,
@@ -465,6 +466,11 @@ export async function runInContext(
     let sourceMapJson: RawSourceMap | undefined
     let lastStatementSourceMapJson: RawSourceMap | undefined
     try {
+      if (context.variant === 'gpu') {
+        // Mutates program
+        transpileToGPU(program)
+      }
+
       const temp = transpile(program, context, false, context.variant)
       // some issues with formatting and semicolons and tslint so no destructure
       transpiled = temp.transpiled

--- a/src/utils/uniqueIds.ts
+++ b/src/utils/uniqueIds.ts
@@ -1,0 +1,49 @@
+import { simple } from 'acorn-walk/dist/walk'
+import * as es from 'estree'
+import { NativeStorage } from '../types'
+
+export function getUniqueId(usedIdentifiers: Set<string>, uniqueId = 'unique') {
+  while (usedIdentifiers.has(uniqueId)) {
+    const start = uniqueId.slice(0, -1)
+    const end = uniqueId[uniqueId.length - 1]
+    const endToDigit = Number(end)
+    if (Number.isNaN(endToDigit) || endToDigit === 9) {
+      uniqueId += '0'
+    } else {
+      uniqueId = start + String(endToDigit + 1)
+    }
+  }
+  usedIdentifiers.add(uniqueId)
+  return uniqueId
+}
+
+export function getIdentifiersInNativeStorage(nativeStorage: NativeStorage) {
+  const identifiers = new Set<string>()
+  let variableScope = nativeStorage.globals
+  while (variableScope !== null) {
+    for (const name of variableScope.variables.keys()) {
+      identifiers.add(name)
+    }
+    variableScope = variableScope.previousScope
+  }
+  return identifiers
+}
+
+export function getIdentifiersInProgram(program: es.Program) {
+  const identifiers = new Set<string>()
+  simple(program, {
+    Identifier(node: es.Identifier) {
+      identifiers.add(node.name)
+    },
+    Pattern(node: es.Pattern) {
+      if (node.type === 'Identifier') {
+        identifiers.add(node.name)
+      } else if (node.type === 'MemberExpression') {
+        if (node.object.type === 'Identifier') {
+          identifiers.add(node.object.name)
+        }
+      }
+    }
+  })
+  return identifiers
+}


### PR DESCRIPTION
This tries to slightly decouple GPU code from the Source -> JS transpiler.

This is in anticipation of future transpiler changes, so those changes can be made more confidently.

----

This is done by adding a small Source-compatible adapter for the gpu.js library, and having automatic loop -> gpu.js rewriting become a Source -> Source transformation that calls this adapter.

For example, the following Source program

```
let res = [];
for (let i = 0; i < 5; i = i + 1) {
  res[i] = i;
}
res;
```

is first transformed to another valid Source program

```
display("Attempting to optimize the loop on line 2");
__clearKernelCache();
let res = [];
__createKernelSource([5], [], [], res, i => {
  return i;
}, 0);
res;
```

which demonstrates automatic GPU optimization. After this, the transpiler runs as usual.

One behaviour change is when the user wants to use the GPU library themselves, or if they're trying to break the implementation. Before, we would continue with optimization by creating a unique symbol to load the GPU library. Now, we simply disable automatic GPU optimization.

```
const __createKernelSource = 10;
let res = [];
for (let i = 0; i < 5; i = i + 1) {
  res[i] = i;
}
```

gets transformed to

```
display("Manual use of GPU library symbols detected, turning off automatic GPU optimizations.");
const __createKernelSource = 10;
let res = [];
for (let i = 0; i < 5; i = i + 1) {
  res[i] = i;
}
```

to warn the user that the loop optimization is no longer being done automatically.