### PR TITLE
Stepper: Properly handle list prelude substitution

### DIFF
--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -3738,6 +3738,118 @@ const x_4 = 2;
 "
 `;
 
+exports[`redeclaration of predeclared functions work control 1`] = `
+"length(list(1, 2, 3));
+
+length(list(1, 2, 3));
+
+length([1, [2, [3, null]]]);
+
+length([1, [2, [3, null]]]);
+
+$length([1, [2, [3, null]]], 0);
+
+$length([1, [2, [3, null]]], 0);
+
+is_null([1, [2, [3, null]]]) ? 0 : $length(tail([1, [2, [3, null]]]), 0 + 1);
+
+is_null([1, [2, [3, null]]]) ? 0 : $length(tail([1, [2, [3, null]]]), 0 + 1);
+
+false ? 0 : $length(tail([1, [2, [3, null]]]), 0 + 1);
+
+false ? 0 : $length(tail([1, [2, [3, null]]]), 0 + 1);
+
+$length(tail([1, [2, [3, null]]]), 0 + 1);
+
+$length(tail([1, [2, [3, null]]]), 0 + 1);
+
+$length([2, [3, null]], 0 + 1);
+
+$length([2, [3, null]], 0 + 1);
+
+$length([2, [3, null]], 1);
+
+$length([2, [3, null]], 1);
+
+is_null([2, [3, null]]) ? 1 : $length(tail([2, [3, null]]), 1 + 1);
+
+is_null([2, [3, null]]) ? 1 : $length(tail([2, [3, null]]), 1 + 1);
+
+false ? 1 : $length(tail([2, [3, null]]), 1 + 1);
+
+false ? 1 : $length(tail([2, [3, null]]), 1 + 1);
+
+$length(tail([2, [3, null]]), 1 + 1);
+
+$length(tail([2, [3, null]]), 1 + 1);
+
+$length([3, null], 1 + 1);
+
+$length([3, null], 1 + 1);
+
+$length([3, null], 2);
+
+$length([3, null], 2);
+
+is_null([3, null]) ? 2 : $length(tail([3, null]), 2 + 1);
+
+is_null([3, null]) ? 2 : $length(tail([3, null]), 2 + 1);
+
+false ? 2 : $length(tail([3, null]), 2 + 1);
+
+false ? 2 : $length(tail([3, null]), 2 + 1);
+
+$length(tail([3, null]), 2 + 1);
+
+$length(tail([3, null]), 2 + 1);
+
+$length(null, 2 + 1);
+
+$length(null, 2 + 1);
+
+$length(null, 3);
+
+$length(null, 3);
+
+is_null(null) ? 3 : $length(tail(null), 3 + 1);
+
+is_null(null) ? 3 : $length(tail(null), 3 + 1);
+
+true ? 3 : $length(tail(null), 3 + 1);
+
+true ? 3 : $length(tail(null), 3 + 1);
+
+3;
+
+3;
+"
+`;
+
+exports[`redeclaration of predeclared functions work test 1`] = `
+"function length(xs) {
+  return 0;
+}
+length(list(1, 2, 3));
+
+function length(xs) {
+  return 0;
+}
+length(list(1, 2, 3));
+
+length(list(1, 2, 3));
+
+length(list(1, 2, 3));
+
+length([1, [2, [3, null]]]);
+
+length([1, [2, [3, null]]]);
+
+0;
+
+0;
+"
+`;
+
 exports[`renaming clash in replacement for function declaration 1`] = `
 "function g() {
   return x_1 + x_2;

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -1377,3 +1377,30 @@ test(`correctly avoids capture by other parameter names`, () => {
   expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
   expect(getLastStepAsString(steps)).toEqual('x + 1;')
 })
+
+describe(`redeclaration of predeclared functions work`, () => {
+  test('control', () => {
+    const code = `
+    length(list(1, 2, 3));
+    `
+    const context = mockContext(2)
+    const program = parse(code, context)!
+    const steps = getEvaluationSteps(program, context, 1000)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('3;')
+  })
+
+  test('test', () => {
+    const code = `
+    function length(xs) {
+      return 0;
+    }
+    length(list(1, 2, 3));
+    `
+    const context = mockContext(2)
+    const program = parse(code, context)!
+    const steps = getEvaluationSteps(program, context, 1000)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('0;')
+  })
+})


### PR DESCRIPTION
Should resolve #1050.

I've only tested via the unit tests, without a manual integration test with sa frontend, but this should work.