### PR TITLE
Updated to import new modules in js-slang

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const TRY_AGAIN = 'try_again' // command for Source 4.3
 export const GLOBAL = typeof window === 'undefined' ? global : window
 export const NATIVE_STORAGE_ID = 'nativeStorage'
 export const MODULE_PARAMS_ID = 'moduleParams'
+export const MODULE_FUNCTIONS = 'functions'
 export const MAX_LIST_DISPLAY_LENGTH = 100
 export const UNKNOWN_LOCATION: es.SourceLocation = {
   start: {

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -622,10 +622,11 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   ImportDeclaration: function*(node: es.ImportDeclaration, context: Context) {
     const moduleName = node.source.value as string
     const neededSymbols = node.specifiers.map(spec => spec.local.name)
-    const module = loadModule(moduleName, context)
+    // TODO pass relevant sideContents to frontend
+    const {functions} = loadModule(moduleName, context)
     declareImports(context, node)
     for (const name of neededSymbols) {
-      defineVariable(context, name, module[name], true);
+      defineVariable(context, name, functions[name], true);
     }
     return undefined
   },

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -7,7 +7,7 @@ import { ModuleNotFound, ModuleInternalError } from '../../errors/errors'
 import { stripIndent } from '../../utils/formatters'
 import { createEmptyContext } from '../../createContext'
 
-test.only('Load a valid module', () => {
+test('Load a valid module', () => {
   const path = '_mock_dir/_mock_file'
   const moduleText = stripIndent`
     (_params) => {
@@ -27,12 +27,12 @@ test.only('Load a valid module', () => {
   })
 })
 
-test('Try loading a non-existing module', () => {
+test.skip('Try loading a non-existing module', () => {
   const moduleName = '_non_existing_dir/_non_existing_file'
   expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
 })
 
-test.only('Try executing a wrongly implemented module', () => {
+test('Try executing a wrongly implemented module', () => {
   // A module in wrong format
   const path = '_mock_dir/_mock_file'
   const wrongModuleText = stripIndent`

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -7,7 +7,7 @@ import { ModuleNotFound, ModuleInternalError } from '../../errors/errors'
 import { stripIndent } from '../../utils/formatters'
 import { createEmptyContext } from '../../createContext'
 
-test('Load a valid module', () => {
+test.only('Load a valid module', () => {
   const path = '_mock_dir/_mock_file'
   const moduleText = stripIndent`
     (_params) => {
@@ -32,7 +32,7 @@ test('Try loading a non-existing module', () => {
   expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
 })
 
-test('Try executing a wrongly implemented module', () => {
+test.only('Try executing a wrongly implemented module', () => {
   // A module in wrong format
   const path = '_mock_dir/_mock_file'
   const wrongModuleText = stripIndent`

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -12,12 +12,18 @@ test('Load a valid module', () => {
   const moduleText = stripIndent`
     (_params) => {
       return {
-        hello: 1
+        functions: {
+          hello: 1
+        },
+        sideContents: [],
       };
     }
   `
   expect(loadModule(path, createEmptyContext(1, 'default', []), moduleText)).toEqual({
-    hello: 1
+    functions: {
+      hello: 1
+    },
+    sideContents: []
   })
 })
 

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -27,7 +27,7 @@ test('Load a valid module', () => {
   })
 })
 
-test.skip('Try loading a non-existing module', () => {
+test('Try loading a non-existing module', () => {
   const moduleName = '_non_existing_dir/_non_existing_file'
   expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
 })

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -11,7 +11,7 @@ import {
   getIdentifiersInProgram,
   getIdentifiersInNativeStorage
 } from '../utils/uniqueIds'
-import { NATIVE_STORAGE_ID, MODULE_PARAMS_ID } from '../constants'
+import { NATIVE_STORAGE_ID, MODULE_PARAMS_ID, MODULE_FUNCTIONS } from '../constants'
 
 /**
  * This whole transpiler includes many many many many hacks to get stuff working.
@@ -42,8 +42,12 @@ function prefixModule(program: es.Program): string {
     if (node.type !== 'ImportDeclaration') {
       break
     }
-    const moduleText = loadModuleText(node.source.value as string)
-    prefix += `const __MODULE_${moduleCounter}__ = (${moduleText.trim()})(${MODULE_PARAMS_ID});\n`
+    const moduleText = loadModuleText(node.source.value as string).trim()
+    // remove ; from moduleText
+    prefix += `const __MODULE_${moduleCounter}__ = (${moduleText.substring(
+      0,
+      moduleText.length - 1
+    )})(${MODULE_PARAMS_ID})["${MODULE_FUNCTIONS}"];\n`
     moduleCounter++
   }
   return prefix


### PR DESCRIPTION
Modified the intepreter.ts and transpiler.ts to use the new modules. 

In intepreter.ts, `functions` are now from destructured from the new module object being returned from `loadModule` instead of being directly returned. 

In transpiler.ts, the functions from the imported `moduleText` now have to be accessed from the new module object, as the functions are no longer directly returned. A constant `MODULE_FUNCTIONS` was added to access the functions. `substring` was used to remove the last character of the `moduleText `, as after transpiling it in babel, there would be a semi-colon there and leaving the semicolon causes an error when the `sandboxedEval` function when it tries to evaluate it.

In __tests__/moduleLoader.ts, the tests were updated to reflect the changes to the new module system

New module object structure:
```
    (_params) => {
      ...
      return {
        functions: {
          ...
        },
        sideContents: [...],
      };
    }
```