### PR TITLE
Update all SICP JS, Source docs, and Source Academy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Open-source implementations of the programming language *Source*. Source
 is a series of small subsets of JavaScript, designed for teaching
 university-level programming courses for computer science majors,
 following Structure and Interpretation of Computer Programs, JavaScript
-Adaptation (<https://source-academy.github.io/sicp/>).
+Adaptation (<https://sourceacademy.org/interactive-sicp/>).
 
 Usage
 =====
@@ -72,7 +72,7 @@ $ js-slang -n --chapter=1 -e "$(< my_source_program.js)"
 Documentation
 =============
 
-Source is documented here: <https://source-academy.github.io/source/>
+Source is documented here: <https://docs.sourceacademy.org/>
 
 ## Requirements
 * `bash`: known working version: GNU bash, version 5.0.16

--- a/docs/jsdoc/templates/template/tmpl/container.tmpl
+++ b/docs/jsdoc/templates/template/tmpl/container.tmpl
@@ -26,11 +26,11 @@
         <article>
 	<p>
   	  Below you find all constants and functions used in the textbook
-	  <a href="https://source-academy.github.io/sicp">Structure and Interpretation
+	  <a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 	  of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 	  These constants and functions are predeclared in the language
 	  Source §4, a JavaScript sublanguage implemented in the
-	  <a href="https://source-academy.github.io">Source Academy</a>.
+	  <a href="https://sourceacademy.org">Source Academy</a>.
 	</p>
 	<h2>Can I use these constants and functions without the Source Academy ?</h2>
 	<p>

--- a/docs/lib/mce.js
+++ b/docs/lib/mce.js
@@ -3,7 +3,7 @@
  * the string <CODE>str</CODE> as a Source program. The format
  * of the parse tree is described in chapter 4 of 
  * the textbook 
- * in <a href="https://sicp.comp.nus.edu.sg/">Structure and
+ * in <a href="https://sourceacademy.org/interactive-sicp/">Structure and
  * Interpretation of Computer Programs, JavaScript Adaptation</a> (SICP).
  * @param {string} x - given program as a string
  * @returns {value} parse tree

--- a/docs/lib/misc.js
+++ b/docs/lib/misc.js
@@ -1,6 +1,6 @@
 /**
  * checks whether a given value is a number.
- * See also <a href="https://sicp.comp.nus.edu.sg/chapters/36">textbook example</a>.
+ * See also <a href="https://sourceacademy.org/interactive-sicp/2.3.2">textbook example</a>.
  * @param {value} v to be checked
  * @returns {boolean} indicating whether the value is a number
  */
@@ -17,7 +17,7 @@ function is_boolean(v) {
 
 /**
  * checks whether a given value is a string.
- * See also <a href="https://sicp.comp.nus.edu.sg/chapters/36">textbook example</a>.
+ * See also <a href="https://sourceacademy.org/interactive-sicp/2.3.2">textbook example</a>.
  * @param {value} v to be checked
  * @returns {boolean} indicating whether the value is a string
  */
@@ -42,7 +42,7 @@ function is_undefined(v) {
 
 /**
  * Returns number of milliseconds elapsed since January 1, 1970 00:00:00 UTC.
- * See also <a href="https://sicp.comp.nus.edu.sg/chapters/17#ex_1.22">textbook example</a>.
+ * See also <a href="https://sourceacademy.org/interactive-sicp/1.2.6#ex-1.21">textbook example</a>.
  * @returns {number} current time in milliseconds
  */
 export function get_time() {
@@ -50,28 +50,28 @@ export function get_time() {
 }
 
 /**
- * Interprets a given string <CODE>s</CODE> as an integer, 
- * using the positive integer <CODE>i</CODE> as radix, 
+ * Interprets a given string <CODE>s</CODE> as an integer,
+ * using the positive integer <CODE>i</CODE> as radix,
  * and returns the respective value.
- * <BR/>Examples: <CODE>parse_int("909", 10)</CODE> returns the number 
- * <CODE>909</CODE>, and <CODE>parse_int("-1111", 2)</CODE> returns the number 
+ * <BR/>Examples: <CODE>parse_int("909", 10)</CODE> returns the number
+ * <CODE>909</CODE>, and <CODE>parse_int("-1111", 2)</CODE> returns the number
  * <CODE>-15</CODE>.<BR/>
  * See <a href="https://www.ecma-international.org/ecma-262/9.0/index.html#sec-parseint-string-radix">ECMAScript Specification, Section 18.2.5</a> for details.
  * @param {string} s - string to be converted
- * @param {number} i - radix 
+ * @param {number} i - radix
  * @returns {number} result of conversion
  */
 function parse_int(s, i) {}
 
 /**
  * The name <CODE>undefined</CODE> refers to the special value <CODE>undefined</CODE>.
- * See also <a href="https://sicp.comp.nus.edu.sg/chapters/4">textbook explanation in section 1.1.2</a>.
+ * See also <a href="https://sourceacademy.org/interactive-sicp/4.1.1#h5">textbook explanation in section 4.1.1</a>.
  * @const {undefined}
  */
 const undefined = (() => {})();
 
 /**
- * The name <CODE>NaN</CODE> refers to the special number value <CODE>NaN</CODE> ("not a number"). Note that 
+ * The name <CODE>NaN</CODE> refers to the special number value <CODE>NaN</CODE> ("not a number"). Note that
  * <CODE>NaN</CODE> is a number, as specified by <CODE>is_number</CODE>.
  * See <a href="https://www.ecma-international.org/ecma-262/9.0/index.html#sec-value-properties-of-the-global-object-nan">ECMAScript Specification, Section 4.3.24</a>
  * @const {number}
@@ -87,9 +87,9 @@ const Infinity = 1 / 0;
 
 /**
  * Pops up a window that displays the string <CODE>s</CODE>, provides
- * an input line for the user to enter a text, a <CODE>Cancel</CODE> button and an <CODE>OK</CODE> button. 
+ * an input line for the user to enter a text, a <CODE>Cancel</CODE> button and an <CODE>OK</CODE> button.
  * The call of <CODE>prompt</CODE>
- * suspends execution of the program until one of the two buttons is pressed. If 
+ * suspends execution of the program until one of the two buttons is pressed. If
  * the <CODE>OK</CODE> button is pressed, <CODE>prompt</CODE> returns the entered text as a string.
  * If the <CODE>Cancel</CODE> button is pressed, <CODE>prompt</CODE> returns a non-string value.
  * @param {string} s to be displayed in popup
@@ -99,14 +99,14 @@ function prompt(s) {
 }
 
 /**
- * Optional second argument. If present, 
+ * Optional second argument. If present,
  * displays the given string <CODE>s</CODE>, followed by a space character, followed by the
- * value <CODE>v</CODE> in the console. 
- * If second argument not present, 
+ * value <CODE>v</CODE> in the console.
+ * If second argument not present,
  * just displays the value <CODE>v</CODE> in the console.
- * The notation used for the display of values 
- * is consistent with 
- * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">JSON</a>, 
+ * The notation used for the display of values
+ * is consistent with
+ * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">JSON</a>,
  * but also displays <CODE>undefined</CODE>, <CODE>NaN</CODE>, <CODE>Infinity</CODE>, and function objects.
  * @param {value} v to be displayed
  * @param {string} s to be displayed, preceding <CODE>v</CODE>, optional argument
@@ -117,16 +117,16 @@ function display(v, s) {
 
 /**
  * Optional second argument.
- * If present, 
+ * If present,
  * displays the given string <CODE>s</CODE>, followed by a space character, followed by the
- * value <CODE>v</CODE> in the console with error flag. 
- * If second argument not present, 
+ * value <CODE>v</CODE> in the console with error flag.
+ * If second argument not present,
  * just displays the value <CODE>v</CODE> in the console with error flag.
  * The evaluation
  * of any call of <CODE>error</CODE> aborts the running program immediately.
- * The notation used for the display of values 
- * is consistent with 
- * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">JSON</a>, 
+ * The notation used for the display of values
+ * is consistent with
+ * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">JSON</a>,
  * but also displays <CODE>undefined</CODE>, <CODE>NaN</CODE>, <CODE>Infinity</CODE>, and function objects.
  * @param {value} v to be displayed
  * @param {string} s to be displayed, preceding <CODE>v</CODE>
@@ -136,10 +136,10 @@ function error(v, s) {
 
 /**
  * returns a string that represents the value <CODE>v</CODE>, using a
- * notation that is is consistent with 
- * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">JSON</a>, 
+ * notation that is is consistent with
+ * <a href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">JSON</a>,
  * but also displays <CODE>undefined</CODE>, <CODE>NaN</CODE>, <CODE>Infinity</CODE>, and function objects.
- * See also <a href="https://sicp.comp.nus.edu.sg/chapters/62">textbook example</a>.
+ * See also <a href="https://sourceacademy.org/interactive-sicp/3.3.5">textbook example</a>.
  * @param {value} v the argument value
  * @returns {string} string representation of v
  */
@@ -151,7 +151,7 @@ function stringify(v) {
  * <CODE>i</CODE> as second argument. If <CODE>i</CODE> is less than the length
  * of <CODE>s</CODE>, this function returns a one-character string that contains
  * the character of <CODE>s</CODE> at position <CODE>i</CODE>, counting from 0.
- * If <CODE>i</CODE> is larger than or equal to the length of 
+ * If <CODE>i</CODE> is larger than or equal to the length of
  * <CODE>s</CODE>, this function returns <CODE>undefined</CODE>.
  * @param {string} s - given string
  * @param {number} i - index

--- a/docs/md/CURVES_README.md
+++ b/docs/md/CURVES_README.md
@@ -34,7 +34,7 @@ We can represent the *types* of these functions as follows:
 ## Examples
 
 A very simple curve is one that always returns the same point:
-<a href="https://source-academy.github.io/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABABzjMUD6EQCcBuApgBRQCUiA3gFCJ2K6FR5IC2AhgNaGarpTEADADoArABpEI0WQDc1AL7UAJrnYB3XmgwBnTAmIBGQYLLE%2BGbHiJygA">
+<a href="https://sourceacademy.org/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABABzjMUD6EQCcBuApgBRQCUiA3gFCJ2K6FR5IC2AhgNaGarpTEADADoArABpEI0WQDc1AL7UAJrnYB3XmgwBnTAmIBGQYLLE%2BGbHiJygA">
 ```
 function point_curve(t) {
     return make_point(0.5, 0.5);
@@ -43,7 +43,7 @@ function point_curve(t) {
 </a>
 
 We define the Curve `unit_circle` and draw it as follows:
-<a href="https://source-academy.github.io/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABOGUD6EYCcIBsCmAFFAJSIDeAUIjYlvlCFkgLYCGA1vmgA5wxgohdlAAWaAM4DCAJkQAqRCPEAFAJILEpADTVa%2Bg4drKMcCbM0n1m0iQDclAL6UAJljYB3U2DD5o%2BFzRQXFw0ADcYfA9CAEYABjiSQhR0TBwCeyA">
+<a href="https://sourceacademy.org/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABOGUD6EYCcIBsCmAFFAJSIDeAUIjYlvlCFkgLYCGA1vmgA5wxgohdlAAWaAM4DCAJkQAqRCPEAFAJILEpADTVa%2Bg4drKMcCbM0n1m0iQDclAL6UAJljYB3U2DD5o%2BFzRQXFw0ADcYfA9CAEYABjiSQhR0TBwCeyA">
 ```
 function unit_circle(t) {
     return make_point(math_cos(2 * math_PI * t),
@@ -68,7 +68,7 @@ displays it graphically, in a window, instead of textually.
 The functions returned by `draw_connected_full_view` stretch or shrink
 the given Curve to show the full curve and maximize its width and height,
 with some padding.
-<a href="https://source-academy.github.io/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABOGUD6AbGYCmaCGUAFAJ4CUiA3gFCJ2IBOOUIDSUiAvAHyIC2%2BANZ4ADnGzEoAGkQlEAakQAGRAHoAjEqVkA3NQC%2B1ACYN8AdzQQEuaDiNFN2oinRZcBYkoB0AVjK6gA">
+<a href="https://sourceacademy.org/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABOGUD6AbGYCmaCGUAFAJ4CUiA3gFCJ2IBOOUIDSUiAvAHyIC2%2BANZ4ADnGzEoAGkQlEAakQAGRAHoAjEqVkA3NQC%2B1ACYN8AdzQQEuaDiNFN2oinRZcBYkoB0AVjK6gA">
 ```
 function unit_line_at(y) {
     return t => make_point(t, y);
@@ -80,7 +80,7 @@ This function takes a number as argument, the y position, and
 returns a Curve that is a horizontal line at the level given by y.
 
 The Curve `haf_way_line`
-<a href="https://source-academy.github.io/playground#chap=2&ext=CURVES&prgrm=MYewdgzgLgBAFgQwDYDMD6B3BBPNSCWYApjALwwCuY%2BUehRaCUAFAAwB0ArAJQDcAUABMATggxpQYYsChFBzAIytW3ZolSYcdYnyA">
+<a href="https://sourceacademy.org/playground#chap=2&ext=CURVES&prgrm=MYewdgzgLgBAFgQwDYDMD6B3BBPNSCWYApjALwwCuY%2BUehRaCUAFAAwB0ArAJQDcAUABMATggxpQYYsChFBzAIytW3ZolSYcdYnyA">
 ```
 const half_way_line = unit_line_at(0.5);
 ```
@@ -101,7 +101,7 @@ Number → (Number → Point)
 A Curve transformation is a function that takes a curve as argument and returns
 a Curve. The following function `up_a_bit` is a Curve transformation that moves
 a given curve up by 0.3.
-<a href="https://source-academy.github.io/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABCADgfQIZoEYygCghACcA3AUwEpEBvAKEUcWPKhKSkQF4A%2BRAWwwBrcmhRwYYAgA80cYIRIV8USpQA0iBkx269%2BxAE85ComXIq1iANSIADADoAzJQDcdAL50ICAM6cACwwAG2A0AHcMY2DJcm5kMDw0GLBRDAJHAFY3bz9OVPDk2PjUTBw8fCDQiKii1JyAE2IMQp8wVOhyBvwARjs7SnwCuqpXIA">
+<a href="https://sourceacademy.org/playground#chap=2&ext=CURVES&prgrm=GYVwdgxgLglg9mABCADgfQIZoEYygCghACcA3AUwEpEBvAKEUcWPKhKSkQF4A%2BRAWwwBrcmhRwYYAgA80cYIRIV8USpQA0iBkx269%2BxAE85ComXIq1iANSIADADoAzJQDcdAL50ICAM6cACwwAG2A0AHcMY2DJcm5kMDw0GLBRDAJHAFY3bz9OVPDk2PjUTBw8fCDQiKii1JyAE2IMQp8wVOhyBvwARjs7SnwCuqpXIA">
 ```
 function up_a_bit(curve) {
     return t => make_point(x_of(curve(t)), 

--- a/docs/md/README_1.md
+++ b/docs/md/README_1.md
@@ -1,7 +1,7 @@
 Source §1 is a small programming language, designed for the first chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 ## What names are predeclared in Source §1?
 
@@ -17,8 +17,8 @@ These names come in two groups:
     </li>
   </ul>
 
-The <a href="https://sourceacademy.nus.edu.sg">Source Academy</a>,
-a learning environment that uses SICP JS and Source, comes with the following 
+The <a href="https://sourceacademy.org"">Source Academy</a>,
+a learning environment that uses SICP JS and Source, comes with the following
 <a href="../External libraries/">external libraries</a> suitable for Source §1:
   <ul>
     <li>
@@ -33,13 +33,13 @@ a learning environment that uses SICP JS and Source, comes with the following
     <li>
       <a href="../EV3/index.html">EV3</a>: Library for EV3 Lego Mindstorms robots
     </li>
-    
+
   </ul>
 
 ## What can you do in Source §1?
 
 You can use all features that are introduced in
-<a href="https://sicp.comp.nus.edu.sg/chapters/1">chapter 1</a> of the
+<a href="https://sourceacademy.org/interactive-sicp/1">chapter 1</a> of the
 textbook. Below is the list of features, each with a link to the
 textbook section that introduces it and a small example.
 
@@ -49,7 +49,7 @@ Literal values are simple expressions that directly evaluate to values. These
 include numbers in the usual decimal notation, the two boolean values
 `true` and `false`, and the predeclared names
 `NaN`, `Infinity` and `undefined`.
-More on literal values in <a href="https://sicp.comp.nus.edu.sg/chapters/2">section
+More on literal values in <a href="https://sourceacademy.org/interactive-sicp/1.1">section
 1.1 The Elements of Programming</a> of the textbook.
 
 ### Constant declarations
@@ -58,18 +58,18 @@ Constant declarations are done in Source with <PRE><CODE>const my_name = x + 2;<
 Here the name `my_name` gets declared within the surrounding block,
 and refers to the result of evaluating `x + 2` in the rest of the block.
 You can read more about the <EM>scope of names</EM> in
-<a href="https://sicp.comp.nus.edu.sg/chapters/10">section 1.1.8
+<a href="https://sourceacademy.org/interactive-sicp/1.1.8">section 1.1.8
 Functions as Black-Box Abstractions</a>.
 
 ### Conditional statements and conditional expressions
 
-Within expressions, you can let a <EM>predicate</EM> determine whether 
+Within expressions, you can let a <EM>predicate</EM> determine whether
 a <EM>consequent expression</EM>
 gets evaluated or an <EM>alternative expression</EM>. This is done by writing,
 for example
 <PRE><CODE>return p(x) ? 7 : f(y);</CODE></PRE>
 Read more on conditional expressions in
-<a href="https://sicp.comp.nus.edu.sg/chapters/8">section 1.1.6
+<a href="https://sourceacademy.org/interactive-sicp/1.1.6">section 1.1.6
 Conditional Expressions and Predicates</a>.
 <EM>Conditional evaluation</EM> is also possible within statements, for
 example the body of a function declaration. For that, you can use <EM>conditional
@@ -79,7 +79,7 @@ statements</EM>, for example:<PRE><CODE>if (p(x)) {
     return f(y);
 }</CODE></PRE>
 Read about <EM>conditional statements</EM> in
-<a href="https://sicp.comp.nus.edu.sg/chapters/20">section 1.3.2
+<a href="https://sourceacademy.org/interactive-sicp/1.3.2">section 1.3.2
 Function Definition Expressions</a>.
 
 ### Function declarations and function definitions
@@ -92,7 +92,7 @@ to a function. For example
 </PRE>
 declares the name `square` and binds it to a squaring function, so that it can be applied
 as in `square(5);`. You can read about function declaration statements in textbook
-<a href="https://sicp.comp.nus.edu.sg/chapters/6">section 1.1.4 Functions</a>.
+<a href="https://sourceacademy.org/interactive-sicp/1.1.4">section 1.1.4 Functions</a>.
 
 Sometimes, it's not necessary to give a name to a function: You may
 want to create a function only to pass it to some other function as argument.
@@ -104,7 +104,7 @@ creates a square function just like the function declaration above,
 but does not give it a name.
 Its only purpose it to be applied to the number 3. See also
 textbook
-<a href="https://sicp.comp.nus.edu.sg/chapters/20">section 1.3.2 Function Definition Expressions</a>.
+<a href="https://sourceacademy.org/interactive-sicp/1.3.2">section 1.3.2 Function Definition Expressions</a>.
 
 ### Blocks
 
@@ -124,7 +124,7 @@ However, the second application
 of `display` shows the value 1, because
 the declaration <B>const</B> `a = 2;` is limited in scope by its surrounding block.
 You can read more about <EM>blocks</EM> in
-<a href="https://sicp.comp.nus.edu.sg/chapters/10">section 1.1.8
+<a href="https://sourceacademy.org/interactive-sicp/1.1.8">section 1.1.8
 Functions as Black-Box Abstractions</a>.
 
 ### Boolean operators
@@ -136,8 +136,8 @@ is carried out. However, the operator `&&` works differently. An expression
 `e1 && e2` should be seen as an abbreviation for `e1 ? e2 : false`. The expression
 `e2` only gets evaluated if `e1` evaluates to `true`. The behaviour of `||` is similar:
 `e1 || e2` should be seen as an abbreviation for `e1 ? true : e2`. More on these
-two boolean operators in textbook 
-<a href="https://sicp.comp.nus.edu.sg/chapters/8">section 1.1.6 Conditional
+two boolean operators in textbook
+<a href="https://sourceacademy.org/interactive-sicp/1.1.6">section 1.1.6 Conditional
 Expressions and Predicates</a>.
 
 ### Sequences
@@ -149,9 +149,9 @@ of a Source implementation, you can write
 square(5);</CODE></PRE>
 The statements in such a sequence are evaluated in the given order. The
 result of evaluating the sequence is the result of evaluating the last
-statement in the sequence, in this case `square(5);`. 
+statement in the sequence, in this case `square(5);`.
 Read more about sequences in
-<a href="https://sicp.comp.nus.edu.sg/chapters/4">section 1.1.2
+<a href="https://sourceacademy.org/interactive-sicp/1.1.2">section 1.1.2
 Naming and the Environment</a> of the textbook.
 
 ## You want the definitive specs?

--- a/docs/md/README_1_LAZY.md
+++ b/docs/md/README_1_LAZY.md
@@ -1,6 +1,6 @@
 Source §1 Lazy is a small programming language, designed for the first chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 Instead of the more common evaluation order of applicative order reduction
 employed by Source §1, the language Source §1 Lazy uses a variant of
@@ -9,9 +9,9 @@ normal order reduction called <EM>lazy evaluation</EM>.
 ## What is lazy  evaluation?
 
 In most programming languages, the arguments of primitive operations
-or functions are fully evaluated before the operation or the 
+or functions are fully evaluated before the operation or the
 the function is applied. This is called <EM>applicative order reduction</EM>.
-<a href="https://sicp.comp.nus.edu.sg/chapters/84">Section 1.1.5</a>
+<a href="https://sourceacademy.org/interactive-sicp/1.1.5">Section 1.1.5</a>
 of Structure and Interpretation of Computer Programs, JavaScript Adaptation
 (SICP JS), introduces an alternative, called normal order reduction. In
 this scheme, the argument expressions of functions are passed un-evaluated
@@ -28,8 +28,8 @@ whenever it is required again.
 
 You can use all features of
 <a href="../source_1/">Source §1</a>, but with the added
-benefit of lazy evaluation. See 
-<a href="https://sicp.comp.nus.edu.sg/chapters/7">Section 1.1.5</a>
+benefit of lazy evaluation. See
+<a href="https://sourceacademy.org/interactive-sicp/1.1.5">Section 1.1.5</a>
 of Structure and Interpretation of Computer Programs, JavaScript Adaptation
 (SICP JS) for examples.
 

--- a/docs/md/README_1_WASM.md
+++ b/docs/md/README_1_WASM.md
@@ -1,7 +1,7 @@
 
 Source §1 is a small programming language, designed for the first chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS).   Source §1 WebAssembly is an experimental implementation of Source §1 that compiles Source §1 to WebAssembly.
 
 

--- a/docs/md/README_2.md
+++ b/docs/md/README_2.md
@@ -1,7 +1,7 @@
 Source §2 is a small programming language, designed for the second chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 ## What names are predeclared in Source §2?
 
@@ -19,8 +19,8 @@ order. Click on a name to see how it is used. They come in these three groups:
     </li>
   </ul>
 
-The <a href="https://sourceacademy.nus.edu.sg">Source Academy</a>,
-a learning environment that uses SICP JS and Source, comes with the following 
+The <a href="https://sourceacademy.org"">Source Academy</a>,
+a learning environment that uses SICP JS and Source, comes with the following
 <a href="../External libraries/">external libraries</a> for Source §2:
   <ul>
     <li>
@@ -41,7 +41,7 @@ a learning environment that uses SICP JS and Source, comes with the following
     <li>
       <a href="../EV3/index.html">EV3</a>: Library for EV3 Lego Mindstorms robots
     </li>
-    
+
   </ul>
 
 ## What can you do in Source §2?
@@ -49,7 +49,7 @@ a learning environment that uses SICP JS and Source, comes with the following
 You can use all features of
 <a href="../source_1/">Source §1</a> and all
 features that are introduced in
-<a href="https://sicp.comp.nus.edu.sg/chapters/23">chapter 2</a> of the
+<a href="https://sourceacademy.org/interactive-sicp/2">chapter 2</a> of the
 textbook.
 Below are the features that Source §2 adds to Source §1.
 

--- a/docs/md/README_2_LAZY.md
+++ b/docs/md/README_2_LAZY.md
@@ -1,6 +1,6 @@
 Source §2 Lazy is a small programming language, designed for the first chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 Instead of the more common evaluation order of applicative order reduction
 employed by Source §2, the language Source §2 Lazy uses a variant of
@@ -9,9 +9,9 @@ normal order reduction called <EM>lazy evaluation</EM>.
 ## What is lazy  evaluation?
 
 In most programming languages, the arguments of primitive operations
-or functions are fully evaluated before the operation or the 
+or functions are fully evaluated before the operation or the
 the function is applied. This is called <EM>applicative order reduction</EM>.
-<a href="https://sicp.comp.nus.edu.sg/chapters/84">Section 1.1.5</a>
+<a href="https://sourceacademy.org/interactive-sicp/1.1.5">Section 1.1.5</a>
 of Structure and Interpretation of Computer Programs, JavaScript Adaptation
 (SICP JS), introduces an alternative, called normal order reduction. In
 this scheme, the argument expressions of functions are passed un-evaluated
@@ -30,8 +30,8 @@ You can use all features of
 <a href="../source_1/">Source §1</a>, but with the added
 benefit of lazy evaluation. For example, lists in
 Source §1 Lazy are lazy: They can be infinite, as shown
-in 
-<a href="https://sicp.comp.nus.edu.sg/chapters/84">Section 4.2.3</a>
+in
+<a href="https://sourceacademy.org/interactive-sicp/4.2.3">Section 4.2.3</a>
 of Structure and Interpretation of Computer Programs, JavaScript Adaptation
 (SICP JS).
 

--- a/docs/md/README_3.md
+++ b/docs/md/README_3.md
@@ -1,7 +1,7 @@
 Source §3 is a small programming language, designed for the third chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 ## What names are predeclared in Source §3?
 
@@ -28,8 +28,8 @@ order. Click on a name to see how it is used. They come in these two groups:
     </li>
   </ul>
 
-The <a href="https://sourceacademy.nus.edu.sg">Source Academy</a>,
-a learning environment that uses SICP JS and Source, comes with the following 
+The <a href="https://sourceacademy.org"">Source Academy</a>,
+a learning environment that uses SICP JS and Source, comes with the following
 <a href="../External libraries/">external libraries</a>:
   <ul>
     <li>
@@ -60,7 +60,7 @@ a learning environment that uses SICP JS and Source, comes with the following
 You can use all features of
 <a href="../source_2/">Source §2</a> and all
 features that are introduced in
-<a href="https://sicp.comp.nus.edu.sg/chapters/47">chapter 3</a> of the
+<a href="https://sourceacademy.org/interactive-sicp/3">chapter 3</a> of the
 textbook.
 Below are the features that Source §3 adds to Source §2.
 
@@ -84,7 +84,7 @@ display(x); // x is still 1
 x = x + 1;
 diplay(x);  // now x is 2</CODE></PRE>
 Read more on variable declaration and assignment in
-<a href="https://sicp.comp.nus.edu.sg/chapters/49">section 3.1.1 Local State Variables</a>
+<a href="https://sourceacademy.org/interactive-sicp/3.1.1">section 3.1.1 Local State Variables</a>
 of the textbook.
 
 ### While loops

--- a/docs/md/README_3_CONCURRENT.md
+++ b/docs/md/README_3_CONCURRENT.md
@@ -1,7 +1,7 @@
 Source §3 Concurrent is a small programming language, designed for the third chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 ## What names are predeclared in Source §3 Concurrent?
 
@@ -36,7 +36,7 @@ order. Click on a name to see how it is used.
 You can use all features of
 <a href="../source_3/">Source §3</a> and all
 features that are introduced in
-<a href="https://sicp.comp.nus.edu.sg/chapters/65">chapter 3.4</a> of the
+<a href="https://sourceacademy.org/interactive-sicp/3.4">chapter 3.4</a> of the
 textbook.
 Below are the features that Source §3 Concurrent adds to Source §3.
 

--- a/docs/md/README_3_NON-DET.md
+++ b/docs/md/README_3_NON-DET.md
@@ -1,6 +1,6 @@
 Source §3 Non-Det is a small programming language, designed for the fourth chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 ## What is nondeterministic programming?
@@ -41,7 +41,7 @@ order. Click on a name to see how it is used.
 You can use all features of
 <a href="../source_3/">Source §3</a> and all
 features that are introduced in
-<a href="https://sicp.comp.nus.edu.sg/chapters/85">chapter 4.3</a> of the
+<a href="https://sourceacademy.org/interactive-sicp/4.3">chapter 4.3</a> of the
 textbook.
 
 Below are the features that Source §3 Non-Det adds to Source §3.
@@ -78,7 +78,7 @@ the <CODE>cut</CODE> operator can be used to prevent backtracking beyond the cur
 In the following example, we are able to obtain only a single value:<br>
 <CODE>const f = amb(1, 2, 3, 4, 5, 6); require(f > 3); cut(); f; // 4</CODE>
 
-Entering <CODE>try_again</CODE> in the playground REPL will not give the subsequent values that were specified, 
+Entering <CODE>try_again</CODE> in the playground REPL will not give the subsequent values that were specified,
 <CODE>5</CODE> and <CODE>6</CODE>.
 
 ### implication function

--- a/docs/md/README_4.md
+++ b/docs/md/README_4.md
@@ -1,6 +1,6 @@
 Source §4 is a small programming language, designed for the fourth chapter
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
 
 ## What names are predeclared in Source §4?
@@ -31,7 +31,7 @@ order. Click on a name to see how it is used. They come in these two groups:
     </li>
   </ul>
 
-The <a href="https://sourceacademy.nus.edu.sg">Source Academy</a>,
+The <a href="https://sourceacademy.org"">Source Academy</a>,
 a learning environment that uses SICP JS and Source, comes with the following 
 <a href="../External libraries/">external libraries</a>:
   <ul>
@@ -63,7 +63,7 @@ a learning environment that uses SICP JS and Source, comes with the following
 You can use all features of
 <a href="../source_3/">Source §3</a> and 
 the two functions that are introduced in chapter 4
-<a href="https://sicp.comp.nus.edu.sg">of the textbook</a>,
+<a href="https://sourceacademy.org/interactive-sicp">of the textbook</a>,
 given in  <a href="../MCE/index.html">MCE</a>.
 
 ## You want the definitive specs?

--- a/docs/md/README_4_GPU.md
+++ b/docs/md/README_4_GPU.md
@@ -29,7 +29,7 @@ order. Click on a name to see how it is used. They come in these two groups:
     </li>
   </ul>
 
-The <a href="https://sourceacademy.nus.edu.sg">Source Academy</a>,
+The <a href="https://sourceacademy.org"">Source Academy</a>,
 a learning environment that uses SICP JS and Source, comes with the following 
 <a href="External libraries/">external libraries</a>:
   <ul>

--- a/docs/md/README_ARRAYS.md
+++ b/docs/md/README_ARRAYS.md
@@ -3,6 +3,6 @@ Click on a name on the right to see how they are defined and used.
 
 Arrays are not covered in 
 the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS),
 but they are included in Source §3.

--- a/docs/md/README_BINARYTREES.md
+++ b/docs/md/README_BINARYTREES.md
@@ -1,7 +1,7 @@
 BINARYTREES provide functions for binary trees, as covered
 the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS) 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS)
 in
-<a href="https://sicp.comp.nus.edu.sg/chapters/37">section 2.3.3 Example: Representing Sets</a>.
+<a href="https://sourceacademy.org/interactive-sicp/2.3.3">section 2.3.3 Example: Representing Sets</a>.
 Click on a name on the right to see how they are defined and used.

--- a/docs/md/README_CONCURRENCY.md
+++ b/docs/md/README_CONCURRENCY.md
@@ -3,8 +3,8 @@ Click on a name on the right to see how they are defined and used.
 
 Concurrency is covered in
 the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS) 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS)
 in
-<a href="https://sicp.comp.nus.edu.sg/chapters/65">section 3.4.2 Mechanisms for Controlling Concurrency</a>.
+<a href="https://sourceacademy.org/interactive-sicp/3.4.2">section 3.4.2 Mechanisms for Controlling Concurrency</a>.
 

--- a/docs/md/README_LISTS.md
+++ b/docs/md/README_LISTS.md
@@ -1,10 +1,10 @@
 The functions in LISTS provide useful functions for list processing,
 as introduced on
-<a href="https://sicp.comp.nus.edu.sg/chapters/29">section
+<a href="https://sourceacademy.org/interactive-sicp/2.2">section
 2.2 Hierarchical Data and the Closure Property</a>
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 On the right, you see all predeclared LISTS functions,
 in alphabetical

--- a/docs/md/README_MCE.md
+++ b/docs/md/README_MCE.md
@@ -4,5 +4,5 @@ Click on a name on the right to see how they are defined and used.
 
 The meta-circular evaluator of Source is covered in chapter 4 of
 the textbook 
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS).

--- a/docs/md/README_MISC.md
+++ b/docs/md/README_MISC.md
@@ -1,12 +1,12 @@
 On the right, you see all predeclared names of MISC, in alphabetical
 order. Click on a name to see how it is defined and used.
 
-Once you have read <a href="https://sicp.comp.nus.edu.sg/chapters/14">section 1.2.3 Orders
+Once you have read <a href="https://sourceacademy.org/interactive-sicp/1.2.3">section 1.2.3 Orders
 of Growth</a> of the textbook, you may wonder about the order of growth of these functions.
 You can assume that all functions in MISC run
-in `O(1)` time, except `display`, `error` and `stringify`, 
+in `O(1)` time, except `display`, `error` and `stringify`,
 which run in `O(n)` time, where `n` is
 the size (number of components such as pairs)
-of their first argument. More on pairs in 
-<a href="https://sicp.comp.nus.edu.sg/chapters/23">chapter 2 Building Abstractions with Data</a>
+of their first argument. More on pairs in
+<a href="https://sourceacademy.org/interactive-sicp/2">chapter 2 Building Abstractions with Data</a>
 of the textbook.

--- a/docs/md/README_NON-DET.md
+++ b/docs/md/README_NON-DET.md
@@ -1,10 +1,10 @@
 The functions in NON-DET provide useful functions for nondeterministic programs,
 as introduced in
-<a href="https://sicp.comp.nus.edu.sg/chapters/85">section
+<a href="https://sourceacademy.org/interactive-sicp/4.3">section
 4.3 Nondeterministic computing</a>
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 On the right, you see all predeclared NON-DET functions,
 in alphabetical order. Click on a name to see how it is defined and used.

--- a/docs/md/README_PAIRMUTATORS.md
+++ b/docs/md/README_PAIRMUTATORS.md
@@ -3,8 +3,8 @@ Click on a name on the right to see how they are defined and used.
 
 Pair mutation is covered in
 the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS) 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS)
 in
-<a href="https://sicp.comp.nus.edu.sg/chapters/58">section 3.3.1 Mutable List Structure</a>.
+<a href="https://sourceacademy.org/interactive-sicp/3.3.1">section 3.3.1 Mutable List Structure</a>.
 

--- a/docs/md/README_STREAMS.md
+++ b/docs/md/README_STREAMS.md
@@ -1,10 +1,10 @@
 The functions in STREAMS provide useful functions for stream processing,
 as introduced on
-<a href="https://sicp.comp.nus.edu.sg/chapters/66">section
+<a href="https://sourceacademy.org/interactive-sicp/3.5">section
 3.5 Stream Processing</a>
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 
 On the right, you see all predeclared STREAMS functions,
 in alphabetical

--- a/docs/md/README_top.md
+++ b/docs/md/README_top.md
@@ -1,5 +1,5 @@
   Source is a family of languages, designed for the textbook
-  <a href="https://source-academy.github.io/sicp/">Structure and Interpretation
+  <a href="https://sourceacademy.org/interactive-sicp/">Structure and Interpretation
   of Computer Programs, JavaScript Adaptation</a> (SICP JS).  The languages are
   called Source §1, Source §2, Source §3 and Source §4, corresponding to the
   respective chapters 1, 2, 3 and 4 of the textbook. Each previous Source
@@ -18,7 +18,7 @@
 
 ### External libraries
 
-The <a href="https://sourceacademy.nus.edu.sg">Source Academy</a>
+The <a href="https://sourceacademy.org"">Source Academy</a>
 comes with the following <a href="External libraries/">external libraries</a>:
 
 <ul>

--- a/docs/md/RUNES_README.md
+++ b/docs/md/RUNES_README.md
@@ -1,9 +1,9 @@
 RUNES is a library for realising the picture language of
-<a href="https://sicp.comp.nus.edu.sg/chapters/33">section
+<a href="https://sourceacademy.org/interactive-sicp/2.2.4">section
 2.2.4 Example: A Picture Language</a>
 of the textbook
-<a href="https://sicp.comp.nus.edu.sg">Structure and Interpretation
-of Computer Programs, JavaScript Adaptation</a> (SICP JS). 
+<a href="https://sourceacademy.org/interactive-sicp">Structure and Interpretation
+of Computer Programs, JavaScript Adaptation</a> (SICP JS).
 It provides primitive values, called runes, such
 as `heart` and `circle`, operations such as `beside`
 to construct more complex runes from simpler ones, and ways

--- a/docs/specs/source_1_bnf.tex
+++ b/docs/specs/source_1_bnf.tex
@@ -1,83 +1,83 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{import-directive} \ldots \ \textit{statement} \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{import-directive}    &&\quad ::= &\quad && \textbf{\texttt{import}}\ \textbf{\texttt{\{}}\ \textit{names} \ \textbf{\texttt{\}}}\ \textbf{\texttt{from}}\  \textit{string} \ \textbf{\texttt{;}}
                                                            && \textrm{import directive} \\[1mm]
 %&& \textit{import-name}  && ::= &\quad && \textit{name}\ | \ \textit{name}\ \textbf{\texttt{as}}\ \textit{name}
 %                                                            && \textrm{import name declaration}} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{names} \ \textbf{\texttt{)}}\ \textit{block} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{return statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p13}{conditional statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p13}{conditional statement}}\\
 &&                       && |   &\quad &&  \textit{block} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\
 &&                       && |   &\quad &&  \textbf{\texttt{debugger}} \ \textbf{\texttt{;}}
                                                            && \textrm{breakpoint} \\[1mm]
 && \textit{names}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{name list}}   \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{name list}}   \\[1mm]
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
                                    \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
                                    \textit{block} \\
 &&                       &&     &      && \textbf{\texttt{else}}\
                                           (\ \textit{block}
                                           \ | \
-                                          \textit{\href{https://source-academy.github.io/sicp/chapters/1.3.3.html\#footnote-1}{if-statement}} \ )
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p12}{conditional statement}}   \\[1mm]
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p12}{conditional statement}}   \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement} \ldots   \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\[1mm]         
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\[1mm]         
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{primitive string expression}}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{primitive string expression}}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}}\\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}}\\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{expression} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{names}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html}{lambda expression (expr. body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2}{lambda expression (expr. body)}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{names}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.4.html\#footnote-3}{lambda expression (block body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.4\#footnote-3}{lambda expression (block body)}}\\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}} 
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}} 
 \end{alignat*}

