### PR TITLE
Updated the specifications for the stepper

### DIFF
--- a/docs/specs/source_1_stepper.tex
+++ b/docs/specs/source_1_stepper.tex
@@ -2,9 +2,9 @@
 
 \begin{document}
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-	\docheader{2021}{Source}{\S 1 Stepper}{Martin Henz, Tan Yee Jian, Zhang Xinyi, Zhao Jingjing}
+	\docheader{2021}{Source}{\S 1 Stepper}{Martin Henz, Tan Yee Jian, Zhang Xinyi, Zhao Jingjing, \\ Zachary Chua, Peter Jung}
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \input source_1_stepper_rules
 
-    \end{document}
+\end{document}

--- a/docs/specs/source_1_stepper_rules.tex
+++ b/docs/specs/source_1_stepper_rules.tex
@@ -1,12 +1,10 @@
 \section*{Reduction}
 
 The \emph{reducer} $\Rightarrow$ is a partial function from
-programs/statements to
-programs/statements 
+programs/statements/expressions to
+programs/statements/expressions (with slight abuse of notation
+via overloading)
 and $\Rightarrow^*$ is its reflexive transitive closure.
-The reducer is defined in terms of the
-\emph{expression reducer} $\Rightarrow_e$, a partial function from
-expressions to expressions.
 A \emph{reduction} is a sequence of programs
 $p_1 \Rightarrow \cdots \Rightarrow p_n$,
 where $p_n$ is not reducible, i.e. there is no
@@ -20,7 +18,7 @@ a primitive string expression, a function definition
 expression or a function declaration statement.
 
 The \emph{substitution} function 
-$p [ n \leftarrow v ]$ on programs/statements/expressions
+$p [ n := v ]$ on programs/statements/expressions
 replaces every free occurrence of the name $n$
 in statement $p$ by value $v$. Care must be taken to introduce
 and preserve
@@ -58,7 +56,7 @@ statements are substituted in the remaining statements.
 }{
 f\ \textit{statement} \ldots\ 
   \Rightarrow\ 
-  \textit{statement} \ldots[\textit{name} \leftarrow f]
+  \textit{statement} \ldots[\textit{name} := f]
 }
 \]
 
@@ -68,11 +66,11 @@ statements are substituted in the remaining statements.
 \[
 \frac{
              c = \textbf{\texttt{const}}\  \textit{name} \ 
-             \textbf{\texttt{=}}\  \textit{v} \ \textbf{\texttt{;}}
+             \textbf{\texttt{=}}\  \textit{v}
 }{
 c\ \textit{statement} \ldots\ 
   \Rightarrow \ 
-  \textit{statement} \ldots[\textit{name} \leftarrow v]
+  \textit{statement} \ldots[\textit{name} := v]
 }
 \]
 
@@ -96,14 +94,14 @@ in constant declarations are evaluated.
 \[
 \frac{
   \textit{expression}
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   \textit{expression}'
 }{
   \textbf{\texttt{const}}\  \textit{name} \ 
-  \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}\ 
+  \textbf{\texttt{=}}\  \textit{expression} \ 
   \Rightarrow \ 
   \textbf{\texttt{const}}\  \textit{name} \ 
-  \textbf{\texttt{=}}\  \textit{expression}' \ \textbf{\texttt{;}}
+  \textbf{\texttt{=}}\  \textit{expression}'
 }
 \]
 
