### PR TITLE
Updates README.md to use yarn link rather than manual copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,18 @@ A common issue when developing modifications to js-slang is how to test
 it using your own local frontend. Assume that you have built your own
 cadet-frontend locally, here is how you can make it use your own
 js-slang, instead of the one that the Source Academy team has deployed
-to npm:
+to npm.
 
+First, build and link your local js-slang:
 ``` {.}
 $ cd js-slang
 $ yarn build
-$ cp -r dist ../cadet-frontend/node_modules/js-slang
+$ yarn link
+```
+Then, from your local copy of cadet-frontend:
+``` {.}
+$ cd cadet-frontend
+$ yarn link "js-slang"
 ```
 
-Then start frontend and the new js-slang will be used.
+Then start the frontend and the new js-slang will be used. 


### PR DESCRIPTION
The standard way of using local versions of JS packages in a project is through the `yarn link` mechanism. This pull request updates the js-slang readme to use this process rather than manually copying the files (as was previously recommended).