### PR TITLE
Library Documentation: transformation functions and unused functions

### DIFF
--- a/docs/lib/webGLhi_graph.js
+++ b/docs/lib/webGLhi_graph.js
@@ -1,35 +1,3 @@
-// USEFUL, SIMPLE, GENERAL PROCEDURES
-
-function compose(f, g) {
-  return function (x) {
-    return f(g(x))
-  }
-}
-
-function thrice(f) {
-  return compose(compose(f, f), f)
-}
-
-function identity(t) {
-  return t
-}
-
-function repeated(f, n) {
-  if (n === 0) {
-    return identity
-  } else {
-    return compose(f, repeated(f, n - 1))
-  }
-}
-
-// USEFUL NUMERICAL PROCEDURE
-
-function square(x) {
-  return x * x
-}
-
-// SOME CURVES
-
 /**
  * this function is a curve: a function from a
  * fraction t to a point. The points lie on the
@@ -86,10 +54,6 @@ function arc(t) {
   return make_point(Math.sin(Math.PI * t), Math.cos(Math.PI * t))
 }
 
-// Curve-Transform = (Curve --> Curve)
-
-// SOME CURVE-TRANSFORMS
-
 /**
  * this function is a Curve transformation: a function from a
  * Curve to a Curve. The points of the result Curve are
@@ -105,10 +69,6 @@ function invert(curve) {
     return curve(1 - t)
   }
 }
-
-// CONSTRUCTORS OF CURVE-TRANSFORMS
-
-// TRANSLATE is of type (JS-Num, JS-Num --> Curve-Transform)
 
 /**
  * this function returns a Curve transformation: 
@@ -137,15 +97,18 @@ function translate_curve(x0, y0, z0) {
   }
 }
 
-// ROTATE-AROUND-ORIGIN is of type (JS-Num --> Curve-Transform)
 /**
  * this function 
- * takes an angle theta as parameter and returns a Curve transformation:
- * a function that takes
- * a Curve a argument and returns
+ * takes either 1 or 3 angles, a, b and c in radians as parameter and 
+ * returns a Curve transformation: 
+ * a function that takes a Curve as argument and returns
  * a new Curve, which is the original Curve rotated by the given angle
- * around the origin, in counter-clockwise direction.
- * @param {number} theta - given angle
+ * around the z-axis (1 parameter) in counter-clockwise direction, or 
+ * the original Curve rotated extrinsically with Euler angles (a, b, c) 
+ * about x, y, and z axes (3 parameters).
+ * @param {number} a - given angle
+ * @param {number} b - (Optional) given angle
+ * @param {number} c - (Optional) given angle
  * @returns {unary_Curve_operator} function that takes a Curve and returns a Curve
  */
 function rotate_around_origin(theta) {
@@ -157,17 +120,6 @@ function rotate_around_origin(theta) {
       var x = x_of(ct)
       var y = y_of(ct)
       return make_color_point(cth * x - sth * y, sth * x + cth * y, r_of(ct), g_of(ct), b_of(ct))
-    }
-  }
-}
-
-function deriv_t(n) {
-  var delta_t = 1 / n
-  return function (curve) {
-    return function (t) {
-      var ct = curve(t)
-      var ctdelta = curve(t + delta_t)
-      return make_color_point((x_of(ctdelta) - x_of(ct)) / delta_t, (y_of(ctdelta) - y_of(ct)) / delta_t, r_of(ct), g_of(ct), b_of(ct))
     }
   }
 }
@@ -209,13 +161,6 @@ function scale_proportional(s) {
   return scale_curve(s, s, s)
 }
 
-// PUT-IN-STANDARD-POSITION is a Curve-Transform.
-// A Curve is in "standard position" if it starts at (0,0) ends at (1,0).
-// A Curve is PUT-IN-STANDARD-POSITION by rigidly translating it so its
-// start Point is at the origin, then rotating it about the origin to put
-// its endpoint on the x axis, then scaling it to put the endpoint at (1,0).
-// Behavior is unspecified on closed curves (with start-point = end-point).
-
 /**
  * this function is a Curve transformation: It
  * takes a Curve as argument and returns
@@ -230,7 +175,6 @@ function scale_proportional(s) {
  * @param {Curve} curve - given Curve
  * @returns {Curve} result Curve
  */