@@ -114,7 +112,7 @@ in constant declarations are evaluated.
 is reducible if its predicate is reducible.
 \[
 \frac{
-  e\ \Rightarrow_e\ e'
+  e\ \Rightarrow\ e'
 }{  
   \textbf{\texttt{if}}\ 
   \textbf{\texttt{(}}\ 
@@ -194,7 +192,7 @@ whose predicate is false reduces to the alternative block.
 
 \subsection*{Statements: Blocks}
 
-\textbf{Reduce-block-statement}: A block statement is
+\textbf{Block-statement-reduce}: A block statement is
 reducible if its program is reducible.
 \[
 \frac{
@@ -214,9 +212,10 @@ reducible if its program is reducible.
 
 \vspace{10mm}
 
-\textbf{Eliminate-block-statement-value}: A block statement 
+\textbf{Block-statement-undefined}: A block statement 
 whose body only contains a single value statement reduces to
-the value.
+the value 
+\textbf{\texttt{undefined}}.
 
 \[
 \frac{
@@ -226,41 +225,39 @@ the value.
   \textbf{\texttt{;}} \ 
   \textbf{\texttt{\}}}
 \  \Rightarrow \ 
-  v\ \texttt{;}
+  \textbf{\texttt{undefined}}
 }
 \]
 
 \vspace{10mm}
 
-\textbf{Reduce-block-statement-return}: A block statement 
-whose body starts with a return statement can 
+\textbf{Block-statement-reduce-return}: A block statement 
+whose body only contains a single return statement can 
 be reduced by reducing the return expression.
 
 \[
 \frac{
   e
-\ \Rightarrow_e \ 
+\ \Rightarrow \ 
   e'
 }{  
   \textbf{\texttt{\{}} \
   \textbf{\texttt{return}} \ e \ 
   \textbf{\texttt{;}} \ 
-  \textit{statement} \ldots\ 
   \textbf{\texttt{\}}}
 \  \Rightarrow \ 
   \textbf{\texttt{\{}} \
   \textbf{\texttt{return}} \ e' \ 
   \textbf{\texttt{;}} \ 
-  \textit{statement} \ldots\ 
   \textbf{\texttt{\}}}
 }
 \]
 
 \vspace{10mm}
 
-\textbf{Eliminate-block-statement-return}: A block statement 
-whose body starts with a return value statement reduces to
-that return value statement.
+\textbf{Block-statement-eliminate-return}: A block statement 
+whose body only contains a single return value reduces to
+that value.
 
 \[
 \frac{
@@ -268,11 +265,9 @@ that return value statement.
   \textbf{\texttt{\{}} \
   \textbf{\texttt{return}} \ v \ 
   \textbf{\texttt{;}} \ 
-  \textit{statement} \ldots\ 
   \textbf{\texttt{\}}}
 \  \Rightarrow \ 
-  \textbf{\texttt{return}} \ v \ 
-  \textbf{\texttt{;}} 
+  v
 }
 \]
 
@@ -283,7 +278,7 @@ that return value statement.
 is reducible if its expression is reducible.
 \[
 \frac{
-  e\ \Rightarrow_e\ e'
+  e\ \Rightarrow\ e'
 }{  
   e \textbf{\texttt{;}}
   \ \Rightarrow \ 
@@ -298,10 +293,10 @@ is reducible if its expression is reducible.
 can be reduced if its left sub-expression can be reduced.
 \[
 \frac{
-  e_1 \ \Rightarrow_e \ e_1'
+  e_1 \ \Rightarrow \ e_1'
 }{
   e_1\  \textit{binary-operator} \ e_2
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e_1'\  \textit{binary-operator} \ e_2
 }
 \]
@@ -316,7 +311,7 @@ $\textbf{\texttt{false}}$.
 \frac{
 }{
   \textbf{\texttt{false}}\  \textbf{\texttt{\&\&}}\ e
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   \textbf{\texttt{false}}
 }
 \]
@@ -330,7 +325,7 @@ the right sub-expression.
 \frac{
 }{
   \textbf{\texttt{true}}\  \textbf{\texttt{\&\&}}\ e
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e
 }
 \]
@@ -344,7 +339,7 @@ $\textbf{\texttt{true}}$.
 \frac{
 }{
   \textbf{\texttt{true}}\  \textbf{\texttt{||}}\ e
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   \textbf{\texttt{true}}
 }
 \]
@@ -358,7 +353,7 @@ the right sub-expression.
 \frac{
 }{
   \textbf{\texttt{false}}\  \textbf{\texttt{||}}\ e
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e
 }
 \]
@@ -369,11 +364,11 @@ can be reduced if its left sub-expression is a value and its right
 sub-expression can be reduced.
 \[
 \frac{
-  e_2\ \Rightarrow_e\ e_2', \textrm{and}\ \textit{binary-operator}
+  e_2\ \Rightarrow\ e_2', \textrm{and}\ \textit{binary-operator}
   \mbox{is not}\ \textbf{\texttt{\&\&}}\ \textrm{or}\ \texttt{\textbf{||}}
 }{
   v\  \textit{binary-operator} \ e_2
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   v\  \textit{binary-operator} \ e_2'
 }
 \]
@@ -387,7 +382,7 @@ the corresponding function is defined for those values.
   v\ \mbox{is result of}\ v_1\  \textit{binary-operator} \ v_2
 }{
   v_1\  \textit{binary-operator} \ v_2
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   v
 }
 \]
