### PR TITLE
Fix import statements breaking infinite loop detector

### DIFF
--- a/src/infiniteLoops/__tests__/instrument.ts
+++ b/src/infiniteLoops/__tests__/instrument.ts
@@ -158,11 +158,3 @@ test('combination of loops and functions run as expected', () => {
   output(z);`
   expect(runWithMock(main)).toBe(100)
 })
-
-test('import statements are removed', () => {
-  const main = `
-  import {turn_upside_down,beside} from 'rune';
-  output(1);`
-  // eval will throw an error if import is still present
-  expect(runWithMock(main)).toBe(1)
-})

--- a/src/infiniteLoops/__tests__/instrument.ts
+++ b/src/infiniteLoops/__tests__/instrument.ts
@@ -158,3 +158,11 @@ test('combination of loops and functions run as expected', () => {
   output(z);`
   expect(runWithMock(main)).toBe(100)
 })
+
+test('import statements are removed', () => {
+  const main = `
+  import {turn_upside_down,beside} from 'rune';
+  output(1);`
+  // eval will throw an error if import is still present
+  expect(runWithMock(main)).toBe(1)
+})

--- a/src/infiniteLoops/__tests__/runtime.ts
+++ b/src/infiniteLoops/__tests__/runtime.ts
@@ -253,3 +253,11 @@ test('detect complicated stream example', () => {
   expect(result).toBeDefined()
   expect(result?.streamMode).toBe(true)
 })
+
+test('handle imports properly', () => {
+  const code = `import {thrice} from "repeat";
+  function f(x) { return is_number(x) ? f(x) : 42; }
+  display(f(thrice(x=>x+1)(0)));`
+  const result = testForInfiniteLoop(code, [])
+  expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
+})

--- a/src/infiniteLoops/instrument.ts
+++ b/src/infiniteLoops/instrument.ts
@@ -2,6 +2,9 @@ import * as es from 'estree'
 import { generate } from 'astring'
 import * as create from '../utils/astCreator'
 import { simple, recursive, WalkerCallback } from '../utils/walkers'