-
 function put_in_standard_position(curve) {
   var start_point = curve(0)
   var curve_started_at_origin = translate_curve(-x_of(start_point), -y_of(start_point))(curve)
@@ -240,10 +184,6 @@ function put_in_standard_position(curve) {
   var end_point_on_x_axis = x_of(curve_ended_at_x_axis(1))
   return scale_proportional(1 / end_point_on_x_axis)(curve_ended_at_x_axis)
 }
-
-// Binary-transform = (Curve,Curve --> Curve)
-
-// CONNECT-RIGIDLY makes a Curve consisting of curve1 followed by curve2.
 
 /**
  * this function is a binary Curve operator: It
@@ -262,9 +202,6 @@ function put_in_standard_position(curve) {
 function connect_rigidly(curve1, curve2) {
   return t => t < 1 / 2 ? curve1(2 * t) : curve2(2 * t - 1)
 }
-
-// CONNECT-ENDS makes a Curve consisting of curve1 followed by
-// a copy of curve2 starting at the end of curve1
 
 /**
  * this function is a binary Curve operator: It

--- a/docs/lib/webGLhi_graph.js
+++ b/docs/lib/webGLhi_graph.js
@@ -72,13 +72,6 @@ function unit_line_at(y) {
   }
 }
 
-// alternative_unit_circle: undocumented feature
-
-function alternative_unit_circle(t) {
-  return make_point(Math.sin(2 * Math.PI * square(t)),
-    Math.cos(2 * Math.PI * square(t)))
-}
-
 /**
  * this function is a curve: a function from a
  * fraction t to a point. The points lie on the
@@ -125,9 +118,9 @@ function invert(curve) {
  * a new Curve, by translating the original by x0 in x-direction, 
  * y0 in y-direction and z0 in z-direction.
  * 
- * @param {number} x0 - x-value
- * @param {number} y0 - y-value
- * @param {number} z0 - z-value
+ * @param {number} [x0 = 0] - x-value
+ * @param {number} [y0 = 0] - y-value
+ * @param {number} [z0 = 0] - z-value
  * @returns {function} Curve transformation
  */
 function translate_curve(x0, y0, z0) {
@@ -184,9 +177,9 @@ function deriv_t(n) {
  * scales a given Curve by <CODE>a</CODE> in x-direction, <CODE>b</CODE> 
  * in y-direction and <CODE>c</CODE> in z-direction.
  * 
- * @param {number} a - scaling factor in x-direction
- * @param {number} b - scaling factor in y-direction
- * @param {number} c - scaling factor in z-direction
+ * @param {number} [a = 1] - scaling factor in x-direction
+ * @param {number} [b = 1] - scaling factor in y-direction
+ * @param {number} [c = 1] - scaling factor in z-direction
  * @returns {unary_Curve_operator} function that takes a Curve and returns a Curve
  */
 function scale_curve(a1, b1, c1) {
@@ -214,62 +207,6 @@ function scale_proportional(s) {
   return scale_curve(s, s, s)
 }
 
-// SQUEEZE-RECTANGULAR-PORTION translates and scales a curve
-// so the portion of the Curve in the rectangle
-// with corners xlo xhi ylo yhi will appear in a display window
-// which has x, y coordinates from 0 to 1.
-// It is of type (JS-Num, JS-Num, JS-Num, JS-Num --> Curve-Transform).
-
-// squeeze_rectangular_portion: undocumented feature
-
-function squeeze_rectangular_portion(xlo, xhi, ylo, yhi) {
-  var width = xhi - xlo
-  var height = yhi - ylo
-  if (width === 0 || height === 0) {
-    throw 'attempt to squeeze window to zero'
-  } else {
-    return compose(scale_x_y(1 / width, 1 / height), translate(-xlo, -ylo))
-  }
-}
-
-// SQUEEZE-FULL-VIEW translates and scales a Curve such that
-// the ends are fully visible.
-// It is very similar to the squeeze-rectangular-portion procedure
-// only that that procedure does not allow the edges to be easily seen
-
-// squeeze_full_view: undocumented feature
-
-function squeeze_full_view(xlo, xhi, ylo, yhi) {
-  var width = xhi - xlo
-  var height = yhi - ylo
-  if (width === 0 || height === 0) {
-    throw 'attempt to squeeze window to zero'
-  } else {
-    return compose(
-      scale_x_y(0.99 * 1 / width, 0.99 * 1 / height),
-      translate(-(xlo - 0.01), -(ylo - 0.01))
-    )
-  }
-}
-
-// full_view_proportional: undocumented feature
-
-function full_view_proportional(xlo, xhi, ylo, yhi) {
-  var width = xhi - xlo
-  var height = yhi - ylo
-  if (width === 0 || height === 0) {
-    throw 'attempt to squeeze window to zero'
-  } else {
-    var scale_factor = Math.min(0.9 * 1 / width, 0.9 * 1 / height)
-    var new_mid_x = scale_factor * (xlo + xhi) / 2
-    var new_mid_y = scale_factor * (ylo + yhi) / 2
-    return compose(
-      translate(0.5 - new_mid_x, 0.5 - new_mid_y),
-      scale_x_y(scale_factor, scale_factor)
-    )
-  }
-}
-
 // PUT-IN-STANDARD-POSITION is a Curve-Transform.
 // A Curve is in "standard position" if it starts at (0,0) ends at (1,0).
 // A Curve is PUT-IN-STANDARD-POSITION by rigidly translating it so its
@@ -294,12 +231,12 @@ function full_view_proportional(xlo, xhi, ylo, yhi) {
 
 function put_in_standard_position(curve) {
   var start_point = curve(0)
-  var curve_started_at_origin = translate(-x_of(start_point), -y_of(start_point))(curve)
+  var curve_started_at_origin = translate_curve(-x_of(start_point), -y_of(start_point))(curve)
   var new_end_point = curve_started_at_origin(1)
   var theta = Math.atan2(y_of(new_end_point), x_of(new_end_point))
   var curve_ended_at_x_axis = rotate_around_origin(-theta)(curve_started_at_origin)
   var end_point_on_x_axis = x_of(curve_ended_at_x_axis(1))
-  return scale(1 / end_point_on_x_axis)(curve_ended_at_x_axis)
+  return scale_proportional(1 / end_point_on_x_axis)(curve_ended_at_x_axis)
 }
 
 // Binary-transform = (Curve,Curve --> Curve)
@@ -346,7 +283,7 @@ function connect_ends(curve1, curve2) {
   const start_point_of_curve2 = curve2(0);
   const end_point_of_curve1 = curve1(1);
   return connect_rigidly(curve1,
-    (translate(x_of(end_point_of_curve1) -
+    (translate_curve(x_of(end_point_of_curve1) -
       x_of(start_point_of_curve2),
       y_of(end_point_of_curve1) -
       y_of(start_point_of_curve2)))

--- a/docs/lib/webGLhi_graph.js
+++ b/docs/lib/webGLhi_graph.js
@@ -112,15 +112,16 @@ function invert(curve) {
 
 /**
  * this function returns a Curve transformation: 
- * It takes an x-value x0, a y-value y0 and a z-value z0 as arguments 
+ * It takes an x-value x0, a y-value y0 and a z-value z0, 
+ * each with default value of 0, as arguments 
  * and returns a Curve transformation that
  * takes a Curve as argument and returns
  * a new Curve, by translating the original by x0 in x-direction, 
  * y0 in y-direction and z0 in z-direction.
  * 
- * @param {number} [x0 = 0] - x-value
- * @param {number} [y0 = 0] - y-value
- * @param {number} [z0 = 0] - z-value
+ * @param {number} x0 - (Optional) x-value
+ * @param {number} y0 - (Optional) y-value
+ * @param {number} z0 - (Optional) z-value
  * @returns {function} Curve transformation
  */
 function translate_curve(x0, y0, z0) {
@@ -173,13 +174,14 @@ function deriv_t(n) {
 
 /**
  * this function takes scaling factors <CODE>a</CODE>, <CODE>b</CODE> 
- * and <CODE>c</CODE> as arguments and returns a Curve transformation that
+ * and <CODE>c</CODE>, each with default value of 1, as arguments and 
+ * returns a Curve transformation that 
  * scales a given Curve by <CODE>a</CODE> in x-direction, <CODE>b</CODE> 
  * in y-direction and <CODE>c</CODE> in z-direction.
  * 
- * @param {number} [a = 1] - scaling factor in x-direction
- * @param {number} [b = 1] - scaling factor in y-direction
- * @param {number} [c = 1] - scaling factor in z-direction
+ * @param {number} a - (Optional) scaling factor in x-direction
+ * @param {number} b - (Optional) scaling factor in y-direction
+ * @param {number} c - (Optional) scaling factor in z-direction
  * @returns {unary_Curve_operator} function that takes a Curve and returns a Curve
  */
 function scale_curve(a1, b1, c1) {


### PR DESCRIPTION
Updated jsdoc for the following functions:
- `translate_curve`
- `scale_curve`
- `rotate_around_origin`

Remove the following unused/undocumented functions in CURVE Library:
- `compose`
- `thrice`
- `identity`
- `repeated`
- `square`
- `deriv_t`
- `squeeze_rectangle_portion`
- `squeeze_full_view`
- `full_view_proportional`