--- a/docs/specs/source_1_bnf_with_import_export.tex
+++ b/docs/specs/source_1_bnf_with_import_export.tex
@@ -1,6 +1,6 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{import-directive} \ \ldots\ \textit{statement} \ \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{import-directive}    &&\quad ::= &\quad && \textbf{\texttt{import}}\ \textbf{\texttt{\{}}\ \textit{import-names} \ \textbf{\texttt{\}}}\ \textbf{\texttt{from}}\  \textit{string} \ \textbf{\texttt{;}}
                                                            && \textrm{import directive} \\[1mm]
 && \textit{import-names}  && ::= &\quad && \epsilon\ | \ \textit{import-name}\ (
@@ -21,75 +21,75 @@
                                                             && \textrm{export name declaration} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{parameters} \ \textbf{\texttt{)}}\ \textit{block} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{return statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p13}{conditional statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p13}{conditional statement}}\\
 &&                       && |   &\quad &&  \textit{block} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\[1mm]
 && \textit{parameters}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ )\ \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function parameters}}   \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function parameters}}   \\[1mm]
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
                                    \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
                                    \textit{block} \\
 &&                       &&     &      && \textbf{\texttt{else}}\
                                           (\ \textit{block}
                                           \ | \
-                                          \textit{\href{https://source-academy.github.io/sicp/chapters/1.3.3.html\#footnote-1}{if-statement}} \ )
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p12}{conditional statement}}   \\[1mm]
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p12}{conditional statement}}   \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement}\ \ldots   \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\[1mm]         
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\[1mm]         
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{primitive string expression}}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{primitive string expression}}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}}\\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}}\\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{expression} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html}{lambda expression (expr. body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2}{lambda expression (expr. body)}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.4.html\#footnote-3}{lambda expression (block body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.4\#footnote-3}{lambda expression (block body)}}\\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       )\ \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}} 
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}} 
 \end{alignat*}

