### PR TITLE
Dynamic Module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -382,12 +382,12 @@ export function getTypeInformation(
 }
 
 function appendModulesToContext(program: Program, context: Context): void {
-  if (context.sideContentComponents == null) context.sideContentComponents = []
+  if (context.modules == null) context.modules = []
   for (const node of program.body) {
     if (node.type !== 'ImportDeclaration') break
     // TODO: remove the force string type and handle errors caused by other types
     const moduleName = (node.source.value as string).trim()
-    context.sideContentComponents.push(loadModule(moduleName, context))
+    context.modules.push(loadModule(moduleName, context))
   }
 }
 
@@ -419,8 +419,6 @@ export async function runInContext(
   if (context.errors.length > 0) {
     return resolvedErrorPromise
   }
-
-  appendModulesToContext(program, context)
 
   if (context.variant === 'concurrent') {
     if (previousCode === code) {
@@ -484,6 +482,7 @@ export async function runInContext(
     let sourceMapJson: RawSourceMap | undefined
     let lastStatementSourceMapJson: RawSourceMap | undefined
     try {
+      appendModulesToContext(program, context)
       // Mutates program
       switch (context.variant) {
         case 'gpu':

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -622,8 +622,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   ImportDeclaration: function*(node: es.ImportDeclaration, context: Context) {
     const moduleName = node.source.value as string
     const neededSymbols = node.specifiers.map(spec => spec.local.name)
-    // TODO pass relevant sideContents to frontend
-    const {functions} = loadModule(moduleName, context)
+    const { functions } = loadModule(moduleName, context)
     declareImports(context, node)
     for (const name of neededSymbols) {
       defineVariable(context, name, functions[name], true);

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -7,7 +7,7 @@ import { ModuleNotFound, ModuleInternalError } from '../../errors/errors'
 import { stripIndent } from '../../utils/formatters'
 import { createEmptyContext } from '../../createContext'
 
-test.only('Load a valid module', () => {
+test('Load a valid module', () => {
   const path = '_mock_dir/_mock_file'
   const moduleText = stripIndent`
     (_params) => {
@@ -27,12 +27,12 @@ test.only('Load a valid module', () => {
   })
 })
 
-test('Try loading a non-existing module', () => {
+test.skip('Try loading a non-existing module', () => {
   const moduleName = '_non_existing_dir/_non_existing_file'
   expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
 })
 
-test.only('Try executing a wrongly implemented module', () => {
+test('Try executing a wrongly implemented module', () => {
   // A module in wrong format
   const path = '_mock_dir/_mock_file'
   const wrongModuleText = stripIndent`

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -7,7 +7,7 @@ import { ModuleNotFound, ModuleInternalError } from '../../errors/errors'
 import { stripIndent } from '../../utils/formatters'
 import { createEmptyContext } from '../../createContext'
 
-test('Load a valid module', () => {
+test.only('Load a valid module', () => {
   const path = '_mock_dir/_mock_file'
   const moduleText = stripIndent`
     (_params) => {
@@ -32,7 +32,7 @@ test('Try loading a non-existing module', () => {
   expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
 })
 
-test('Try executing a wrongly implemented module', () => {
+test.only('Try executing a wrongly implemented module', () => {
   // A module in wrong format
   const path = '_mock_dir/_mock_file'
   const wrongModuleText = stripIndent`

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 
-import { loadModuleText, loadModule } from '../moduleLoader'
+import { memoizedLoadModuleText, loadModule } from '../moduleLoader'
 import { ModuleNotFound, ModuleInternalError } from '../../errors/errors'
 import { stripIndent } from '../../utils/formatters'
 import { createEmptyContext } from '../../createContext'
@@ -29,7 +29,7 @@ test('Load a valid module', () => {
 
 test('Try loading a non-existing module', () => {
   const moduleName = '_non_existing_dir/_non_existing_file'
-  expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
+  expect(() => memoizedLoadModuleText(moduleName)).toThrow(ModuleNotFound)
 })
 
 test('Try executing a wrongly implemented module', () => {

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 import { memoizedLoadModuleText, loadModule } from '../moduleLoader'
 import { ModuleNotFound, ModuleInternalError } from '../../errors/errors'
 import { stripIndent } from '../../utils/formatters'

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -27,7 +27,7 @@ test('Load a valid module', () => {
   })
 })
 
-test.skip('Try loading a non-existing module', () => {
+test('Try loading a non-existing module', () => {
   const moduleName = '_non_existing_dir/_non_existing_file'
   expect(() => loadModuleText(moduleName)).toThrow(ModuleNotFound)
 })

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -27,7 +27,8 @@ export function loadModule(path: string, context: Context, moduleText?: string) 
     }
     // tslint:disable-next-line:no-eval
     const moduleLib = eval(moduleText)
-    return moduleLib({ runes: {}, ...context.moduleParams })
+    const moduleObject = moduleLib({ runes: {}, ...context.moduleParams })
+    return moduleObject
   } catch (_error) {
     throw new ModuleInternalError(path)
   }

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -13,8 +13,20 @@ export function setBackendStaticURL(url: string) {
 function loadModuleText(path: string) {
   const scriptPath = `${BACKEND_STATIC_URL}/${path}.js`
   const req = new HttpRequest()
-  req.open('GET', scriptPath, false)
-  req.send(null)
+
+  try {
+    // Set the request timeout here to a random value of 10 seconds for modules
+    // that cannot be found
+    req.timeout = 10000
+    req.open('GET', scriptPath, false)
+    req.send(null)
+  } catch (error) {
+    // Catch DOMException thrown by request when module path is not found and
+    // request timesout (For jsdom environment)
+    // For node environment, the request doesnt throw any errors...
+    if (!(error instanceof DOMException)) throw error
+  }
+
   if (req.status !== 200 && req.status !== 304) {
     throw new ModuleNotFound(path)
   }

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -1,3 +1,4 @@
+import { memoize } from 'lodash'
 import { ModuleNotFound, ModuleInternalError } from '../errors/errors'
 import { XMLHttpRequest as NodeXMLHttpRequest } from 'xmlhttprequest-ts'
 import { Context } from '..'
@@ -9,7 +10,7 @@ export function setBackendStaticURL(url: string) {
   BACKEND_STATIC_URL = url
 }
 
-export function loadModuleText(path: string) {
+function loadModuleText(path: string) {
   const scriptPath = `${BACKEND_STATIC_URL}/${path}.js`
   const req = new HttpRequest()
   req.open('GET', scriptPath, false)
@@ -20,16 +21,22 @@ export function loadModuleText(path: string) {
   return req.responseText
 }
 
+// Uses lodash to memoize loadModuleText
+export const memoizedLoadModuleText = memoize(loadModuleText)
+
 export function loadModule(path: string, context: Context, moduleText?: string) {
   try {
     if (moduleText === undefined) {
-      moduleText = loadModuleText(path)
+      moduleText = memoizedLoadModuleText(path)
     }
     // tslint:disable-next-line:no-eval
     const moduleLib = eval(moduleText)
     const moduleObject = moduleLib({ runes: {}, ...context.moduleParams })
     return moduleObject
   } catch (_error) {
+    if (_error instanceof ModuleNotFound) {
+      throw _error
+    }
     throw new ModuleInternalError(path)
   }
 }

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -712,6 +712,7 @@ export function transpile(
   transformFunctionDeclarationsToArrowFunctions(program, functionsToStringMap)
   wrapArrowFunctionsToAllowNormalCallsAndNiceToString(program, functionsToStringMap, globalIds)
   addInfiniteLoopProtection(program, globalIds, usedIdentifiers)
+
   const modulePrefix = prefixModule(program)
   transformImportDeclarations(program)
   const statementsToSaveDeclaredGlobals = createStatementsToStoreCurrentlyDeclaredGlobals(

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -4,7 +4,7 @@ import * as es from 'estree'
 import { RawSourceMap, SourceMapGenerator } from 'source-map'
 import { AllowedDeclarations, Context, NativeStorage, ValueWrapper } from '../types'
 import { ConstAssignment, UndefinedVariable } from '../errors/errors'
-import { loadModuleText } from '../modules/moduleLoader'
+import { memoizedLoadModuleText } from '../modules/moduleLoader'
 import * as create from '../utils/astCreator'
 import {
   getUniqueId,
@@ -42,7 +42,7 @@ function prefixModule(program: es.Program): string {
     if (node.type !== 'ImportDeclaration') {
       break
     }
-    const moduleText = loadModuleText(node.source.value as string).trim()
+    const moduleText = memoizedLoadModuleText(node.source.value as string).trim()
     // remove ; from moduleText
     prefix += `const __MODULE_${moduleCounter}__ = (${moduleText.substring(
       0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,11 @@ export interface Context<T = any> {
   variant: Variant
 
   typeEnvironment: TypeEnvironment
+
+  /**
+   * The side content components to be displayed after the evaluation
+   */
+  sideContentComponents?: any[]
 }
 
 export interface BlockFrame {

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,7 +152,7 @@ export interface Context<T = any> {
   /**
    * The side content components to be displayed after the evaluation
    */
-  sideContentComponents?: any[]
+  modules?: any[]
 }
 
 export interface BlockFrame {


### PR DESCRIPTION
### Updated js-slang to support the [new modules system](https://github.com/source-academy/modules/tree/modules/development)
Changes:
#### _moduleLoader.ts_
- `loadModuleText` retrieves the module from the http-server and returns it as a string, added a timeout to fix the test issue
- `loadModuleText` is memoized by lodash in `memoizedLoadModuleText` to prevent duplicate calls to the modules http-server.
- `loadModule` calls `memoizedLoadModuleText` and returns it as a module object

#### _src/modules/__tests__/moduleLoader.ts_
- fixed issue with "loading a non-existing module" test
- updated relevant tests

#### _src/index.ts_
- When `runInContext` is called, `appendModulesToContext` pushes the modules from `loadModule` into the context object in `context.modules`. 

#### _src/types.ts_
- The `modules` field was added into the Context object in `src/types.ts` as well.

---
### How to test
1) Pull js-slang from modules/development branch, and [follow the steps here](https://github.com/source-academy/js-slang#using-your-js-slang-in-local-source-academy) to link it to the cadet-front end

2) Pull cadet-frontend from modules/development branch, and setup the env file and run it. Set the module backend url to this:
`REACT_APP_MODULE_BACKEND_URL=http://localhost:8022`

3) Pull modules from modules/development branch, and [follow the steps here](https://github.com/source-academy/modules/tree/modules/development) to set it up and run it.

4) On the playground, the side content tab will spawn after the 'test' module is imported and if the output in the REPL is "test":
![image](https://user-images.githubusercontent.com/50147457/107918108-07bbcd00-6fa4-11eb-95c4-fae0f243fa25.png)