### PR TITLE
Allow draw_data to take in multiple parameters

### DIFF
--- a/docs/lib/list.js
+++ b/docs/lib/list.js
@@ -65,12 +65,12 @@ function list(value1, value2, ...values ) {}
 /**
  * visualizes <CODE>x</CODE> in a separate drawing
  * area in the Source Academy using a box-and-pointer diagram; time, space:
- * O(n), where n is the number of data structures such as
- * pairs in <CODE>x</CODE>.
- * @param {value} x - given value
+ * O(n), where n is the total number of data structures such as
+ * pairs in all the separate structures provided in <CODE>x</CODE>.
+ * @param {value} value1,value2,...,value_n - given values
  * @returns {value} given <CODE>x</CODE>
  */
-function draw_data(x) {}
+ function draw_data(value1, value2, ...values ) {}
 
 /**
  * Returns <CODE>true</CODE> if both

--- a/docs/specs/source_lists.tex
+++ b/docs/specs/source_lists.tex
@@ -20,10 +20,10 @@ chain of \lstinline{tail} operations that can be applied to \lstinline{x}.
 first element is \lstinline{x1}, the second \lstinline{x2}, etc. Iterative
 process; time: $O(n)$, space: $O(n)$, since the constructed list data structure
 consists of $n$ pairs, each of which takes up a constant amount of space.
-\item \lstinline{draw_data(x)}: \textit{primitive}, visualizes \lstinline{x} in a separate drawing
+\item \lstinline{draw_data(x1, x2,..., xn)}: \textit{primitive}, visualizes each \lstinline{x1, x2,..., xn} in a separate drawing
   area in the Source Academy using a box-and-pointer diagram; time, space:
-  $O(n)$, where $n$ is the number of data structures such as
-  pairs in \lstinline{x}.
+  $O(n)$, where $n$ is the combined number of data structures such as
+  pairs in \lstinline{x1, x2,..., xn}.
 \item \lstinline{equal(x1, x2)}: Returns \lstinline{true} if both
   have the same structure with respect to \lstinline{pair},
   and the same numbers, boolean values, functions or empty list

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -173,7 +173,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
     externalBuiltIns.alert(v, '', context.externalContext)
     context.nativeStorage.maxExecTime += Date.now() - start
   }
-  const visualiseList = (v: Value) => externalBuiltIns.visualiseList(v, context.externalContext)
+  const visualiseList = (...v: Value) => externalBuiltIns.visualiseList(v, context.externalContext)
 
   if (context.chapter >= 1) {
     defineBuiltin(context, 'get_time()', misc.get_time)
@@ -222,7 +222,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, 'head(xs)', new LazyBuiltIn(list.head, true))
       defineBuiltin(context, 'tail(xs)', new LazyBuiltIn(list.tail, true))
       defineBuiltin(context, 'is_null(val)', new LazyBuiltIn(list.is_null, true))
-      defineBuiltin(context, 'draw_data(xs)', new LazyBuiltIn(visualiseList, true))
+      defineBuiltin(context, 'draw_data(...xs)', new LazyBuiltIn(visualiseList, true))
     } else {
       defineBuiltin(context, 'pair(left, right)', list.pair)
       defineBuiltin(context, 'is_pair(val)', list.is_pair)
@@ -230,7 +230,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, 'tail(xs)', list.tail)
       defineBuiltin(context, 'is_null(val)', list.is_null)
       defineBuiltin(context, 'list(...values)', list.list)
-      defineBuiltin(context, 'draw_data(xs)', visualiseList)
+      defineBuiltin(context, 'draw_data(...xs)', visualiseList)
       defineBuiltin(context, 'display_list(val, prepend = undefined)', displayList)
     }
   }

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -51,7 +51,7 @@ function _display(args) {
 }
 
 // 6 placeholder
-function _draw_data(v) {}
+function _draw_data(args) {}
 
 // 7
 function _enum_list(start, end) {
@@ -661,6 +661,7 @@ const VARARG_PRIMITIVES: [string, number?, number?][] = [
   ['math_min', OpCodes.MODG, OpCodes.MATH_MIN],
   ['math_hypot', OpCodes.NOTG, OpCodes.MATH_HYPOT],
   ['list'],
+  ['draw_data'],
   ['stream'],
   ['prompt', OpCodes.NOTG, OpCodes.PROMPT]
 ]
@@ -673,7 +674,6 @@ export const NULLARY_PRIMITIVES: [string, number, any?][] = [
 
 export const UNARY_PRIMITIVES: [string, number, any?][] = [
   ['array_length', OpCodes.ARRAY_LEN],
-  ['draw_data', OpCodes.DRAW_DATA],
   ['is_array', OpCodes.IS_ARRAY],
   ['is_boolean', OpCodes.IS_BOOL],
   ['is_function', OpCodes.IS_FUNC],
@@ -721,7 +721,6 @@ export const BINARY_PRIMITIVES: [string, number, any?][] = [
 
 export const EXTERNAL_PRIMITIVES: [string, number][] = [
   ['display', OpCodes.DISPLAY],
-  ['draw_data', OpCodes.DRAW_DATA],
   ['error', OpCodes.ERROR],
   ['prompt', OpCodes.PROMPT]
 ]

--- a/src/stepper/lib.ts
+++ b/src/stepper/lib.ts
@@ -148,6 +148,6 @@ export function list(...values: substituterNodes[]): es.ArrayExpression {
   return ret as es.ArrayExpression
 }
 //   defineBuiltin(context, 'draw_data(xs)', visualiseList)
-export function draw_data(xs: substituterNodes): es.Identifier {
+export function draw_data(...xs: substituterNodes[]): es.Identifier {
   return ast.primitive(undefined) as es.Identifier
 }


### PR DESCRIPTION
draw_data is now allowed to accept multiple arguments for side-by-side visualization.
(Edited documentation accordingly)