--- a/docs/specs/source_1_bnf_without_import.tex
+++ b/docs/specs/source_1_bnf_without_import.tex
@@ -1,77 +1,77 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{statement} \ \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{parameters} \ \textbf{\texttt{)}}\ \textit{block} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{return statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p13}{conditional statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p13}{conditional statement}}\\
 &&                       && |   &\quad &&  \textit{block} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\[1mm]
 && \textit{parameters}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ )\ \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function parameters}}   \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function parameters}}   \\[1mm]
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
                                    \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
                                    \textit{block} \\
 &&                       &&     &      && \textbf{\texttt{else}}\
                                           (\ \textit{block}
                                           \ | \
-                                          \textit{\href{https://source-academy.github.io/sicp/chapters/1.3.3.html\#footnote-1}{if-statement}} \ )
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p12}{conditional statement}}   \\[1mm]
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p12}{conditional statement}}   \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement}\ \ldots   \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\[1mm]         
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\[1mm]         
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{primitive string expression}}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{primitive string expression}}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}}\\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}}\\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{expression} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html}{lambda expression (expr. body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2}{lambda expression (expr. body)}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.4.html\#footnote-3}{lambda expression (block body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.4\#footnote-3}{lambda expression (block body)}}\\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       )\ \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}} 
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}} 
 \end{alignat*}

