### PR TITLE
Perform proper path check in jsdoc.sh

### DIFF
--- a/scripts/jsdoc.sh
+++ b/scripts/jsdoc.sh
@@ -17,7 +17,7 @@ main() {
 	clean
     elif [ "$1" == "via" ]; then
 	via
-    elif [[ $(git rev-parse --show-toplevel 2> /dev/null) = "$PWD" ]]; then
+    elif [[ "$(git rev-parse --show-toplevel 2> /dev/null)" -ef "$PWD" ]]; then
         run
     else
         echo "Please run this command from the git root directory."


### PR DESCRIPTION
Use -ef to compare paths instead of =. This way, the path comparison will work properly on case insensitive OSes like Mac OSX.