### PR TITLE
Support toReplString, allowing overriding of `stringify` default behaviour

### DIFF
--- a/src/__tests__/__snapshots__/stringify.ts.snap
+++ b/src/__tests__/__snapshots__/stringify.ts.snap
@@ -866,6 +866,51 @@ forceIt(lastStatementResult);
 }
 `;
 
+exports[`String representation of objects with toReplString member calls toReplString: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "const o = { toReplString: () => '<RUNE>' };
+stringify(o);",
+  "displayResult": Array [],
+  "errors": Array [],
+  "parsedErrors": "",
+  "result": "<RUNE>",
+  "resultStatus": "finished",
+  "transpiled": "const native = nativeStorage;
+const forceIt = native.operators.get(\\"forceIt\\");
+const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
+const boolOrErr = native.operators.get(\\"boolOrErr\\");
+const wrap = native.operators.get(\\"wrap\\");
+const unaryOp = native.operators.get(\\"unaryOp\\");
+const binaryOp = native.operators.get(\\"binaryOp\\");
+const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");
+const setProp = native.operators.get(\\"setProp\\");
+const getProp = native.operators.get(\\"getProp\\");
+let lastStatementResult = undefined;
+const globals = native.globals;
+{
+  {
+    const o = {
+      toReplString: wrap(() => ({
+        isTail: false,
+        value: '<RUNE>'
+      }), \\"() => '<RUNE>'\\", native)
+    };
+    lastStatementResult = eval(\\"callIfFuncAndRightArgs(stringify, 2, 0, o);\\");
+    globals.variables.set(\\"o\\", {
+      kind: \\"const\\",
+      getValue: () => {
+        return o;
+      }
+    });
+  }
+}
+forceIt(lastStatementResult);
+",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`String representation of strings are nice: expectResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/__tests__/stringify.ts
+++ b/src/__tests__/stringify.ts
@@ -319,6 +319,16 @@ test('String representation of objects are nice', () => {
   ).toMatchInlineSnapshot(`"{\\"a\\": 1, \\"b\\": true, \\"c\\": () => 1}"`)
 })
 
+test('String representation of objects with toReplString member calls toReplString', () => {
+  return expectResult(
+    stripIndent`
+  const o = { toReplString: () => '<RUNE>' };
+  stringify(o);
+  `,
+    { chapter: 100, native: true }
+  ).toMatchInlineSnapshot(`"<RUNE>"`)
+})
+
 test('String representation of nested objects are nice', () => {
   return expectResult(
     stripIndent`

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -117,6 +117,8 @@ ${indentify(indentString.repeat(indentLevel), valueStrs[1])}${arrSuffix}`
       return v.toString()
     } else if (ancestors.size > MAX_LIST_DISPLAY_LENGTH) {
       return '...<truncated>'
+    } else if (typeof v.toReplString === 'function') {
+      return v.toReplString()
     } else if (Array.isArray(v)) {
       return stringifyArray(v, indentLevel)
     } else {


### PR DESCRIPTION
Needed for https://github.com/source-academy/cadet-frontend/pull/1441