@@ -398,10 +393,10 @@ the corresponding function is defined for those values.
 can be reduced if its sub-expression can be reduced.
 \[
 \frac{
-  e \ \Rightarrow_e \ e'
+  e \ \Rightarrow \ e'
 }{
   \textit{unary-operator} \ e
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   \textit{unary-operator} \ e'
 }
 \]
@@ -415,27 +410,27 @@ the corresponding function is defined for that value.
   v'\ \mbox{is result of}\ \textit{unary-operator} \ v
 }{
   \textit{unary-operator} \ v
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   v'
 }
 \]
 
 \subsection*{Expressions: conditionals}
 
-\textbf{Conditional-expression-predicate-reduce}: A conditional
+\textbf{Conditional-predicate-reduce}: A conditional
 expression can be reduced, if its predicate can be reduced.
 \[
 \frac{
-  e_1 \ \Rightarrow_e \ e_1'
+  e_1 \ \Rightarrow \ e_1'
 }{
   e_1\  \textbf{\texttt{?}}\ e_2\ \textbf{\texttt{:}}\ e_3
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e_1'\ \textbf{\texttt{?}}\ e_2\ \textbf{\texttt{:}}\ e_3
 }
 \]
 
 \vspace{10mm}
-\textbf{Conditional-expression-true-reduce}: A conditional
+\textbf{Conditional-true-reduce}: A conditional
 expression whose predicate is the value
 $\textbf{\texttt{true}}$
 can be reduced to its consequent expression.
@@ -443,13 +438,13 @@ can be reduced to its consequent expression.
 \frac{
 }{
   \textbf{\texttt{true}}\  \textbf{\texttt{?}}\ e_1\ \textbf{\texttt{:}}\ e_2
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e_1
 }
 \]
 
 \vspace{10mm}
-\textbf{Conditional-expression-false-reduce}: A conditional
+\textbf{Conditional-false-reduce}: A conditional
 expression whose predicate is the value
 $\textbf{\texttt{false}}$
 can be reduced to its alternative expression.
@@ -457,7 +452,7 @@ can be reduced to its alternative expression.
 \frac{
 }{
   \textbf{\texttt{false}}\  \textbf{\texttt{?}}\ e_1\ \textbf{\texttt{:}}\ e_2
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e_2
 }
 \]
@@ -469,10 +464,10 @@ can be reduced to its alternative expression.
 can be reduced if its functor expression can be reduced.
 \[
 \frac{
-  e \ \Rightarrow_e \ e'
+  e \ \Rightarrow \ e'
 }{
   e\  \textbf{\texttt{(}}\ \textit{expressions} \ \textbf{\texttt{)}}
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   e'\  \textbf{\texttt{(}}\ \textit{expressions} \ \textbf{\texttt{)}}
 }
 \]
@@ -484,10 +479,10 @@ can be reduced if one of its argument expressions can be reduced and all
 preceding arguments are values.
 \[
 \frac{
-  e \ \Rightarrow_e \ e'
+  e \ \Rightarrow \ e'
 }{
   v\  \textbf{\texttt{(}}\ v_1 \ldots v_i \ e \ldots\ \textbf{\texttt{)}}
-  \ \Rightarrow_e \ 
+  \ \Rightarrow \ 
   v\  \textbf{\texttt{(}}\ v_1 \ldots v_i \ e' \ldots\ \textbf{\texttt{)}}
 }
 \]
@@ -506,107 +501,539 @@ arguments are values.
                  \ \textbf{\texttt{)}}\ \textit{block}
 }{
   f\ \textbf{\texttt{(}}\ v_1 \ldots v_n\ \textbf{\texttt{)}}
-  \ \Rightarrow_e \ 
-  \textit{block} [x_1 \leftarrow v_1]\ldots[x_n \leftarrow v_n]
-  [n \leftarrow f]
+  \ \Rightarrow \ 
+  \textit{block} [x_1 := v_1]\ldots[x_n := v_n]
+  [n := f]
 }
 \]
 
 \vspace{10mm}
