### PR TITLE
Stepper error check

### DIFF
--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1670,7 +1670,7 @@ function pathifyMain(
       if (path[pathIndex] === 'left') {
         if (pathIndex === endIndex) {
           redex = left
-          if (redex.type === 'BinaryExpression' || redex.type === 'ConditionalExpression') {
+          if (redex.type === 'ConditionalExpression') {
             left = withBrackets as es.Expression
           } else {
             left = redexMarker as es.Expression


### PR DESCRIPTION
Added error checking to stepper: the code is run normally in the editor first, then if the result returns an error, an error is returned in the stepper as well.

The error message directs students to check their code in the editor, which is more useful compared to before, when the stepper would just not run if the code is erroneous. The error check also prevents issues where the stepper evaluates the code wrongly (due to issues such as variable capture) when the editor throws an error.

![image](https://user-images.githubusercontent.com/54243224/92300852-dcfb3080-ef90-11ea-9f82-76a530c6f550.png)

Also included: fix to #736 that makes bracketing more consistent.
