### PR TITLE
Fix problem with source modules import aliases

### DIFF
--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -59,13 +59,23 @@ export function transformSingleImportDeclaration(
 ) {
   const result = []
   const tempNamespace = `__MODULE_${moduleCounter}__`
-  // const yyy = __MODULE_xxx__.yyy;
-  const neededSymbols = node.specifiers.map(specifier => specifier.local.name)
+  const neededSymbols = node.specifiers.map(specifier => {
+    if (specifier.type !== 'ImportSpecifier') {
+      throw new Error(
+        `I expected only ImportSpecifiers to be allowed, but encountered ${specifier.type}.`
+      )
+    }
+
+    return {
+      imported: specifier.imported.name,
+      local: specifier.local.name
+    }
+  })
   for (const symbol of neededSymbols) {
     result.push(
       create.constantDeclaration(
-        symbol,
-        create.memberExpression(create.identifier(tempNamespace), symbol)
+        symbol.local,
+        create.memberExpression(create.identifier(tempNamespace), symbol.imported)
       )
     )
   }


### PR DESCRIPTION
Fix problem with source modules import aliases.

```javascript
import { baz as foo } from "bar";

foo(); // Now works
```

Fixes source-academy/modules#59.

## Testing

To test the fixes mentioned above, follow the steps listed below. 

Fetch and checkout to the `modules/importalias` branch in `js-slang` code repository.

Build and use the new `js-slang` branch on your local `cadet-frontend` instance. 

Go to the Source Academy Playground and run the following code to test the Source transpiler for Source Module import aliases.
```javascript
import { make_empty_tree as foo } from "binary_tree";

foo(); // REPL should display "null"
``` 

Run the following code to test the Source imterpreter for Source Module import aliases.
```javascript
"enable verbose";
import { make_empty_tree as foo } from "binary_tree";

foo(); // REPL should display "null"
``` 