+import { transformSingleImportDeclaration } from '../transpiler/transpiler'
+import { MODULE_PARAMS_ID } from '../constants'
+import { memoizedGetModuleFile } from '../modules/moduleLoader'
 // transforms AST of program
 
 const globalIds = {
@@ -26,10 +29,6 @@ enum FunctionNames {
   trackLoc,
   evalB,
   evalU
-}
-
-function removeImports(program: es.Program) {
-  program.body = program.body.filter(x => x.type !== 'ImportDeclaration')
 }
 
 /**
@@ -275,7 +274,7 @@ function hybridizeVariablesAndLiterals(program: es.Node) {
       }
     },
     MemberExpression(node: es.MemberExpression, state: boolean, callback: WalkerCallback<boolean>) {
-      if (node.object.type === 'Identifier' && node.object.name === globalIds.functionsId) return
+      if (!node.computed) return
       callback(node.object, false)
       callback(node.property, false)
       create.mutateToCallExpression(node.object, callFunction(FunctionNames.concretize), [
@@ -563,6 +562,44 @@ function trackLocations(program: es.Program) {
   })
 }
 
+function transformImportDeclarations(programs: es.Program[]) {
+  let moduleCounter = 0
+  let allImports: es.ImportDeclaration[] = []
+  for (const program of programs) {
+    const imports = []
+    let result: es.VariableDeclaration[] = []
+    while (program.body.length > 0 && program.body[0].type === 'ImportDeclaration') {
+      imports.push(program.body.shift() as es.ImportDeclaration)
+    }
+    for (const node of imports) {
+      result = transformSingleImportDeclaration(moduleCounter, node).concat(result)
+      moduleCounter++
+    }
+    program.body = (result as (es.Statement | es.ModuleDeclaration)[]).concat(program.body)
+    allImports = allImports.concat(imports)
+  }
+  return allImports
+}
+
+function handleImports(programs: es.Program[]) {
+  const imports = transformImportDeclarations(programs)
+  let moduleCounter = 0
+  let prefix = ''
+  const names = []
+  for (const node of imports) {
+    const moduleText = memoizedGetModuleFile(node.source.value as string, 'bundle').trim()
+    // remove ; from moduleText
+    const name = `__MODULE_${moduleCounter}__`
+    prefix += `const ${name} = (${moduleText.substring(
+      0,
+      moduleText.length - 1
+    )})(${MODULE_PARAMS_ID});\n`
+    moduleCounter++
+    names.push(name)
+  }
+  return [prefix, names]
+}
+
 /**
  * Instruments the given code with functions that track the state of the program.
  *
@@ -581,10 +618,12 @@ function instrument(
   predefined[builtinsId] = builtinsId
   predefined[functionsId] = functionsId
   predefined[stateId] = stateId
-  removeImports(program)
   const innerProgram = { ...program }
+  const [prefix, moduleNames] = handleImports([program].concat(previous))
+  for (const name of moduleNames) {
+    predefined[name] = name
+  }
   for (const toWrap of previous) {
-    removeImports(toWrap)
     wrapOldCode(program, toWrap.body as es.Statement[])
   }
   wrapOldCode(program, builtinsToStmts(builtins))
@@ -602,7 +641,7 @@ function instrument(
   addStateToIsNull(program)
   wrapCallArguments(program)
   const code = generate(program)
-  return code
+  return prefix + code
 }
 
 export {

--- a/src/infiniteLoops/instrument.ts
+++ b/src/infiniteLoops/instrument.ts
@@ -28,6 +28,10 @@ enum FunctionNames {
   evalU
 }
 
+function removeImports(program: es.Program) {
+  program.body = program.body.filter(x => x.type !== 'ImportDeclaration')
+}
+
 /**
  * Renames all variables in the program to differentiate shadowed variables and
  * variables declared with the same name but in different scopes.
@@ -577,8 +581,10 @@ function instrument(
   predefined[builtinsId] = builtinsId
   predefined[functionsId] = functionsId
   predefined[stateId] = stateId
+  removeImports(program)
   const innerProgram = { ...program }
   for (const toWrap of previous) {
+    removeImports(toWrap)
     wrapOldCode(program, toWrap.body as es.Statement[])
   }
   wrapOldCode(program, builtinsToStmts(builtins))

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -12,6 +12,7 @@ import {
 } from './instrument'
 import { parse } from '../parser/parser'
 import { createContext } from '../index'
+import { MODULE_PARAMS_ID } from '../constants'
 
 function checkTimeout(state: st.State) {
   if (state.hasTimedOut()) {
@@ -279,10 +280,18 @@ export function testForInfiniteLoop(code: string, previousCodeStack: string[]) {
 
   const state = new st.State()
 
-  const sandboxedRun = new Function('code', functionsId, stateId, builtinsId, 'return eval(code)')
+  const sandboxedRun = new Function(
+    'code',
+    functionsId,
+    stateId,
+    builtinsId,
+    MODULE_PARAMS_ID,
+    // redeclare window so modules don't do anything funny like play sounds
+    '{let window = {}; return eval(code)}'
+  )
 
   try {
-    sandboxedRun(instrumentedCode, functions, state, newBuiltins)
+    sandboxedRun(instrumentedCode, functions, state, newBuiltins, context.moduleParams)
   } catch (error) {
     if (error instanceof InfiniteLoopError) {
       if (state.lastLocation !== undefined) {


### PR DESCRIPTION
With the new change where students manually import libraries in their code, wild `import` statements in the program will break the infinite loop detector (in particular when we use `eval` on the instrumented code).

e.g.
```
import {turn_upside_down,beside,heart,stackn,show} from 'rune';
function besiden(n, rune) {
  // edit the return expression
    return besiden(n,rune);
  }
  
show(besiden(5, heart));
```
This will currently not be detected unless you remove the first line.

EDIT:
Fixed this by actually importing the module into the code.
One hiccup is that modules like `sound` might try to play sound in the browser's `window` so to prevent this we shadow the original window with an empty object (before eval), i.e. `{let window = {}; return eval(code)}`