--- a/docs/specs/source_2_bnf.tex
+++ b/docs/specs/source_2_bnf.tex
@@ -1,85 +1,85 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{import-directive} \ldots \ \textit{statement} \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{import-directive}    &&\quad ::= &\quad && \textbf{\texttt{import}}\ \textbf{\texttt{\{}}\ \textit{names} \ \textbf{\texttt{\}}}\ \textbf{\texttt{from}}\  \textit{string} \ \textbf{\texttt{;}}
                                                            && \textrm{import directive} \\[1mm]
 %&& \textit{import-name}  && ::= &\quad && \textit{name}\ | \ \textit{name}\ \textbf{\texttt{as}}\ \textit{name}
 %                                                            && \textrm{import name declaration}} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{names} \ \textbf{\texttt{)}}\ \textit{block} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{return statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p13}{conditional statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p13}{conditional statement}}\\
 &&                       && |   &\quad &&  \textit{block} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\
 &&                       && |   &\quad &&  \textbf{\texttt{debugger}} \ \textbf{\texttt{;}}
                                                            && \textrm{breakpoint} \\[1mm]
 && \textit{names}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{name list}}   \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{name list}}   \\[1mm]
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
                                    \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
                                    \textit{block} \\
 &&                       &&     &      && \textbf{\texttt{else}}\
                                           (\ \textit{block}
                                           \ | \
-                                          \textit{\href{https://source-academy.github.io/sicp/chapters/1.3.3.html\#footnote-1}{if-statement}} \ )
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p12}{conditional statement}}   \\[1mm]
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p12}{conditional statement}}   \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement} \ldots   \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\[1mm]         
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\[1mm]         
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{primitive string expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{primitive string expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{null}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.1.html\#p1}{primitive list expression}} \\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.1\#p1}{primitive list expression}} \\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}}\\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}}\\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{expression} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{names}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html}{lambda expression (expr. body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2}{lambda expression (expr. body)}}\\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{names}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.4.html\#footnote-3}{lambda expression (block body)}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.4\#footnote-3}{lambda expression (block body)}}\\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}} 
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}} 
 \end{alignat*}

