### PR TITLE
Add color points to CURVES library

### DIFF
--- a/docs/lib/webGLcurve.js
+++ b/docs/lib/webGLcurve.js
@@ -267,7 +267,7 @@ function r_of(pt) {
 }
 
 /**
- * retrieves the red component of a given Point
+ * retrieves the green component of a given Point
  * @param {Point} p - given point
  * @returns {Number} Green component of the Point
  */
@@ -276,7 +276,7 @@ function g_of(pt) {
 }
 
 /**
- * retrieves the red component of a given Point
+ * retrieves the blue component of a given Point
  * @param {Point} p - given point
  * @returns {Number} Blue component of the Point
  */

--- a/docs/lib/webGLcurve.js
+++ b/docs/lib/webGLcurve.js
@@ -1,9 +1,13 @@
 var viewport_size = 600
 
 function generateCurve(scaleMode, drawMode, numPoints, func, isFullView) {
+  curveColor = t => func(t).getColor()
+  const viewport_size = 600
   const frame = open_pixmap('frame', viewport_size, viewport_size, true);
   var curvePosArray = []
+  var curveColorArray = []
   var transMat = mat4.create()
+  var curveObject = {}
   // initialize the min/max to extreme values
   var min_x = Infinity
   var max_x = -Infinity
@@ -15,20 +19,25 @@ function generateCurve(scaleMode, drawMode, numPoints, func, isFullView) {
     // where x,y is in [0, 1]
     // evaluator has a side effect of recording the max/min
     // x and y value for adjusting the position
+    curveObject = {}
     curvePosArray = []
+    curveColorArray = []
     for (var i = 0; i <= num; i += 1) {
-      var value = func(i / num)
+      var point = func(i / num)
       if (
-        typeof value !== 'object' ||
-        value.length !== 2 ||
-        typeof value[0] !== 'number' ||
-        typeof value[1] !== 'number'
+        !(point instanceof Point)
       ) {
-        throw 'Expected a point, encountered ' + value
+        throw 'Expected a point, encountered ' + point
       }
-      var x = value[0] * 2 - 1
-      var y = value[1] * 2 - 1
+      var x = point.getX() * 2 - 1
+      var y = point.getY() * 2 - 1
       curvePosArray.push(x, y)
+      var colorArray = curveColor(i / num)
+      var color_r = colorArray[0]
+      var color_g = colorArray[1]
+      var color_b = colorArray[2]
+      var color_a = colorArray[3]
+      curveColorArray.push(color_r, color_g, color_b, color_a)
       min_x = Math.min(min_x, x)
       max_x = Math.max(max_x, x)
       min_y = Math.min(min_y, y)
@@ -66,7 +75,9 @@ function generateCurve(scaleMode, drawMode, numPoints, func, isFullView) {
   }
   clear_viewport()
   gl.uniformMatrix4fv(u_transformMatrix, false, transMat)
-  drawCurve(drawMode, curvePosArray)
+  curveObject.curvePos = curvePosArray
+  curveObject.color = curveColorArray
+  drawCurve(drawMode, curveObject)
   copy_viewport(gl.canvas, frame);
   return new ShapeDrawn(frame);
 }
@@ -193,23 +204,82 @@ function draw_connected_full_view_proportional(num) {
  * @returns {Point} with x and y as coordinates
  */
 function make_point(x, y) {
-  return [x, y]
+  var p = new Point()
+  p.setX(x)
+  p.setY(y)
+  p.setZ(0) //0 as default for 2D curves
+  p.setColor([0, 0, 0, 1]) //black as default
+  return p
 }
 
 /**
- * retrieves the x-coordinate a given Point
+ * makes a color Point with given x and y coordinates, and RGB values
+ * @param {Number} x - x-coordinate of new point
+ * @param {Number} y - y-coordinate of new point
+ * @param {Number} r - red component of new point
+ * @param {Number} g - green component of new point
+ * @param {Number} b - blue component of new point
+ * @returns {Point} with x and y as coordinates, and r, g, and b as RGB values
+ */
+function make_color_point(x, y, r, g, b){
+  var p = new Point()
+  p.setX(x)
+  p.setY(y)
+  p.setZ(0) //0 as default for 2D curves
+  p.setColor([r/255, g/255, b/255, 1])
+  return p
+}
+
+/**
+ * retrieves the x-coordinate of a given Point
  * @param {Point} p - given point
  * @returns {Number} x-coordinate of the Point
  */
 function x_of(pt) {
-  return pt[0]
+  return pt.getX();
 }
 
 /**
- * retrieves the y-coordinate a given Point
+ * retrieves the y-coordinate of a given Point
  * @param {Point} p - given point
  * @returns {Number} y-coordinate of the Point
  */
 function y_of(pt) {
-  return pt[1]
+  return pt.getY();
+}
+
+/**
+ * retrieves the z-coordinate of a given Point
+ * @param {Point} p - given point
+ * @returns {Number} z-coordinate of the Point
+ */
+function z_of(pt) {
+  return pt.getZ();
+}
+
+/**
+ * retrieves the red component of a given Point
+ * @param {Point} p - given point
+ * @returns {Number} Red component of the Point
+ */
+function r_of(pt) {
+  return pt.getColor()[0] * 255;
+}
+
+/**
+ * retrieves the red component of a given Point
+ * @param {Point} p - given point
+ * @returns {Number} Green component of the Point
+ */
+function g_of(pt) {
+  return pt.getColor()[1] * 255;
+}
+
+/**
+ * retrieves the red component of a given Point
+ * @param {Point} p - given point
+ * @returns {Number} Blue component of the Point
+ */
+function b_of(pt) {
+  return pt.getColor()[2] * 255;
 }

--- a/docs/lib/webGLhi_graph.js
+++ b/docs/lib/webGLhi_graph.js
@@ -124,7 +124,7 @@ function invert(curve) {
 function rotate_pi_over_2(curve) {
     return t => {
 	var ct = curve(t)
-	return make_point(-y_of(ct), x_of(ct))
+	return make_color_point(-y_of(ct), x_of(ct), r_of(ct), g_of(ct), b_of(ct))
     }
 }
 
@@ -148,7 +148,7 @@ function translate(x0, y0) {
   return curve => 
 	(t) => {
 	    var ct = curve(t)
-	    return make_point(x0 + x_of(ct), y0 + y_of(ct))
+	    return make_color_point(x0 + x_of(ct), y0 + y_of(ct), r_of(ct), g_of(ct), b_of(ct))
 	}
 }
 
@@ -171,7 +171,7 @@ function rotate_around_origin(theta) {
       var ct = curve(t)
       var x = x_of(ct)
       var y = y_of(ct)
-      return make_point(cth * x - sth * y, sth * x + cth * y)
+      return make_color_point(cth * x - sth * y, sth * x + cth * y, r_of(ct), g_of(ct), b_of(ct))
     }
   }
 }
@@ -182,7 +182,7 @@ function deriv_t(n) {
     return function(t) {
       var ct = curve(t)
       var ctdelta = curve(t + delta_t)
-      return make_point((x_of(ctdelta) - x_of(ct)) / delta_t, (y_of(ctdelta) - y_of(ct)) / delta_t)
+      return make_color_point((x_of(ctdelta) - x_of(ct)) / delta_t, (y_of(ctdelta) - y_of(ct)) / delta_t, r_of(ct), g_of(ct), b_of(ct))
     }
   }
 }
@@ -201,7 +201,7 @@ function scale_x_y(a, b) {
   return curve => 
 	t => {
 	    var ct = curve(t)
-	    return make_point(a * x_of(ct), b * y_of(ct))
+	    return make_color_point(a * x_of(ct), b * y_of(ct), r_of(ct), g_of(ct), b_of(ct))
 	}
 }
 
@@ -324,13 +324,7 @@ function put_in_standard_position(curve) {
  * @returns {Curve} result Curve
  */
 function connect_rigidly(curve1, curve2) {
-  return function(t) {
-    if (t < 1 / 2) {
-      return curve1(2 * t)
-    } else {
-      return curve2(2 * t - 1)
-    }
-  }
+  return t < 1 / 2 ? curve1(2 * t) : curve2(2 * t - 1)
 }
 
 // CONNECT-ENDS makes a Curve consisting of curve1 followed by


### PR DESCRIPTION
Adds the following functions to docs:
- `make_color_point`
- `z_of`
- `r_of`
- `g_of`
- `b_of`

Updates the implementations of the following functions to support the new Point object construct:
- `make_point`
- `x_of`
- `y_of`
- `rotate_pi_over_2`
- `translate`
- `rotate_around_origin`
- `deriv_t`
- `scale_x_y`
- `generateCurve`