-\textbf{Block-lambda-expression-application-reduce}:
-The application of a lambda expression with block body
+\textbf{Function-definition-application-reduce}:
+The application of a function definition
 can be reduced, if all
 arguments are values. 
 \[
 \frac{
   f = \textbf{\texttt{(}}\  x_1 \ldots x_n
-                 \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block}
+                 \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ b
+                   \mbox{, where $b$ is an expression or block}
 }{
   f\ \textbf{\texttt{(}}\ v_1 \ldots v_n\ \textbf{\texttt{)}}
-  \ \Rightarrow_e \ 
-  \textit{block}\ [x_1 \leftarrow v_1]\ldots[x_n \leftarrow v_n]
+  \ \Rightarrow \ 
+  b [x_1 := v_1]\ldots[x_n := v_n]
 }
 \]
 
+\pagebreak
 
-\vspace{10mm}
-\textbf{Expression-lambda-expression-application-reduce}:
-The application of a lambda expression with expression body
-can be reduced, if all arguments are values. 
+\section*{Substitution}
+
+\textbf{Identifier}: An identifier with the same name as $x$ is substituted with $e_x$.
 \[
 \frac{
-  f = \textbf{\texttt{(}}\  x_1 \ldots x_n
-                 \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ e
 }{
-  f\ \textbf{\texttt{(}}\ v_1 \ldots v_n\ \textbf{\texttt{)}}
-  \ \Rightarrow_e \ 
-  e\ [x_1 \leftarrow v_1]\ldots[x_n \leftarrow v_n]
+  x[x := e_x]
+  \ = \ 
+  e_x
 }
 \]
 
-
-\subsection*{Expressions: Blocks}
-
-\textbf{Reduce-block-expression}: A block expression is
-reducible if the block statement is reducible
 \[
 \frac{
-  \textbf{\texttt{\{}} \
-  \textit{program} 
-\ \Rightarrow \ 
-  \textit{program}'  \ 
-  \textbf{\texttt{\}}}
-}{  
-  \textbf{\texttt{\{}} \
-  \textit{program} \ 
-  \textbf{\texttt{\}}}
-\  \Rightarrow_e \ 
-  \textbf{\texttt{\{}} \
-  \textit{program}' \ 
-  \textbf{\texttt{\}}}
+\textit{name}
+\ \neq \ 
+x
+}{
+  \textit{name} [x := e_x] 
+  \ = \ 
+  \textit{name}
 }
 \]
 
 \vspace{10mm}
-
-\textbf{Eliminate-block-expression-value}: A block expression
-whose body starts with a value expression statement reduces to
-\lstinline{undefined}.
-
+\textbf{Expression statement}: All occurrences of $x$ in $e$ are substituted with $e_x$.
 \[
 \frac{
-}{  
-  \textbf{\texttt{\{}} \
-  v \ 
-  \textbf{\texttt{;}} \ 
-  \textit{statement} \ldots\ 
-  \textbf{\texttt{\}}}
-\  \Rightarrow_e \ 
-  \texttt{undefined}
+}{
+  e\textbf{\texttt{;}}[x := e_x]
+  \ = \ 
+  e\,[x := e_x]\textbf{\texttt{;}}
 }
 \]
 
 \vspace{10mm}
-
-\textbf{Eliminate-block-expression-return}: A block expression
-whose body starts with a single return value statement reduces to
-the value.
-
+\textbf{Binary expression}: All occurrences of $x$ in the operands are substituted with $e_x$.
 \[
 \frac{
-}{  
-  \textbf{\texttt{\{}} \
-  \textbf{\texttt{return}} \ v \ 
-  \textbf{\texttt{;}} \
-  \textit{statement} \ldots\ 
-  \textbf{\texttt{\}}}
-\  \Rightarrow_e \ 
-v \ 
+}{
+  (e_1 \  \textit{binary-operator} \ e_2)[x := e_x] 
+  \ = \ 
+  e_1[x := e_x] \ \textit{binary-operator} \ e_2[x := e_x]
 }
 \]
 
+\vspace{10mm}
+\textbf{Unary expression}: All occurrences of $x$ in the operand are substituted with $e_x$.
+\[
+\frac{
+}{
+  (\textit{unary-operator} \ e)[x := e_x]
+  \ = \ 
+  \textit{unary-operator} \ e[x := e_x]
+}
+\]
 
+\vspace{10mm}
+\textbf{Conditional expression}: All occurrences of $x$ in the operands are substituted with $e_x$.
+\[
+\frac{
+}{
+  (e_1\  \textbf{\texttt{?}}\ e_2\ \textbf{\texttt{:}}\ e_3)[x := e_x]
+  \ = \ 
+  e_1[x := e_x]\  \textbf{\texttt{?}}\ e_2[x := e_x]\ \textbf{\texttt{:}}\ e_3[x := e_x]
+}
+\]
 
+\vspace{10mm}
+\textbf{Logical expression}: All occurrences of $x$ in the operands are substituted with $e_x$.
+\[
+\frac{
+}{
+  (e_1\  \textbf{\texttt{||}}\ e_2)[x := e_x]
+  \ = \ 
+  e_1[x := e_x]\  \textbf{\texttt{||}}\ e_2[x := e_x]
+}
+\]
 
+\[
+\frac{
+}{
+  (e_1\  \textbf{\texttt{\&\&}}\ e_2)[x := e_x]
+  \ = \ 
+  e_1[x := e_x]\  \textbf{\texttt{\&\&}}\ e_2[x := e_x]
+}
+\]
 
-    \end{document}
+\vspace{10mm}
+\textbf{Call expression}: All occurrences of $x$ in the arguments and the function expression of the application $e$ are substituted with $e_x$.
+\[
+\frac{
+}{
+  (e \ \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}})[x := e_x]
+  \ = \ 
+  e[x := e_x] \ \textbf{\texttt{(}}\ x_1[x := e_x] \ldots x_n[x := e_x] \ \textbf{\texttt{)}}
+}
+\]
+
+\pagebreak
+\textbf{Function declaration}: All occurrences of $x$ in the body of a function are substituted with $e_x$ under given circumstances.
+\begin{enumerate}[label=\large\protect\textcircled{\small\arabic*}]
+    \item Function declaration where $x$ has the same name as a parameter.
+\end{enumerate}
+    \[
+    \frac{
+      \exists \, i \in \{1, \cdots, n\} \text{ s.t. } x \ = \ x_i
+    }{
+      (\textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textit{block})[x := e_x]
+      \ = \ 
+      \textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textit{block}
+    }
+    \]
+\vspace{3mm}
+\begin{enumerate}[label=\large\protect\textcircled{\small\arabic*}, start=2]
+    \item Function declaration where $x$ does not have the same name as a parameter.
+    \begin{enumerate}[label=(\,\roman*\,)]
+        \item No parameter of the function occurs free in $e_x$.
+    \end{enumerate}
+\end{enumerate}
+        \[
+        \frac{
+          \forall \, i \in \{1, \cdots, n\} \text{ s.t. } x \ \neq \ x_i \text{, } \ \forall \, j \in \{1, \cdots, n\} \text{ s.t. } x_j \text{ does not occur free in $e_x$}
+        }{
+          \substack{\substack{\displaystyle{(\textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textit{block})[x := e_x]} \vspace{1.5mm} \\ \vspace{0.5mm} \displaystyle{=}} \\  \displaystyle{ \textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textit{block}[x := e_x]}}
+        }
+        \]
+\vspace{3mm}
+\begin{enumerate}
+    \item[]
+    \begin{enumerate}[label=(\,\roman*\,), start=2]
+        \item A parameter of the function occurs free in $e_x$.
+    \end{enumerate}
+\end{enumerate}
+        \[
+        \frac{
+          \forall \, i \in \{1, \cdots, n\} \text{ s.t. } x \ \neq \ x_i \text{, } \ \exists \, j \in \{1, \cdots, n\} \text{ s.t. } x_j \text{ occurs free in $e_x$}
+        }{
+          \substack{\substack{\displaystyle{(\textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots x_j \ldots x_n \ \textbf{\texttt{)}}\ \textit{block})[x := e_x]} \vspace{1.5mm} \\ \vspace{0.5mm} \displaystyle{=}} \\  \displaystyle{(\textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots y \ldots x_n \ \textbf{\texttt{)}}\ \textit{block}[x_j := y])[x := e_x]}}
+        }
+        \]
+
+\begin{enumerate}
+    \item[]
+    \begin{enumerate}[label=\roman*., start=2]
+        \item[]
+        \vspace{3mm}
+        Substitution is applied to the whole expression again as to recursively detect and rename all parameters of the function declaration that clash with variables that occur free in $e_x$, at which point (\,i\,) takes place. Note that the name $y$ is not declared in, nor occurs in \textit{block} and $e_x$.
+    \end{enumerate}
+\end{enumerate}
+
+\vspace{10mm}
+\textbf{Lambda expression}: All occurrences of $x$ in the body of a lambda expression are substituted with $e_x$ under given circumstances.
+\begin{enumerate}[label=\large\protect\textcircled{\small\arabic*}]
+    \item Lambda expression where $x$ has the same name as a parameter.
+\end{enumerate}
+    \[
+    \frac{
+      \exists \, i \in \{1, \cdots, n\} \text{ s.t. } x \ = \ x_i
+    }{
+      (\textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block})[x := e_x]
+      \ = \ 
+      \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block}
+    }
+    \]
+\vspace{3mm}
+\begin{enumerate}[label=\large\protect\textcircled{\small\arabic*}, start=2]
+    \item Lambda expression where $x$ does not have the same name as a parameter.
+    \begin{enumerate}[label=(\,\roman*\,)]
+        \item No parameter of the lambda expression occurs free in $e_x$.
+    \end{enumerate}
+\end{enumerate}
+        \[
+        \frac{
+          \forall \, i \in \{1, \cdots, n\} \text{ s.t. } x \ \neq \ x_i \text{, } \ \forall \, j \in \{1, \cdots, n\} \text{ s.t. } x_j \text{ does not occur free in $e_x$}
+        }{
+          (\textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block})[x := e_x]
+          \ = \ 
+          \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block}[x := e_x]
+        }
+        \]
+\vspace{3mm}
+\begin{enumerate}
+    \item[]
+    \begin{enumerate}[label=(\,\roman*\,), start=2]
+        \item A parameter of the lambda expression occurs free in $e_x$.
+    \end{enumerate}
+\end{enumerate}
+        \[
+        \frac{
+          \forall \, i \in \{1, \cdots, n\} \text{ s.t. } x \ \neq \ x_i \text{, } \ \exists \, j \in \{1, \cdots, n\} \text{ s.t. } x_j \text{ occurs free in $e_x$}
+        }{
+          (\textbf{\texttt{(}}\ x_1 \ldots x_j \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block})[x := e_x]
+          \ = \ 
+          (\textbf{\texttt{(}}\ x_1 \ldots y \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block}[x_j := y])[x := e_x]
+        }
+        \]
+\begin{enumerate}
+    \item[]
+    \begin{enumerate}[label=\roman*., start=2]
+        \item[]
+        \vspace{3mm}
+        Substitution is applied to the whole expression again as to recursively detect and rename all parameters of the lambda expression that clash with variables that occur free in $e_x$, at which point (\,i\,) takes place. Note that the name $y$ is not declared in, nor occurs in \textit{block} and $e_x$.
+    \end{enumerate}
+\end{enumerate}
+
+\pagebreak
+\textbf{Block expression}: All occurrences of $x$ in the statements of a block expression are substituted with $e_x$ under given circumstances.
+\begin{enumerate}[label=\large\protect\textcircled{\small\arabic*}]
+    \item Block expression in which $x$ is declared.
+\end{enumerate}
+    \[
+    \frac{
+      x \text{ is declared in \textit{block}}
+    }{
+      \textit{block}[x := e_x]
+      \ = \ 
+      \textit{block}
+    }
+    \]
+\vspace{3mm}
+\begin{enumerate}[label=\large\protect\textcircled{\small\arabic*}, start=2]
+    \item Block expression in which $x$ is not declared.
+    \begin{enumerate}[label=(\,\roman*\,)]
+        \item No names declared in the block occurs free in $e_x$.
+    \end{enumerate}
+\end{enumerate}
+        \[
+        \frac{
+           x \text{ is not declared in \textit{block}}\text{, } \ \textit{name} \text{ declared in \textit{block} does not occur free in } e_x
+        }{
+          \textit{block}[x := e_x]
+          \ = \ 
+          [\textit{block}[0][x := e_x] \text{, } \ldots \text{, } \textit{block}[n][x := e_x]]
+        }
+        \]
+\vspace{3mm}
+\begin{enumerate}
+    \item[]
+    \begin{enumerate}[label=(\,\roman*\,), start=2]
+        \item A name declared in the block occurs free in $e_x$.
+    \end{enumerate}
+\end{enumerate}
+        \[
+        \frac{
+          x \text{ is not declared in \textit{block}}\text{, } \ \textit{name} \text{ declared in \textit{block} occurs free in } e_x
+        }{
+          \textit{block}[x := e_x]
+          \ = \ 
+          [\textit{block}[0][\textit{name} := y] \text{, } \ldots \text{, } \textit{block}[n][\textit{name} := y]][x := e_x]
+        }
+        \]
+\begin{enumerate}
+    \item[]
+    \begin{enumerate}[label=\roman*., start=2]
+        \item[]
+        \vspace{3mm}
+        Substitution is applied to the whole expression again as to recursively detect and rename all declared names of the block expression that clash with variables that occur free in $e_x$, at which point (\,i\,) takes place. Note that the name $y$ is not declared in, nor occurs in \textit{block} and $e_x$.
+    \end{enumerate}
+\end{enumerate}
+
+\vspace{10mm}
+\textbf{Variable declaration}: All occurrences of $x$ in the declarators of a variable declaration are substituted with $e_x$.
+\[
+\frac{
+}{
+  \textit{declarations}[x := e_x]
+  \ = \ 
+  [\textit{declarations}[0][x := e_x] \ldots \textit{declarations}[n][x := e_x]]
+}
+\]
+
+\vspace{10mm}
+\textbf{Return statement}: All occurrences of $x$ in the expression that is to be returned are substituted with $e_x$.
+\[
+\frac{
+}{
+  (\textbf{\texttt{return}} \ e\textbf{\texttt{;}})[x := e_x]
+  \ = \ 
+  \textbf{\texttt{return}} \ e[x := e_x]\textbf{\texttt{;}}
+}
+\]
+
+\vspace{10mm}
+\textbf{Conditional statement}: All occurrences of $x$ in the condition, consequent, and alternative expressions of a conditional statement are substituted with $e_x$.
+\[
+\frac{
+}{
+  (
+  \textbf{\texttt{if}}\ 
+  \textbf{\texttt{(}}\ 
+  e \ 
+  \textbf{\texttt{)}} \ 
+  \textit{block} \
+  \textbf{\texttt{else}} \ 
+  \textit{block}
+  )[x := e_x]
+  \ = \ 
+  \textbf{\texttt{if}}\ 
+  \textbf{\texttt{(}}\ 
+  e[x := e_x] \ 
+  \textbf{\texttt{)}} \ 
+  \textit{block}[x := e_x] \
+  \textbf{\texttt{else}} \ 
+  \textit{block}[x := e_x]
+}
+\]
+
+\vspace{10mm}
+\textbf{Array expression}: All occurrences of $x$ in the elements of an array are substituted with $e_x$.
+\[
+\frac{
+}{
+  [x_1 \text{, } \ldots \text{, } x_n][x := e_x]
+  \ = \ 
+  [x_1[x := e_x] \text{, } \ldots \text{, } x_n[x := e_x]]
+}
+\]
+
+\pagebreak
+\section*{Free names}
+
+Let $\rhd$ be the relation that defines the set of free names of a given Source expression; the symbols $p_1$ and $p_2$ shall henceforth refer to unary and binary operations, respectively. That is, $p_1$ ranges over $\{\textbf{\texttt{!}}\}$ and $p_2$ ranges over $\{\textbf{\texttt{||}},\, \textbf{\texttt{\&\&}},\, \textbf{\texttt{+}},\, \textbf{\texttt{-}},\, \textbf{\texttt{*}},\, \textbf{\texttt{/}},\, \textbf{\texttt{===}},\, \textbf{\texttt{>}},\, \textbf{\texttt{<}}\}$.
+
+\vspace{10mm}
+\textbf{Identifier}:
+\[
+\frac{
+}{  
+  x
+  \ \rhd \
+  \{x\}
+}
+\]
+\[
+\frac{
+}{  
+  \textit{name}
+  \ \rhd \
+  \varnothing
+}
+\]
+
+\vspace{10mm}
+\textbf{Boolean}:
+\[
+\frac{
+}{  
+  \textbf{\texttt{true}}
+  \ \rhd \
+  \varnothing
+}
+\]
+\[
+\frac{
+}{  
+  \textbf{\texttt{false}}
+  \ \rhd \
+  \varnothing
+}
+\]
+
+\vspace{10mm}
+\textbf{Expression statement}:
+\[
+\frac{
+  e \ \rhd \ S
+}{  
+  e \textbf{\texttt{;}} \ \rhd \ S
+}
+\]
+
+\vspace{10mm}
+\textbf{Unary expression}:
+\[
+\frac{
+  e \ \rhd \ S
+}{  
+  p_1(e) \ \rhd \ S
+}
+\]
+
+\vspace{10mm}
+\textbf{Binary expression}:
+\[
+\frac{
+  e_1 \ \rhd \ S_1
+  \text{, } \
+  e_2 \ \rhd \ S_2
+}{  
+  p_1(e_1, e_2)
+  \ \rhd \
+  S_1 \cup S_2
+}
+\]
+
+\vspace{10mm}
+\textbf{Conditional expression}:
+\[
+\frac{
+  e_1 \ \rhd \ S_1
+  \text{, } \
+  e_2 \ \rhd \ S_2
+  \text{, } \
+  e_3 \ \rhd \ S_3
+}{  
+  e_1\  \textbf{\texttt{?}}\ e_2\ \textbf{\texttt{:}}\ e_3
+  \ \rhd \
+  S_1 \cup S_2 \cup S_3
+}
+\]
+
+\vspace{10mm}
+\textbf{Call expression}:
+\[
+\frac{
+  e \ \rhd \ S
+  \text{, } \
+  e_k \ \rhd \ T_k
+}{  
+  e(e_1,\, \ldots,\, e_n)
+  \ \rhd \
+  S \cup T_1 \cup \ldots \cup T_n
+}
+\]
+
+\vspace{10mm}
+\textbf{Function declaration}:
+\[
+\frac{
+  \textit{block} \ \rhd \ S
+}{  
+  \textbf{\texttt{function}}\  \textit{name} \ \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textit{block}
+  \ \rhd \
+  S - \{x_1,\, \ldots,\, x_n\}
+}
+\]
+
+\vspace{10mm}
+\textbf{Lambda expression}:
+\[
+\frac{
+  \textit{block} \ \rhd \ S
+}{  
+  \textbf{\texttt{(}}\ x_1 \ldots x_n \ \textbf{\texttt{)}}\ \textbf{\texttt{=>}}\ \textit{block}
+  \ \rhd \
+  S - \{x_1,\, \ldots,\, x_n\}
+}
+\]
+
+\vspace{10mm}
+\textbf{Block expression}:
+\[
+\frac{
+  \textit{block}[k] \ \rhd \ S_k
+  \text{, } \
+  T \text{ contains all names declared in \textit{block}}
+}{  
+  \textit{block}
+  \ \rhd \
+  (S_1 \cup \ldots \cup S_n) - T
+}
+\]
+
+\vspace{10mm}
+\textbf{Constant declaration}:
+\[
+\frac{
+  e \ \rhd \ S
+}{  
+  \textbf{\texttt{const}}\  \textit{name} \ 
+             \textbf{\texttt{=}}\ e\textbf{\texttt{;}}
+  \ \rhd \
+  S
+}
+\]
+
+\vspace{10mm}
+\textbf{Return statement}:
+\[
+\frac{
+  e \ \rhd \ S
+}{  
+  \textbf{\texttt{return}}\ e\textbf{\texttt{;}}
+  \ \rhd \
+  S
+}
+\]
+
+\vspace{10mm}
+\textbf{Conditional statement}:
+\[
+\frac{
+  e \ \rhd \ S
+  \text{, } \
+  \textit{block}_1 \ \rhd \ T_1
+  \text{, } \
+  \textit{block}_2 \ \rhd \ T_2
+}{  
+  \textbf{\texttt{if}}\ 
+  \textbf{\texttt{(}}\ 
+  e \ 
+  \textbf{\texttt{)}} \ 
+  \textit{block}_1 \
+  \textbf{\texttt{else}} \ 
+  \textit{block}_2
+  \ \rhd \
+  S \cup T_1 \cup T_2
+}
+\]
+

--- a/docs/specs/source_header.tex
+++ b/docs/specs/source_header.tex
@@ -4,7 +4,9 @@
 \usepackage{graphics}
 \usepackage{CJKutf8}
 \usepackage{latexsym}
+\usepackage{mathtools}
 \usepackage{amsmath,amssymb}
+\usepackage{enumitem}
 
 \usepackage[T1]{fontenc}
 


### PR DESCRIPTION
Updated the specfications for the stepper, namely adding sections for **Substitution** and **Free names**.

**Substitution** explains how substitution of expressions occurs during the reduction process. The _function declaration_ subsection uses multiline fractions to keep expressions within the text width. The notation for substitution has also been changed from "←" to ":=" as to stay true to lambda calculus conventions.

**Free names** explains the rules for which the stepper extracts free names for an expression. A new relation "▷" is defined to draw the relationship between an expression and the set of free names of said expression.

The header was also updated accordingly.