### PR TITLE
REPL: Fix execution mode for non-det variant

### DIFF
--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -101,7 +101,10 @@ function main() {
     )
   }
 
-  const executionMethod = opt.options.variant === 'interpreter' ? 'interpreter' : 'native'
+  const executionMethod =
+    opt.options.variant === 'interpreter' || opt.options.variant === 'non-det'
+      ? 'interpreter'
+      : 'native'
   const useSubst = opt.options.variant === 'substituter'
   const useRepl = !opt.options.e
   const prelude = opt.argv[0] ?? ''


### PR DESCRIPTION
Fixes #638 

Currently, when we run the REPL (`repl.ts`) with `--variant=non-det --chapter=3`, the REPL does not actually use the non-det interpreter but instead transpiles code to native JS.

In this PR, I have fixed `repl.ts` such that the execution method is set to `interpreter` when `--variant=non-det` is used.

We can now run non-det programs using the REPL, as follows:
`node dist/repl/repl.js -e --chapter=3 --variant=non-det "$(cat <path_to_program>)"`

Working example:
Run: `node dist/repl/repl.js -e --chapter=3 --variant=non-det "$(cat ./js_programs/prime_sum_pair.js)"`

where `js_programs` folder contains `prime_sum_pair.js` as follows:
```
// SICP JS 4.3.1
function square(x) {
    return x * x;
}

function is_divisible(x, y) { return x % y === 0; }

function integers_starting_from(n) {
    return pair(n, () => integers_starting_from(n + 1));
}

function is_prime(n) {
    function iter(ps) {
        return square(head(ps)) > n
               ? true
               : is_divisible(n, head(ps))
               ? false
               : iter(stream_tail(ps));
    }
    return iter(primes);
}
const primes = pair(2,
                    () => stream_filter(
                              is_prime, 
                              integers_starting_from(3))
                   );

function prime_sum_pair(list1, list2) {    
    const a = an_element_of(list1);
    const b = an_element_of(list2);
    require(is_prime(a + b));
    return list(a, b);
}

prime_sum_pair(list(1, 3, 5, 8), list(20, 35, 110));
```


### Limitations
The `repl.ts` REPL does not support non-det's `try_again` keyword yet.
The original REPL created for non-det (`repl-non.det.ts`) does support `try_again`.
