### PR TITLE
Stepper: Fix substPredefined* by making Program create new scope

### DIFF
--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -85,10 +85,14 @@ function scanOutBoundNames(
 }
 
 function scanOutDeclarations(
-  node: es.BlockStatement | BlockExpression | es.Expression
+  node: es.BlockStatement | BlockExpression | es.Expression | es.Program
 ): es.Identifier[] {
   const declaredIds: es.Identifier[] = []
-  if (node.type == 'BlockExpression' || node.type == 'BlockStatement') {
+  if (
+    node.type === 'BlockExpression' ||
+    node.type === 'BlockStatement' ||
+    node.type === 'Program'
+  ) {
     for (const stmt of node.body) {
       // if stmt is assignment or functionDeclaration
       // add stmt into a set of identifiers
@@ -158,6 +162,7 @@ function findMain(
     | es.BlockStatement
     | BlockExpression
     | es.FunctionDeclaration
+    | es.Program
 ): string[] {
   const params: string[] = []
   if (
@@ -710,8 +715,69 @@ function substituteMain(
     },
 
     Program(target: es.Program, index: number): es.Program {
-      const substedProgram = ast.program(target.body.map(() => dummyStatement()))
+      const substedBody = target.body.map(() => dummyStatement())
+      const substedProgram = ast.program(substedBody)
       seenBefore.set(target, substedProgram)
+      const declaredNames: Set<string> = getDeclaredNames(target)
+      const re = / same/
+      // checks if the replacement is a functionExpression or arrowFunctionExpression and not from within the same block
+      if (
+        (replacement.type == 'FunctionExpression' ||
+          replacement.type == 'ArrowFunctionExpression') &&
+        !re.test(name.name)
+      ) {
+        const freeTarget: string[] = findMain(target)
+        const declaredIds: es.Identifier[] = scanOutDeclarations(target)
+        const freeReplacement: string[] = findMain(replacement)
+        const boundReplacement: es.Identifier[] = scanOutDeclarations(replacement.body)
+        for (const declaredId of declaredIds) {
+          if (freeReplacement.includes(declaredId.name)) {
+            const re = /_\d+$/
+            let newNum
+            if (re.test(declaredId.name)) {
+              const num = declaredId.name.split('_')
+              newNum = Number(num[1]) + 1
+              const changedName: string = getFreshName(
+                num[0],
+                newNum,
+                freeTarget,
+                freeReplacement,
+                declaredIds,
+                boundUpperScope,
+                boundReplacement
+              )
+              const changed = ast.identifier(changedName + ' rename', declaredId.loc)
+              const newName = ast.identifier(declaredId.name + ' rename', declaredId.loc)
+              target = substituteMain(newName, changed, target, [[]])[0] as es.Program
+            } else {
+              newNum = 1
+              const changedName: string = getFreshName(
+                declaredId.name,
+                newNum,
+                freeTarget,
+                freeReplacement,
+                declaredIds,
+                boundUpperScope,
+                boundReplacement
+              )
+              const changed = ast.identifier(changedName + ' rename', declaredId.loc)
+              const newName = ast.identifier(declaredId.name + ' rename', declaredId.loc)
+              target = substituteMain(newName, changed, target, [[]])[0] as es.Program
+            }
+          }
+        }
+      }
+
+      const re2 = / rename/
+      if (declaredNames.has(name.name) && !re2.test(name.name)) {
+        substedProgram.body = target.body
+        return substedProgram
+      }
+
+      // if it is from the same block then the name would be name + " same", hence need to remove " same"
+      // if not this statement does nothing as variable names should not have spaces
+      name.name = name.name.split(' ')[0]
+
       const arr: number[] = []
       let nextIndex = index
       for (let i = 1; i < target.body.length; i++) {
@@ -1602,128 +1668,171 @@ function reduceMain(
       context: Context,
       paths: string[][]
     ): [substituterNodes, Context, string[][], string] {
-      const [firstStatement, ...otherStatements] = node.body
-      if (
-        firstStatement.type === 'ExpressionStatement' &&
-        isIrreducible(firstStatement.expression)
-      ) {
-        paths[0].push('body[0]')
-        paths.push([])
-        return [ast.program(otherStatements as es.Statement[]), context, paths, explain(node)]
-      } else if (firstStatement.type === 'FunctionDeclaration') {
-        let funDecExp = ast.functionDeclarationExpression(
-          firstStatement.id!,
-          firstStatement.params,
-          firstStatement.body
-        ) as FunctionDeclarationExpression
-        // substitute body
-        funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
-          []
-        ])[0] as FunctionDeclarationExpression
-        // substitute the rest of the program
-        const remainingProgram = ast.program(otherStatements as es.Statement[])
-        const subst = substituteMain(funDecExp.id, funDecExp, remainingProgram, paths)
-        // concats paths such that:
-        // paths[0] -> path to the program to be substituted, pre-redex
-        // paths[1...] -> path(s) to the parts of the remaining program
-        // that were substituted, post-redex
-        paths[0].push('body[0]')
-        const allPaths = paths.concat(subst[1])
-        if (subst[1].length === 0) {
-          allPaths.push([])
-        }
-        return [subst[0], context, allPaths, explain(node)]
-      } else if (firstStatement.type === 'VariableDeclaration') {
-        const { kind, declarations } = firstStatement
-        if (kind !== 'const') {
-          // TODO: cannot use let or var
-          return [dummyProgram(), context, paths, 'cannot use let or var']
-        } else if (
-          declarations.length <= 0 ||
-          declarations.length > 1 ||
-          declarations[0].type !== 'VariableDeclarator' ||
-          !declarations[0].init
-        ) {
-          // TODO: syntax error
-          return [dummyProgram(), context, paths, 'syntax error']
-        } else {
-          const declarator = declarations[0] as es.VariableDeclarator
-          const rhs = declarator.init!
-          if (declarator.id.type !== 'Identifier') {
-            // TODO: source does not allow destructuring
-            return [dummyProgram(), context, paths, 'source does not allow destructuring']
-          } else if (isIrreducible(rhs)) {
-            const remainingProgram = ast.program(otherStatements as es.Statement[])
-            // forced casting for some weird errors
-            const subst = substituteMain(
-              declarator.id,
-              rhs as es.ArrayExpression,
-              remainingProgram,
-              paths
-            )
-            // concats paths such that:
-            // paths[0] -> path to the program to be substituted, pre-redex
-            // paths[1...] -> path(s) to the parts of the remaining program
-            // that were substituted, post-redex
-            paths[0].push('body[0]')
-            const allPaths = paths.concat(subst[1])
-            if (subst[1].length === 0) {
-              allPaths.push([])
+      if (node.body.length === 0) {
+        return [ast.expressionStatement(ast.identifier('undefined')), context, paths, explain(node)]
+      } else {
+        const [firstStatement, ...otherStatements] = node.body
+        if (firstStatement.type === 'ReturnStatement') {
+          return [firstStatement, context, paths, explain(node)]
+        } else if (firstStatement.type === 'IfStatement') {
+          paths[0].push('body[0]')
+          const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
+          if (reduced.type === 'BlockStatement') {
+            const body = reduced.body as es.Statement[]
+            if (body.length > 1) {
+              path[1] = [...path[0].slice(0, path[0].length - 1)]
             }
-            return [subst[0], context, allPaths, explain(node)]
-          } else if (rhs.type === 'ArrowFunctionExpression' || rhs.type === 'FunctionExpression') {
-            let funDecExp = ast.functionDeclarationExpression(
-              declarator.id,
-              rhs.params,
-              rhs.body.type === 'BlockStatement'
-                ? rhs.body
-                : ast.blockStatement([ast.returnStatement(rhs.body)])
-            ) as FunctionDeclarationExpression
-            funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
-              []
-            ])[0] as FunctionDeclarationExpression
-            // substitute the rest of the program
-            const remainingProgram = ast.program(otherStatements as es.Statement[])
-            const subst = substituteMain(funDecExp.id, funDecExp, remainingProgram, paths)
-            // concats paths such that:
-            // paths[0] -> path to the program to be substituted, pre-redex
-            // paths[1...] -> path(s) to the parts of the remaining program
-            // that were substituted, post-redex
-            paths[0].push('body[0]')
-            const allPaths = paths.concat(subst[1])
-            if (subst[1].length === 0) {
-              allPaths.push([])
-            }
-            return [subst[0], context, allPaths, explain(node)]
+            const wholeBlock = body.concat(...(otherStatements as es.Statement[]))
+            return [ast.program(wholeBlock), cont, path, str]
           } else {
-            paths[0].push('body[0]')
-            paths[0].push('declarations[0]')
-            paths[0].push('init')
-            const [reducedRhs, cont, path, str] = reduce(rhs, context, paths)
             return [
-              ast.program([
-                ast.declaration(
-                  declarator.id.name,
-                  'const',
-                  reducedRhs as es.Expression
-                ) as es.Statement,
-                ...(otherStatements as es.Statement[])
-              ]),
+              ast.program([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
               cont,
               path,
               str
             ]
           }
+        } else if (
+          firstStatement.type === 'ExpressionStatement' &&
+          isIrreducible(firstStatement.expression)
+        ) {
+          // let stmt
+          // if (otherStatements.length > 0) {
+          paths[0].push('body[0]')
+          paths.push([])
+          const stmt = ast.program(otherStatements as es.Statement[])
+          // } else {
+          //   stmt = ast.expressionStatement(firstStatement.expression)
+          // }
+          return [stmt, context, paths, explain(node)]
+        } else if (firstStatement.type === 'FunctionDeclaration') {
+          let funDecExp = ast.functionDeclarationExpression(
+            firstStatement.id!,
+            firstStatement.params,
+            firstStatement.body
+          ) as FunctionDeclarationExpression
+          // substitute body
+          funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
+            []
+          ])[0] as FunctionDeclarationExpression
+          // substitute the rest of the program
+          const remainingProgram = ast.program(otherStatements as es.Statement[])
+          // substitution within the same program, add " same" so that substituter can differentiate between
+          // substitution within the program and substitution from outside the program
+          const newId = ast.identifier(funDecExp.id.name + ' same', funDecExp.id.loc)
+          const subst = substituteMain(newId, funDecExp, remainingProgram, paths)
+          // concats paths such that:
+          // paths[0] -> path to the program to be substituted, pre-redex
+          // paths[1...] -> path(s) to the parts of the remaining program
+          // that were substituted, post-redex
+          paths[0].push('body[0]')
+          const allPaths = paths.concat(subst[1])
+          if (subst[1].length === 0) {
+            allPaths.push([])
+          }
+          return [subst[0], context, allPaths, explain(node)]
+        } else if (firstStatement.type === 'VariableDeclaration') {
+          const { kind, declarations } = firstStatement
+          if (kind !== 'const') {
+            // TODO: cannot use let or var
+            return [dummyProgram(), context, paths, 'cannot use let or var']
+          } else if (
+            declarations.length <= 0 ||
+            declarations.length > 1 ||
+            declarations[0].type !== 'VariableDeclarator' ||
+            !declarations[0].init
+          ) {
+            // TODO: syntax error
+            return [dummyProgram(), context, paths, 'syntax error']
+          } else {
+            const declarator = declarations[0] as es.VariableDeclarator
+            const rhs = declarator.init!
+            if (declarator.id.type !== 'Identifier') {
+              // TODO: source does not allow destructuring
+              return [dummyProgram(), context, paths, 'source does not allow destructuring']
+            } else if (isIrreducible(rhs)) {
+              const remainingProgram = ast.program(otherStatements as es.Statement[])
+              // force casting for weird errors
+              // substitution within the same program, add " same" so that substituter can differentiate between
+              // substitution within the program and substitution from outside the program
+              const newId = ast.identifier(declarator.id.name + ' same', declarator.id.loc)
+              const subst = substituteMain(
+                newId,
+                rhs as es.ArrayExpression,
+                remainingProgram,
+                paths
+              )
+              // concats paths such that:
+              // paths[0] -> path to the program to be substituted, pre-redex
+              // paths[1...] -> path(s) to the parts of the remaining program
+              // that were substituted, post-redex
+              paths[0].push('body[0]')
+              const allPaths = paths.concat(subst[1])
+              if (subst[1].length === 0) {
+                allPaths.push([])
+              }
+              return [subst[0], context, allPaths, explain(node)]
+            } else if (
+              rhs.type === 'ArrowFunctionExpression' ||
+              rhs.type === 'FunctionExpression'
+            ) {
+              let funDecExp = ast.functionDeclarationExpression(
+                declarator.id,
+                rhs.params,
+                rhs.body.type === 'BlockStatement'
+                  ? rhs.body
+                  : ast.blockStatement([ast.returnStatement(rhs.body)])
+              ) as FunctionDeclarationExpression
+              // substitute body
+              funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
+                []
+              ])[0] as FunctionDeclarationExpression
+              // substitute the rest of the program
+              const remainingProgram = ast.program(otherStatements as es.Statement[])
+              // substitution within the same block, add " same" so that substituter can differentiate between
+              // substitution within the block and substitution from outside the block
+              const newId = ast.identifier(funDecExp.id.name + ' same', funDecExp.id.loc)
+              const subst = substituteMain(newId, funDecExp, remainingProgram, paths)
+              // concats paths such that:
+              // paths[0] -> path to the program to be substituted, pre-redex
+              // paths[1...] -> path(s) to the parts of the remaining program
+              // that were substituted, post-redex
+              paths[0].push('body[0]')
+              const allPaths = paths.concat(subst[1])
+              if (subst[1].length === 0) {
+                allPaths.push([])
+              }
+              return [subst[0], context, allPaths, explain(node)]
+            } else {
+              paths[0].push('body[0]')
+              paths[0].push('declarations[0]')
+              paths[0].push('init')
+              const [reducedRhs, cont, path, str] = reduce(rhs, context, paths)
+              return [
+                ast.program([
+                  ast.declaration(
+                    declarator.id.name,
+                    'const',
+                    reducedRhs as es.Expression
+                  ) as es.Statement,
+                  ...(otherStatements as es.Statement[])
+                ]),
+                cont,
+                path,
+                str
+              ]
+            }
+          }
         }
+        paths[0].push('body[0]')
+        const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
+        return [
+          ast.program([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
+          cont,
+          path,
+          str
+        ]
       }
-      paths[0].push('body[0]')
-      const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
-      return [
-        ast.program([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
-        cont,
-        path,
-        str
-      ]
     },
 
     BlockStatement(

--- a/src/stepper/util.ts
+++ b/src/stepper/util.ts
@@ -39,7 +39,9 @@ export function isAllowedLiterals(node: substituterNodes): boolean {
   return node.type === 'Identifier' && ['NaN', 'Infinity', 'undefined'].includes(node.name)
 }
 
-export function getDeclaredNames(node: es.BlockStatement | BlockExpression): Set<string> {
+export function getDeclaredNames(
+  node: es.BlockStatement | BlockExpression | es.Program
+): Set<string> {
   const declaredNames = new Set<string>()
   for (const stmt of node.body) {
     // if stmt is assignment or functionDeclaration


### PR DESCRIPTION
Resolves #772.

In the following test case taken from #772,

```
const reverse = x => x;
reverse(0);
```

The issue was that substPredefinedFns was substituting `reverse` at the very start. When the time came for `const reverse = ...` to be substituted, the `reverse` on line 2 already had its own "name", distinct from the Program-scoped `reverse` on line 1.

The fix is to treat substituting into a program the same as BlockStatements. However, because block statements and programs have different fields in the AST type, I simply copy-pasted instead of trying to convert back and forth between the two.

Now, when substPredefinedFns tries to substitute into the program, it will first scanOutDeclarations, same as with BlockStatements. This causes the substitution to stop because reverse is bound. Then, when the time comes for `const reverse = ...` to be substituted, the `reverse` on lines 1 and 2 share the same name as they are both untouched, and the substitution succeeds.