### PR TITLE
Make sicp compact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "js-slang",
-  "version": "0.4.79",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
-      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
+      "version": "15.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
       "dev": true
     }
   }

--- a/scripts/build_sicp_package.sh
+++ b/scripts/build_sicp_package.sh
@@ -32,47 +32,23 @@ write() {
     echo "\"use strict\";" >> $SICPJSPATH
     echo "Object.defineProperty(exports, \"__esModule\", { value: true });" >> $SICPJSPATH
     echo "const createContext_1 = require(\"./createContext\");" >> $SICPJSPATH
-    echo "createContext_1.default(4);" >> $SICPJSPATH
-    echo "const dict = createContext_1.dict;" >> $SICPJSPATH
+    echo "const dict = createContext_1.default(4).nativeStorage.globals.variables;" >> $SICPJSPATH
 
     cat sicp_publish/prelude.txt >> $SICPJSPATH
 
-    # Write Prelude
-    COUNT=0
 
+    #Write prelude names
     while read -r CURRENT_LINE
     do 
-        IFS=' ' read -r -a array <<< "$CURRENT_LINE"
-
-        if [ "${array[0]}" == "function" ]
-        then
-            if [ $COUNT -le 0 ]
-            then
-                IFS='(' read -r -a name <<< "${array[1]}"
-                echo "global.${name[0]} = ${name[0]};" >> $SICPJSPATH
-            fi
-        fi
-
-        if [ ${#array[@]} != 0 ]
-        then
-            if [ "${array[${#array[@]} - 1]}" == "{" ]
-            then 
-            ((COUNT++))
-            fi
-        fi
-
-        if [ "${array[0]}" == "}" ]
-        then
-            ((COUNT--))
-        fi
-    done < "sicp_publish/prelude.txt"
+        echo "global.$CURRENT_LINE = $CURRENT_LINE;" >> $SICPJSPATH
+    done < "sicp_publish/prelude_names.txt"
 
     #Write Functions
     while read -r CURRENT_LINE
     do 
         if [ "$CURRENT_LINE" != "undefined" -a "$CURRENT_LINE" != "NaN" -a "$CURRENT_LINE" != "Infinity" ]
         then
-            echo "global.$CURRENT_LINE = dict[\"$CURRENT_LINE\"];" >> $SICPJSPATH
+            echo "global.$CURRENT_LINE = dict.get(\"$CURRENT_LINE\").getValue();" >> $SICPJSPATH
         fi
     done < "sicp_publish/names.txt"
 }

--- a/sicp_publish/.gitignore
+++ b/sicp_publish/.gitignore
@@ -1,3 +1,4 @@
 names.txt
 prelude.txt
+prelude_names.txt
 package-lock.json

--- a/sicp_publish/package.json
+++ b/sicp_publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sicp",
-  "version": "1.0.17",
+  "version": "1.0.20",
   "description": "SICP Library",
   "dependencies": {
     "@types/estree": "0.0.47",

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -160,11 +160,7 @@ export const ensureGlobalEnvironmentExist = (context: Context) => {
   }
 }
 
-export const dict = {}
-
 export const defineSymbol = (context: Context, name: string, value: Value) => {
-  dict[name] = value
-
   const globalEnvironment = context.runtime.environments[0]
   Object.defineProperty(globalEnvironment.head, name, {
     value,

--- a/src/stdlib/README.md
+++ b/src/stdlib/README.md
@@ -1,2 +1,0 @@
-* By convention, we are including files with the name ...prelude...js literally in the sicp package.
-* We are extracting names that need to be globally defined by looking for lines that start with "function". So these prelude libraries can only declare functions, not other constants.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,9 +1300,9 @@
   integrity sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg==
 
 "@types/node@^15.6.1":
-  version "15.6.1"
-  resolved "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
-  integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
+  version "15.12.2"
+  resolved "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
+  integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
I have cut off `dict` and also process `prelude_names.txt` by acorn.

The `sicp` package has been published and tested successfully with almost every functions.