--- a/docs/specs/source_3_bnf.tex
+++ b/docs/specs/source_3_bnf.tex
@@ -1,95 +1,95 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{import-directive} \ldots \ \textit{statement} \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{import-directive}    &&\quad ::= &\quad && \textbf{\texttt{import}}\ \textbf{\texttt{\{}}\ \textit{names} \ \textbf{\texttt{\}}}\ \textbf{\texttt{from}}\  \textit{string} \ \textbf{\texttt{;}}
                                                            && \textrm{import directive} \\[1mm]
 %&& \textit{import-name}  && ::= &\quad && \textit{name}\ | \ \textit{name}\ \textbf{\texttt{as}}\ \textit{name}
 %                                                            && \textrm{import name declaration}} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textit{let} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p3}{variable declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p3}{variable declaration}} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{names} \ \textbf{\texttt{)}}\ \textit{block} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{return statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p13}{conditional statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p13}{conditional statement}}\\
 &&                       && |   &\quad && \textbf{\texttt{while}}\  
                                    \textbf{\texttt{(}}\  \textit{expression} \ \textbf{\texttt{)}} \
                                    \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{while loop}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{while loop}}\\
 &&                       && |   &\quad && \textbf{\texttt{for}}\ \textbf{\texttt{(}} \ 
-                                          (\ \textit{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.8}{assignment}} \ | \  \textit{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.9}{let}}\ ) \textbf{\texttt{;}} \\
+                                          (\ \textit{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.8}{assignment}} \ | \  \textit{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.9}{let}}\ ) \textbf{\texttt{;}} \\
 &&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{expression} \ \textbf{\texttt{;}} \\
 &&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{assignment} \ \textbf{\texttt{)}} \ 
                                             \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.8}{for loop}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.8}{for loop}}\\
 &&                       && |   &\quad && \textbf{\texttt{break}}\ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{break statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{break statement}}\\
 &&                       && |   &\quad && \textbf{\texttt{continue}}\ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{continue statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{continue statement}}\\
 &&                       && |   &\quad &&  \textit{block} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\
 &&                       && |   &\quad &&  \textbf{\texttt{debugger}} \ \textbf{\texttt{;}}
                                                            && \textrm{breakpoint} \\[1mm]
 && \textit{names}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{name list}} \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{name list}} \\[1mm]
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
                                    \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
                                    \textit{block} \\
 &&                       &&     &      && [ \ \textbf{\texttt{else}}\
                                           (\ \textit{block}
                                           \ | \
-                                          \textit{\href{https://source-academy.github.io/sicp/chapters/1.3.3.html\#footnote-1}{if-statement}} \ )\ ]
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p12}{conditional statement}} \\[1mm]
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )\ ]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p12}{conditional statement}} \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement} \ldots \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}} \\[1mm]
 && \textit{let}          && ::= &\quad &&  \textbf{\texttt{let}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} 
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p3}{variable declaration}} \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p3}{variable declaration}} \\[1mm]
 && \textit{assignment}   && ::= &\quad &&  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} 
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p4}{variable assignment}} \\[1mm]
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p4}{variable assignment}} \\[1mm]
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{primitive string expression}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{primitive string expression}} \\
 &&                       && |   &\quad && \textbf{\texttt{null}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.1.html\#p1}{primitive list expression}} \\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.1\#p1}{primitive list expression}} \\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}} \\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}} \\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{expression} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}} \\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{names}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html}{lambda expression (expr. body)}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2}{lambda expression (expr. body)}} \\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{names}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.4.html\#footnote-3}{lambda expression (block body)}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.4\#footnote-3}{lambda expression (block body)}} \\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}} \\
 &&                       && |   &\quad && \textit{assignment} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p4}{variable assignment}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p4}{variable assignment}} \\
 &&                       && |   &\quad && \textit{expression} \textbf{\texttt{[}}
                                           \textit{expression} \textbf{\texttt{]}}
                                                            && \textrm{array access} \\
@@ -102,19 +102,19 @@
                                             \textbf{\texttt{]}}
                                                            && \textrm{literal array expression}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]                        
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]                        
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}}
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}}
 \end{alignat*}

--- a/docs/specs/source_3_bnf_without_import.tex
+++ b/docs/specs/source_3_bnf_without_import.tex
@@ -1,93 +1,93 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{statement} \ \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textit{let} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p3}{variable declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p3}{variable declaration}} \\
 &&                       && |   &\quad && \textit{assignment} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p4}{variable assignment}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p4}{variable assignment}} \\
 &&                       && |   &\quad && \textit{expression} \textbf{\texttt{[}}
                                           \textit{expression} \textbf{\texttt{]}} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \textrm{array assignment} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{parameters} \ \textbf{\texttt{)}}\ \textit{block} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{return statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p13}{conditional statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p13}{conditional statement}}\\
 &&                       && |   &\quad && \textbf{\texttt{while}}\  
                                    \textbf{\texttt{(}}\  \textit{expression} \ \textbf{\texttt{)}} \
                                    \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{while loop}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{while loop}}\\
 &&                       && |   &\quad && \textbf{\texttt{for}}\ \textbf{\texttt{(}} \ 
-                                          (\ \textit{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.8}{assignment}} \ | \  \textit{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.9}{let}}\ ) \textbf{\texttt{;}} \\
+                                          (\ \textit{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.8}{assignment}} \ | \  \textit{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.9}{let}}\ ) \textbf{\texttt{;}} \\
 &&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{expression} \ \textbf{\texttt{;}} \\
 &&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{assignment} \ \textbf{\texttt{)}} \ 
                                             \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.8}{for loop}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.8}{for loop}}\\
 &&                       && |   &\quad && \textbf{\texttt{break}}\ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{break statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{break statement}}\\
 &&                       && |   &\quad && \textbf{\texttt{continue}}\ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{continue statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{continue statement}}\\
 &&                       && |   &\quad &&  \textit{block} 
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\[1mm]
 && \textit{parameters}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ )\ \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function parameters}} \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function parameters}} \\[1mm]
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
                                    \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
                                    \textit{block} \\
 &&                       &&     &      && [ \ \textbf{\texttt{else}}\
                                           (\ \textit{block}
                                           \ | \
-                                          \textit{\href{https://source-academy.github.io/sicp/chapters/1.3.3.html\#footnote-1}{if-statement}} \ )\ ]
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#p12}{conditional statement}} \\[1mm]
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )\ ]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2\#p12}{conditional statement}} \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement}\ \ldots \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.8.html\#p14}{block statement}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.8\#p14}{block statement}} \\[1mm]
 && \textit{let}          && ::= &\quad &&  \textbf{\texttt{let}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} 
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p3}{variable declaration}} \\[1mm]
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p3}{variable declaration}} \\[1mm]
 && \textit{assignment}   && ::= &\quad &&  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} 
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p4}{variable assignment}} \\[1mm]
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p4}{variable assignment}} \\[1mm]
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{primitive string expression}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{primitive string expression}} \\
 &&                       && |   &\quad && \textbf{\texttt{null}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.1.html\#p1}{primitive list expression}} \\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.1\#p1}{primitive list expression}} \\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}} \\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}} \\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{expression} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}} \\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.3.2.html}{lambda expression (expr. body)}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.3.2}{lambda expression (expr. body)}} \\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
                                             )\    
                                             \texttt{\textbf{=>}}\ \textit{block}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/2.2.4.html\#footnote-3}{lambda expression (block body)}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/2.2.4\#footnote-3}{lambda expression (block body)}} \\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}} \\
 &&                       && |   &\quad && \textit{expression} \textbf{\texttt{[}}
                                           \textit{expression} \textbf{\texttt{]}}
                                                            && \textrm{array access} \\
@@ -96,19 +96,19 @@
                                             \textbf{\texttt{]}}
                                                            && \textrm{literal array expression}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]                        
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]                        
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       )\ \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}}
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}}
 \end{alignat*}

--- a/docs/specs/source_3_concurrent.tex
+++ b/docs/specs/source_3_concurrent.tex
@@ -23,11 +23,11 @@ Source \S 3 Concurrent modifies Source \S 3 in the following ways:
 \end{itemize}
 \noindent
 The concurrency of Source \S 3 Concurrent is thread-based and deviates
-from the event-driven concurrency of  
+from the event-driven concurrency of
 \href{http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf}{\color{DarkBlue}
   ECMAScript 2018 ($9^{\textrm{th}}$ Edition)}. Source \S 3 Concurrent is
 motivated by Section 3.4 of the textbook
-\href{https://sicp.comp.nus.edu.sg}{\color{DarkBlue}\emph{Structure and Interpretation
+\href{https://sourceacademy.org/interactive-sicp}{\color{DarkBlue}\emph{Structure and Interpretation
 of Computer Programs}, JavaScript Adaptation}.
 
 \section{Concurrency}

--- a/docs/specs/source_boolean_operators.tex
+++ b/docs/specs/source_boolean_operators.tex
@@ -1,6 +1,6 @@
 \subsection*{Binary boolean operators}
 
-\subsubsection*{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{Conjunction}}
+\subsubsection*{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{Conjunction}}
 
 \[
 \textit{expression}_1 \ \textbf{\texttt{\&\&}} \ \textit{expression}_2
@@ -10,7 +10,7 @@ stands for
 \textit{expression}_1 \ \textbf{\texttt{?}} \ \textit{expression}_2 \ \textbf{\texttt{:}}\ \textbf{\texttt{false}}
 \]
 
