### PR TITLE
Improve syntax colours' hulk mode compatibility

### DIFF
--- a/src/editors/ace/theme/source.ts
+++ b/src/editors/ace/theme/source.ts
@@ -65,9 +65,13 @@ function theme(acequire, exports, module) {
                         }\
                         .ace-source .ace_constant,\
                         .ace-source .ace_constant.ace_character,\
-                        .ace-source .ace_constant.ace_character.ace_escape,\
-                        .ace-source .ace_constant.ace_other {\
+                        .ace-source .ace_constant.ace_other,\
+                        .ace-source .ace_string,\
+                        .ace-source .ace_string.ace_regexp {\
                         color: #FF628C\
+                        }\
+                        .ace-source .ace_constant.ace_character.ace_escape {\
+                        color: #FFFFFF\
                         }\
                         .ace-source .ace_invalid {\
                         color: #F8F8F8;\
@@ -94,12 +98,6 @@ function theme(acequire, exports, module) {
                         }\
                         .ace-source .ace_entity {\
                         color: #FFDD00\
-                        }\
-                        .ace-source .ace_string {\
-                        color: #3AD900\
-                        }\
-                        .ace-source .ace_string.ace_regexp {\
-                        color: #80FFC2\
                         }\
                         .ace-source .ace_comment {\
                         font-style: italic;\


### PR DESCRIPTION
The green string literals were causing them to disappear when hulk mode is used in conjunction with the chroma key effect. This change makes strings match other constants (light red).