### PR TITLE
Allow number-type property for astCreator.memberExpression 

### DIFF
--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -24,13 +24,13 @@ export const literal = (
 
 export const memberExpression = (
   object: es.Expression,
-  propertyString: string
+  property: string | number
 ): es.MemberExpression => ({
   type: 'MemberExpression',
   object,
   computed: false,
   optional: false,
-  property: identifier(propertyString)
+  property: typeof property === 'string' ? identifier(property) : literal(property)
 })
 
 export const declaration = (

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -28,9 +28,9 @@ export const memberExpression = (
 ): es.MemberExpression => ({
   type: 'MemberExpression',
   object,
-  computed: false,
+  computed: typeof property === 'number',
   optional: false,
-  property: typeof property === 'string' ? identifier(property) : literal(property)
+  property: typeof property === 'number' ? literal(property) : identifier(property)
 })
 
 export const declaration = (


### PR DESCRIPTION
This will allow constructing AST like `xs[0]` 