-\subsubsection*{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{Disjunction}}
+\subsubsection*{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{Disjunction}}
 
 \[
 \textit{expression}_1 \ \textbf{\texttt{||}} \ \textit{expression}_2

--- a/docs/specs/source_comments.tex
+++ b/docs/specs/source_comments.tex
@@ -1,4 +1,4 @@
-\subsection*{\href{https://source-academy.github.io/sicp/chapters/2.2.3.html\#footnote-8}{Comments}}
+\subsection*{\href{https://sourceacademy.org/interactive-sicp/2.2.3\#footnote-8}{Comments}}
 
 In Source, any sequence of characters between ``\texttt{/*}'' and
 the next ``\texttt{*/}'' is ignored.

--- a/docs/specs/source_interpreter.tex
+++ b/docs/specs/source_interpreter.tex
@@ -25,7 +25,7 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{statement} \ \ldots
                                                            && \texttt{list("sequence", list of  } \langle \textit{statement}\rangle \textit{)} \\[1mm]
-&& \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
+&& \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \texttt{list("constant\_declaration",  } \langle \textit{name}\rangle \textit{,  } \langle \textit{expression}\rangle \textit{)} \\
 &&                       && |   &\quad && \textit{let} \ \textbf{\texttt{;}}
@@ -33,21 +33,21 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
 &&                       && |   &\quad && \textit{assignment} \ \textbf{\texttt{;}}
                                                            && \textrm{see below}\\
 &&                       && |   &\quad && \textit{expression}_1 \textbf{\texttt{[}}
-                                          \textit{expression}_2 \textbf{\texttt{]}} \ 
-                                           \textbf{\texttt{=}}\  \textit{expression}_3  \textbf{\texttt{;}}\ 
+                                          \textit{expression}_2 \textbf{\texttt{]}} \
+                                           \textbf{\texttt{=}}\  \textit{expression}_3  \textbf{\texttt{;}}\
                                                            && \texttt{list("object\_assignment", } \langle \textit{expression}_1 \textbf{\texttt{[}} \textit{expression}_2 \textbf{\texttt{]}}  \rangle \textit{,  } \langle \textit{expression}_3\rangle \textit{)} \\
-&&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
+&&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \
                                    \textbf{\texttt{(}}\  \textit{parameters} \ \textbf{\texttt{)}}\ \textit{block} \quad
                                                            &&  \texttt{list("function\_declaration",  } \langle \textit{name}\rangle \textit{, } \langle \textit{parameters}\rangle \textit{,}\ \langle \textit{block}\rangle \textit{)} \\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \texttt{list("return\_statement",  } \langle \textit{expression}\rangle \textit{)} \\
 &&                       && |   &\quad && \textit{if-statement} \quad
                                                            && \textrm{see below}\\
-&&                       && |   &\quad && \textbf{\texttt{while}}\  
+&&                       && |   &\quad && \textbf{\texttt{while}}\
                                    \textbf{\texttt{(}}\  \textit{expression} \ \textbf{\texttt{)}} \
                                    \textit{block}
                                                            && \texttt{list("while\_loop",  } \langle \textit{expression}\rangle \textit{,  } \langle \textit{block}\rangle \textit{)} \\
-&&                       && |   &\quad && \textbf{\texttt{for}}\ \textbf{\texttt{(}} \ 
+&&                       && |   &\quad && \textbf{\texttt{for}}\ \textbf{\texttt{(}} \
                                           (\ \textit{\hyperlink{for}{assignment}}_1 \ | \  \textit{\hyperlink{for2}{let}}\ ) \textbf{\texttt{;}} \\
 &&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{expression} \ \textbf{\texttt{;}} && \texttt{list("for\_loop",  } \langle \textit{assignment}_1\rangle\ \textrm{or}\ \langle \textit{let}\rangle \textit{,  } \langle \textit{expression}\rangle \textit{,  } \langle \textit{assignment}_2\rangle \textit{,}\\
 &&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{assignment}_2 \ \textbf{\texttt{)}} \  \textit{block}
@@ -56,7 +56,7 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
                                                            && \texttt{list("break\_statement")} \\
 &&                       && |   &\quad && \textbf{\texttt{continue}}\ \textbf{\texttt{;}}
                                                            && \texttt{list("continue\_statement")} \\
-&&                       && |   &\quad &&  \textit{block} 
+&&                       && |   &\quad &&  \textit{block}
                                                            && \textrm{see below}\\
 &&                       && |   &\quad &&  \textbf{\texttt{try}}\ \textit{block}_1 \ \textbf{\texttt{catch (}}\ \textit{name}\ \textbf{\texttt{)}}\ \textit{block}_2
                                                            && \texttt{list("try\_statement",}\ \langle  \textit{block}_1 \rangle \texttt{,}\ \langle  \textit{name} \rangle \texttt{,}\ \langle  \textit{block}_2 \rangle \texttt{)} \\
@@ -64,30 +64,30 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
                                                            && \texttt{list("throw\_statement",}\ \langle  \textit{expression} \rangle \texttt{)} \\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \textrm{see below}\\[1mm]
-&& \textit{parameters}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
+&& \textit{parameters}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ )\ \ldots
                                                             && \texttt{list of  } \langle \textit{name}\rangle  \\
 && \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
-                                   \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
+                                   \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\
                                    \textit{block}_1 \\
 &&                       &&     &      && \textbf{\texttt{else}}\
                                           (\ \textit{block}_2
                                           \ | \
-                                          \textit{\href{https://sicp.comp.nus.edu.sg/chapters/21\#footnote-1}{if-statement}} \ )
+                                          \textit{\href{https://sourceacademy.org/interactive-sicp/1.3.3\#footnote-1}{if-statement}} \ )
                                           && \texttt{list("conditional\_statement",  } \langle \textit{expression}\rangle \textit{, } \\
                                             &&&&&&&&&\ \ \ \ \ \ \texttt{ } \langle \textit{block}_1\rangle \textit{,  } \langle \textit{block}_2\rangle \ \textrm{or}\ \langle \textit{if-statement} \rangle \texttt{)} \\
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{program}   \ \textbf{\texttt{\}}} \quad
                                                            && \texttt{list("block",  } \langle \textit{program}\rangle \textit{)} \\
-&& \textit{let}          && ::= &\quad &&  \textbf{\texttt{let}}\  \textit{name} \ 
-                                           \textbf{\texttt{=}}\  \textit{expression} 
+&& \textit{let}          && ::= &\quad &&  \textbf{\texttt{let}}\  \textit{name} \
+                                           \textbf{\texttt{=}}\  \textit{expression}
                                                             && \texttt{list("variable\_declaration",  } \langle \textit{name}\rangle \textit{,  } \langle \textit{expression}\rangle \textit{)} \\
-&& \textit{assignment}   && ::= &\quad &&  \textit{name} \ 
-                                           \textbf{\texttt{=}}\  \textit{expression} 
+&& \textit{assignment}   && ::= &\quad &&  \textit{name} \
+                                           \textbf{\texttt{=}}\  \textit{expression}
                                                             && \texttt{list("assignment",  } \langle \textit{name}\rangle \textit{,  } \langle \textit{expression}\rangle \textit{)} \\
 &&                       && |   &\quad && \textit{expression}_1 \textbf{\texttt{[}}
-                                          \textit{expression}_2 \textbf{\texttt{]}} \ 
-                                           \textbf{\texttt{=}}\  \textit{expression}_3  \textbf{\texttt{;}}\ 
-                                                           && \texttt{list("object\_assignment", } \langle \textit{expression}_1 \textbf{\texttt{[}} \textit{expression}_2 \textbf{\texttt{]}}  \rangle \textit{,  } \langle \textit{expression}_3\rangle \textit{)} 
+                                          \textit{expression}_2 \textbf{\texttt{]}} \
+                                           \textbf{\texttt{=}}\  \textit{expression}_3  \textbf{\texttt{;}}\
+                                                           && \texttt{list("object\_assignment", } \langle \textit{expression}_1 \textbf{\texttt{[}} \textit{expression}_2 \textbf{\texttt{]}}  \rangle \textit{,  } \langle \textit{expression}_3\rangle \textit{)}
 \end{alignat*}
 
 \begin{alignat*}{9}
@@ -102,31 +102,31 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
 &&                       && |   &\quad &&  \textit{string}
                                                            && \texttt{list("literal",}\ \textit{string}\texttt{)} \\
 &&                       && |   &\quad &&  \textit{name}   && \texttt{list("name", string)}  \\
-&&                       && |   &\quad &&  \textit{expression}_1 \  \textit{log-op} \ 
+&&                       && |   &\quad &&  \textit{expression}_1 \  \textit{log-op} \
                                             \textit{expression}_2 \qquad
                                                            && \texttt{list("logical\_composition",  } \langle \textit{log-op}\rangle \textit{, } \langle \textit{expression}_1\rangle \textit{, } \langle \textit{expression}_2\rangle \textit{)} \\
-&&                       && |   &\quad &&  \textit{expression}_1 \  \textit{bin-op} \ 
+&&                       && |   &\quad &&  \textit{expression}_1 \  \textit{bin-op} \
                                             \textit{expression}_2 \qquad
                                                            && \texttt{list("binary\_operator\_combination",  } \langle \textit{bin-op}\rangle \textit{, } \langle \textit{expression}_1\rangle \textit{, } \langle \textit{expression}_2\rangle \textit{)} \\
-&&                       && |   &\quad &&   \textit{un-op} \ 
+&&                       && |   &\quad &&   \textit{un-op} \
                                             \textit{expression}
                                                            && \texttt{list("unary\_operator\_combination",  } \langle \textit{un-op}\rangle \textit{, } \langle \textit{expression}\rangle \textit{)} \\
-&&                       && |   &\quad &&   \textit{expression} \ 
+&&                       && |   &\quad &&   \textit{expression} \
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
                                                            && \texttt{list("application",  } \langle \textit{expression}\rangle \textit{, list of  } \langle \textit{expression}\rangle \textit{)} \\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
-                                            )\    
+                                            )\
                                             \texttt{\textbf{=>}}\ \textit{expression}
                                             && \texttt{list("lambda\_expression",  } \langle \textit{parameters}\rangle \textit{,}  \\
                                               && && & && && \texttt{list("return\_statement",  } \langle \textit{expression}\rangle \textit{))} \\
 &&                       && |   &\quad &&   (\ \textit{name}\ | \
                                                \textbf{\texttt{(}}\ \textit{parameters}\ \textbf{\texttt{)}}\
-                                            )\    
+                                            )\
                                             \texttt{\textbf{=>}}\ \textit{block}
                                                            && \texttt{list("lambda\_expression",  } \langle \textit{parameters}\rangle \textit{,  } \langle \textit{statement}\rangle \textit{)} \\
-&&                       && |   &\quad &&   \textit{expression}_1 \ \textbf{\texttt{?}}\ 
+&&                       && |   &\quad &&   \textit{expression}_1 \ \textbf{\texttt{?}}\
                                             \textit{expression}_2
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}_3\
@@ -135,7 +135,7 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
 &&                       && |   &\quad && \textit{expression}_1 \textbf{\texttt{[}}
                                           \textit{expression}_2 \textbf{\texttt{]}}
                                                            && \texttt{list("object\_access",  } \langle \textit{expression}_1\rangle \textit{,  } \langle \textit{expression}_2\rangle \textit{)} \\
-&&                       && |   &\quad &&   \textbf{\texttt{[}}\ 
+&&                       && |   &\quad &&   \textbf{\texttt{[}}\
                                             \textit{expressions}\
                                             \textbf{\texttt{]}}
                                                            && \texttt{list("array\_expression", list of  } \langle \textit{expression}\rangle \textit{)} \\
@@ -143,25 +143,25 @@ apply_in_underlying_javascript(times, list(2, 3)); // returns 6
                                                            && \texttt{list("new\_expression",}\ \langle  \textit{expression} \rangle \texttt{)} \\
 &&                       && |   &\quad &&  \textit{expression}\ \textbf{\texttt{.}}\ \textit{name}
                                                            && \textrm{treat as}:\ \textit{expression}\ \textbf{\texttt{[ "}}\textit{name}\textbf{\texttt{" ]}}  \\
-&&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
+&&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \
                                             \textbf{\texttt{)}} && \textrm{treat as:}\ \textit{expression} \\[1mm]
-&& \textit{log-op}    
+&& \textit{log-op}
                         &&\quad  ::= &\quad && \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
                                           && \textit{string representing operator} \\[1mm]
-&& \textit{bin-op}     
-                        &&\quad  ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
+&& \textit{bin-op}
+                        &&\quad  ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}  && \textit{string representing operator} \\
 &&                       && |  &\quad &&  \texttt{\textbf{<}}\ |\ \texttt{\textbf{>}}\ |\ \texttt{\textbf{<=}}\ |\ \texttt{\textbf{>=}}
                                           && \textit{string representing operator} \\[1mm]
-&& \textit{un-op}    
+&& \textit{un-op}
                         &&\quad  ::= &\quad && \textbf{\texttt{!}}
                         && \texttt{"!"} \\
-&& 
+&&
                         && | &\quad && \textbf{\texttt{-}}
                         && \texttt{"-unary"} \\
 && \textit{expressions}  &&\quad  ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
-                                                                 \textit{expression} \ 
+                                                                 \textit{expression} \
                                                                       )\ \ldots
                                                             && \texttt{list of  } \langle \textit{expression}\rangle  \\
 \end{alignat*}

--- a/docs/specs/source_intro.tex
+++ b/docs/specs/source_intro.tex
@@ -1,5 +1,5 @@
 The language Source is the official language of the textbook
-\href{https://source-academy.github.io/sicp/}{\color{DarkBlue}\emph{Structure and Interpretation
+\href{https://sourceacademy.org/interactive-sicp/}{\color{DarkBlue}\emph{Structure and Interpretation
 of Computer Programs}, JavaScript Adaptation}.
 Source is a sublanguage of 
 \href{http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf}{\color{DarkBlue}

--- a/docs/specs/source_js_differences.tex
+++ b/docs/specs/source_js_differences.tex
@@ -14,7 +14,7 @@ should be allowed to deviate from the JavaScript specification, for the
 sake of internal consistency and esthetics.
 
 \begin{description}
-\item[\href{https://source-academy.github.io/sicp/chapters/4.1.1.html\#footnote-4}{Evaluation result of programs:}]
+\item[\href{https://sourceacademy.org/interactive-sicp/4.1.1\#footnote-4}{Evaluation result of programs:}]
   % from SICP JS 4.1.2, last exercise
 JavaScript statically
         distinguishes between \emph{value-producing} and
@@ -58,9 +58,9 @@ JavaScript statically
 
   Implementations of Source are currently allowed to opt for a simpler scheme. 
 
-\item[\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#footnote-2}{Hoisting of function declarations:}] In JavaScript, function declarations
+\item[\href{https://sourceacademy.org/interactive-sicp/1.3.2\#footnote-2}{Hoisting of function declarations:}] In JavaScript, function declarations
   are ``hoisted''
-  (\href{https://source-academy.github.io/sicp/chapters/4.3.1.html#footnote-4}{automagically} moved)
+  (\href{https://sourceacademy.org/interactive-sicp/4.3.1#footnote-4}{automagically} moved)
   to the beginning of the block in which
   they appear. This means that applications of functions that are declared
   with function declaration statements never fail because the name is not

--- a/docs/specs/source_loops.tex
+++ b/docs/specs/source_loops.tex
@@ -1,6 +1,6 @@
 \subsection*{Loops}
 
-\subsubsection*{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{while-loops}}
+\subsubsection*{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{while-loops}}
 
 Roughly speaking, while loops are seen as abbreviations for function applications as follows:
 
@@ -30,7 +30,7 @@ function _while(test, body) {
 }
 \end{lstlisting}
 
-\subsubsection*{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.8}{Simple for-loops}}
+\subsubsection*{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.8}{Simple for-loops}}
 
 \[\textbf{\texttt{for}}\ \textbf{\texttt{(}} \ 
                                           \textit{assignment}_1 \textbf{\texttt{;}} 
@@ -50,7 +50,7 @@ while (^$\textrm{\textit{expression}}$^) {
   \end{minipage}
 \end{center}
 
-\subsubsection*{\href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.9}{for-loops with loop control variable}}
+\subsubsection*{\href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.9}{for-loops with loop control variable}}
 
 \[\textbf{\texttt{for}}\ \textbf{\texttt{(}} \ 
 \textbf{\texttt{let}}\ \textit{name}\ \texttt{=}\
@@ -81,8 +81,8 @@ stands for
 
 Contrary to the simplified explanation above, \lstinline{while} and \lstinline{for} loops return
 the value of their last loop execution, or \lstinline{undefined} if there is no loop execution.
-Evaluation of a \href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{\lstinline{break}} statement within a loop terminates the loop with the return value
-\lstinline{undefined} and evaluation of a \href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#ex_4.7}{\lstinline{continue}} statement within a loop
+Evaluation of a \href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{\lstinline{break}} statement within a loop terminates the loop with the return value
+\lstinline{undefined} and evaluation of a \href{https://sourceacademy.org/interactive-sicp/4.1.2\#ex_4.7}{\lstinline{continue}} statement within a loop
 terminates the current loop iteration and evaluates the test.
 
 

--- a/docs/specs/source_math.tex
+++ b/docs/specs/source_math.tex
@@ -3,7 +3,7 @@
 
 The following names are provided by the MATH library:
 \begin{itemize}
-\item \href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p8}{\lstinline{math_}$\textit{name}$},
+\item \href{https://sourceacademy.org/interactive-sicp/1.1.4\#p8}{\lstinline{math_}$\textit{name}$},
 where $\textit{name}$ is any name specified in the
 JavaScript
 \texttt{Math} library, see\\

--- a/docs/specs/source_misc.tex
+++ b/docs/specs/source_misc.tex
@@ -4,28 +4,28 @@
 The following
 names are provided by the MISC library:
 \begin{itemize}
-\item \href{https://source-academy.github.io/sicp/chapters/1.2.6.html\#ex_1.22}{\lstinline{get_time()}}: \textit{primitive}, returns number of milliseconds elapsed since January 1, 1970 00:00:00 UTC
+\item \href{https://sourceacademy.org/interactive-sicp/1.2.6\#ex_1.22}{\lstinline{get_time()}}: \textit{primitive}, returns number of milliseconds elapsed since January 1, 1970 00:00:00 UTC
 \item \verb#parse_int#\texttt{(s, i)}: \textit{primitive}, 
 interprets the \emph{string} \texttt{s} as an integer, using the positive integer \texttt{i} as radix, and returns the respective value,
 see \href{https://www.ecma-international.org/ecma-262/9.0/index.html\#sec-parseint-string-radix}{\color{DarkBlue}ECMAScript Specification, Section 18.2.5}.
-\item \href{https://source-academy.github.io/sicp/chapters/2.4.3.html\#p6}{\texttt{undefined}},
+\item \href{https://sourceacademy.org/interactive-sicp/2.4.3\#p6}{\texttt{undefined}},
   \texttt{\href{https://www.ecma-international.org/ecma-262/9.0/index.html\#sec-value-properties-of-the-global-object-nan}{\color{DarkBlue}NaN}}, \texttt{\href{https://www.ecma-international.org/ecma-262/9.0/index.html\#sec-value-properties-of-the-global-object-infinity}{\color{DarkBlue}Infinity}}: \textit{primitive}, refer to JavaScript's undefined,
 NaN (``Not a Number'') and Infinity values, respectively.
-\item \href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#p2}{\lstinline{is_boolean(x)}}, \href{https://source-academy.github.io/sicp/chapters/2.3.2.html\#p5}{\lstinline{is_number(x)}},
-  \href{https://source-academy.github.io/sicp/chapters/2.3.2.html\#p7}{\lstinline{is_string(x)}}, \href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#p2}{\lstinline{is_undefined(x)}}, \verb#is_function#\texttt{(x)}: \textit{primitive}, returns \texttt{true} if the type of \texttt{x} matches the function name and \texttt{false} if it does not. Following
+\item \href{https://sourceacademy.org/interactive-sicp/4.1.2\#p2}{\lstinline{is_boolean(x)}}, \href{https://sourceacademy.org/interactive-sicp/2.3.2\#p5}{\lstinline{is_number(x)}},
+  \href{https://sourceacademy.org/interactive-sicp/2.3.2\#p7}{\lstinline{is_string(x)}}, \href{https://sourceacademy.org/interactive-sicp/4.1.2\#p2}{\lstinline{is_undefined(x)}}, \verb#is_function#\texttt{(x)}: \textit{primitive}, returns \texttt{true} if the type of \texttt{x} matches the function name and \texttt{false} if it does not. Following
         JavaScript, we specify that \verb#is_number# returns \texttt{true} for \texttt{NaN} and \texttt{Infinity}.
 \item \texttt{prompt(s)}: \textit{primitive}, pops up a window that displays the \emph{string} \texttt{s}, provides
 an input line for the user to enter a text, a ``Cancel'' button and an ``OK'' button. The call of \texttt{prompt}
 suspends execution of the program until one of the two buttons is pressed. If 
 the ``OK'' button is pressed, \texttt{prompt} returns the entered text as a string.
 If the ``Cancel'' button is pressed, \texttt{prompt} returns a non-string value.
-\item \href{https://source-academy.github.io/sicp/chapters/1.2.6.html\#footnote-7}{\texttt{display(x)}}: \textit{primitive}, displays the value \texttt{x} in the console\footnote{The notation used for the display of values is consistent with \href{http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf}{\color{DarkBlue}JSON}, but also displays \texttt{undefined} and function objects.}; returns the argument \texttt{a}.
+\item \href{https://sourceacademy.org/interactive-sicp/1.2.6\#footnote-7}{\texttt{display(x)}}: \textit{primitive}, displays the value \texttt{x} in the console\footnote{The notation used for the display of values is consistent with \href{http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf}{\color{DarkBlue}JSON}, but also displays \texttt{undefined} and function objects.}; returns the argument \texttt{a}.
 \item \texttt{display(x, s)}: \textit{primitive}, displays the string \texttt{s}, followed by a space character, followed by the value \texttt{x} in the console\footnotemark[\value{footnote}]; returns the argument \texttt{x}.
-\item \href{https://source-academy.github.io/sicp/chapters/1.2.6.html\#footnote-7}{\texttt{error(x)}}: \textit{primitive}, displays the value \texttt{x} in the console\footnotemark[\value{footnote}] with error flag. The evaluation
+\item \href{https://sourceacademy.org/interactive-sicp/1.2.6\#footnote-7}{\texttt{error(x)}}: \textit{primitive}, displays the value \texttt{x} in the console\footnotemark[\value{footnote}] with error flag. The evaluation
   of any call of \texttt{error} aborts the running program immediately.
-\item \href{https://source-academy.github.io/sicp/chapters/2.1.3.html\#footnote-2}{\texttt{error(x, s)}}: \textit{primitive}, displays the string \texttt{s}, followed by a space character, followed by the value \texttt{x} in the console\footnotemark[\value{footnote}] with error flag. The evaluation
+\item \href{https://sourceacademy.org/interactive-sicp/2.1.3\#footnote-2}{\texttt{error(x, s)}}: \textit{primitive}, displays the string \texttt{s}, followed by a space character, followed by the value \texttt{x} in the console\footnotemark[\value{footnote}] with error flag. The evaluation
   of any call of \texttt{error} aborts the running program immediately.
-\item \href{https://source-academy.github.io/sicp/chapters/3.3.4.html\#p24}{\lstinline{stringify(x)}}: \textit{primitive}, returns a string that represents\footnotemark[\value{footnote}] the value \texttt{x}. 
+\item \href{https://sourceacademy.org/interactive-sicp/3.3.4\#p24}{\lstinline{stringify(x)}}: \textit{primitive}, returns a string that represents\footnotemark[\value{footnote}] the value \texttt{x}. 
 \end{itemize}
 All library functions can be assumed to run
 in $O(1)$ time, except \texttt{display}, \texttt{error} and \texttt{stringify}, 

--- a/docs/specs/source_numbers.tex
+++ b/docs/specs/source_numbers.tex
@@ -1,4 +1,4 @@
-\subsection*{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{Numbers}}
+\subsection*{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{Numbers}}
 
 We use decimal notation for numbers, with an optional decimal dot. ``Scientific notation''
 (multiplying the number with $10^x$) is indicated with the letter \texttt{e}, followed

--- a/docs/specs/source_return.tex
+++ b/docs/specs/source_return.tex
@@ -10,7 +10,7 @@
   and
   $\texttt{\textbf{=>}}$ in function definition expressions.\footnote{ditto}
 \item Implementations of Source are allowed to treat function
-  declaration as \href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#footnote-2}{
+  declaration as \href{https://sourceacademy.org/interactive-sicp/1.3.2\#footnote-2}{
     syntactic sugar for constant declaration}.\footnote{ECMAScript prescribes ``hoisting''
     of function declarations to the beginning of the surrounding block. Programs that rely
     on this feature will run fine in JavaScript but might encounter a runtime error ``Cannot

--- a/docs/specs/source_strings.tex
+++ b/docs/specs/source_strings.tex
@@ -1,4 +1,4 @@
-\subsection*{\href{https://source-academy.github.io/sicp/chapters/2.3.1.html}{Strings}}
+\subsection*{\href{https://sourceacademy.org/interactive-sicp/2.3.1}{Strings}}
 
 Strings are of the form \texttt{"}$ \textit{double-quote-characters} $\texttt{"},
 where $\textit{double-quote-characters}$ is a possibly empty sequence of characters without

--- a/docs/specs/source_studio_2_bnf.tex
+++ b/docs/specs/source_studio_2_bnf.tex
@@ -1,51 +1,51 @@
 \begin{alignat*}{9}
 && \textit{program}    &&\quad ::= &\quad && \textit{statement} \ldots
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/3.1.1.html\#p6}{program}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/3.1.1\#p6}{program}} \\[1mm]
 && \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name} \ 
                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html\#p2}{constant declaration}} \\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2\#p2}{constant declaration}} \\
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                           \textbf{\texttt{(}}\  \textit{parameters} \ \textbf{\texttt{) \{}}\\
  &&                       &&     &      && \ \ \  \textbf{\texttt{return}}\ \textit{expression}\textbf{\texttt{;}} \\
-&&                       &&     &      && \textbf{\texttt{\}}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function declaration}}\\
+&&                       &&     &      && \textbf{\texttt{\}}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function declaration}}\\
 &&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{expression statement}} \\[1mm]
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{expression statement}} \\[1mm]
 && \textit{parameters}   && ::= &\quad &&  \epsilon\ | \  \textit{name} \ 
                                                    (\ \textbf{\texttt{,}} \ \textit{name}\ ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p4}{function parameters}}   \\[1mm]
-&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p3}{primitive number expression}}\\
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p4}{function parameters}}   \\[1mm]
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{primitive boolean expression}}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.2.html}{name expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.2}{name expression}}\\
 &&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
                                             \textit{expression} \qquad
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p5}{binary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p5}{binary operator combination}}\\
 &&                       && |   &\quad &&   \textit{unary-operator} \ 
                                             \textit{expression}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator combination}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator combination}}\\
 &&                       && |   &\quad &&   \textit{name} \ 
                                             \textbf{\texttt{(}}\ \textit{expressions}\
                                             \textbf{\texttt{)}}
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{function application}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{function application}}\\
 &&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
                                             \textit{expression}
                                             \ \textbf{\texttt{:}}\
                                             \textit{expression}\
-                                                           && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p1}{conditional expression}}\\
+                                                           && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p1}{conditional expression}}\\
 &&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
-                                            \textbf{\texttt{)}} && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p6}{parenthesised expression}}\\[1mm]
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p6}{parenthesised expression}}\\[1mm]
 && \textit{binary-operator}    \ 
                         && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
                                    \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
 &&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}\
                                           |\ \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
-                                          && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.1.html\#p4}{binary operator}}\\[1mm]
+                                          && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.1\#p4}{binary operator}}\\[1mm]
 && \textit{unary-operator}    
                         && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
-                        && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.6.html\#p4}{unary operator}}\\[1mm]
+                        && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.6\#p4}{unary operator}}\\[1mm]
 && \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
                                                                \ \textbf{\texttt{,}} \
                                                                  \textit{expression} \ 
                                                                       ) \ldots
-                                                            && \textrm{\href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p5}{argument expressions}} 
+                                                            && \textrm{\href{https://sourceacademy.org/interactive-sicp/1.1.4\#p5}{argument expressions}} 
 \end{alignat*}

--- a/docs/specs/source_studio_2_js_differences.tex
+++ b/docs/specs/source_studio_2_js_differences.tex
@@ -14,7 +14,7 @@ should be allowed to deviate from the JavaScript specification, for the
 sake of internal consistency and esthetics.
 
 \begin{description}
-\item[\href{https://source-academy.github.io/sicp/chapters/4.1.1.html\#footnote-4}{Evaluation result of programs:}]
+\item[\href{https://sourceacademy.org/interactive-sicp/4.1.1\#footnote-4}{Evaluation result of programs:}]
   % from SICP JS 4.1.2, last exercise
 JavaScript statically
         distinguishes between \emph{value-producing} and
@@ -49,9 +49,9 @@ JavaScript statically
 
   Implementations of Source are currently allowed to opt for a simpler scheme. 
 
-\item[\href{https://source-academy.github.io/sicp/chapters/1.3.2.html\#footnote-2}{Hoisting of function declarations:}] In JavaScript, function declarations
+\item[\href{https://sourceacademy.org/interactive-sicp/1.3.2\#footnote-2}{Hoisting of function declarations:}] In JavaScript, function declarations
   are ``hoisted''
-  (\href{https://source-academy.github.io/sicp/chapters/4.3.1.html#footnote-4}{automagically} moved)
+  (\href{https://sourceacademy.org/interactive-sicp/4.3.1#footnote-4}{automagically} moved)
   to the beginning of the block in which
   they appear (in Studio 2: the beginning of the program, because there are no blocks yet).
   This means that applications of functions that are declared

--- a/docs/specs/source_studio_2_misc.tex
+++ b/docs/specs/source_studio_2_misc.tex
@@ -6,7 +6,7 @@ are declared using \texttt{\textbf{const}}, \texttt{\textbf{function}},
 $\texttt{\textbf{=>}}$ (and \texttt{\textbf{let}} in Source \S3 and 4), the following
 names refer to primitive functions and constants:
 \begin{itemize}
-\item \href{https://source-academy.github.io/sicp/chapters/1.1.4.html\#p8}{\lstinline{math_}$\textit{name}$},
+\item \href{https://sourceacademy.org/interactive-sicp/1.1.4\#p8}{\lstinline{math_}$\textit{name}$},
 where $\textit{name}$ is any name specified in the
 JavaScript
 \texttt{Math} library, see\\
@@ -18,7 +18,7 @@ JavaScript
 \item 
   \texttt{\href{https://www.ecma-international.org/ecma-262/9.0/index.html\#sec-value-properties-of-the-global-object-nan}{\color{DarkBlue}NaN}}, \texttt{\href{https://www.ecma-international.org/ecma-262/9.0/index.html\#sec-value-properties-of-the-global-object-infinity}{\color{DarkBlue}Infinity}}: Refer to JavaScript's 
 NaN (``Not a Number'') and Infinity values, respectively.
-\item \href{https://source-academy.github.io/sicp/chapters/4.1.2.html\#p2}{\lstinline{is_boolean(x)}}, \href{https://source-academy.github.io/sicp/chapters/2.3.2.html\#p5}{\lstinline{is_number(x)}},
+\item \href{https://sourceacademy.org/interactive-sicp/4.1.2\#p2}{\lstinline{is_boolean(x)}}, \href{https://sourceacademy.org/interactive-sicp/2.3.2\#p5}{\lstinline{is_number(x)}},
   \verb#is_function#\texttt{(x)}:
         return \texttt{true} if the type of \texttt{x} matches the function name and \texttt{false} if it does not. Following
         JavaScript, we specify that \verb#is_number# returns \texttt{true} for \texttt{NaN} and \texttt{Infinity}.

--- a/docs/specs/source_typing.tex
+++ b/docs/specs/source_typing.tex
@@ -24,7 +24,7 @@ generate an error message when the types do not match.
 \begin{tabular}{c|c|c|c}
 operator & argument 1 & argument 2 & result\\ \hline
 \texttt{\textbf{+}} & number   & number     & number\\
-\texttt{\href{https://source-academy.github.io/sicp/chapters/3.3.4.html\#p24}{\textbf{+}}} & string   & string     & string\\
+\texttt{\href{https://sourceacademy.org/interactive-sicp/3.3.4\#p24}{\textbf{+}}} & string   & string     & string\\
 \texttt{\textbf{-}} & number   & number     & number\\
 \texttt{\textbf{*}} & number   & number     & number\\
 \texttt{\textbf{/}} & number   & number     & number\\

--- a/sicp_publish/README.md
+++ b/sicp_publish/README.md
@@ -1,4 +1,4 @@
-This JavaScript npm package provides all functions and constants that are assumed to be predeclared in the textbook [Structure and Interpretation of Computer Programs, JavaScript Adaptation](https://source-academy.github.io/interactive-sicp). This package therefore allows readers of the textbook to run and experiment with all JavaScript programs that appear in the textbook, using Node.js.
+This JavaScript npm package provides all functions and constants that are assumed to be predeclared in the textbook [Structure and Interpretation of Computer Programs, JavaScript Adaptation](https://sourceacademy.org/interactive-sicp). This package therefore allows readers of the textbook to run and experiment with all JavaScript programs that appear in the textbook, using Node.js.
 
 Setting up and Using SICP library
 =================================
@@ -30,6 +30,6 @@ const p = list("I", "love", "sicp");
 display(head(tail(p)));
 ```
 The documentation of the functions and constants provided by the `sicp` package is
-[available here](https://source-academy.github.io/source/source_4/global.html).
+[available here](https://docs.sourceacademy.org/source_4/global.html).
 
 This package is generated from the GitHub repository [`js-slang`](https://github.com/source-academy/js-slang) in the GitHub organization `source-academy`. Please report issues and bugs in this repository, using the prefix `sicp:` in the title.


### PR DESCRIPTION
- All SICP links (previously `https://source-academy.github.io/sicp`, `https://sicp.comp.nus.edu.sg`) now point to `https://sourceacademy.org/interactive-sicp/*`
- All Source Academy links (previously `https://source-academy.github.io` or `https://sourceacademy.nus.edu.sg`) now point to `https://sourceacademy.org`
- All Source documentation links (previously `https://source-academy.github.io/source`) now point to `https://docs.sourceacademy.org/*`