### PR TITLE
Make typechecking lazy

### DIFF
--- a/src/__tests__/__snapshots__/inspect.ts.snap
+++ b/src/__tests__/__snapshots__/inspect.ts.snap
@@ -38,19 +38,6 @@ Array [
       ],
       "callee": Node {
         "end": 78,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "undefined",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -63,14 +50,9 @@ Array [
         },
         "name": "a",
         "start": 77,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 82,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "undefined",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 7,
@@ -82,7 +64,6 @@ Array [
         },
       },
       "start": 77,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -177,19 +158,6 @@ Array [
       ],
       "callee": Node {
         "end": 78,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "undefined",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -202,14 +170,9 @@ Array [
         },
         "name": "a",
         "start": 77,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 82,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "undefined",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 7,
@@ -221,7 +184,6 @@ Array [
         },
       },
       "start": 77,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -443,19 +405,6 @@ Array [
       ],
       "callee": Node {
         "end": 108,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -468,14 +417,9 @@ Array [
         },
         "name": "a",
         "start": 107,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 112,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 7,
@@ -487,7 +431,6 @@ Array [
         },
       },
       "start": 107,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -577,19 +520,6 @@ Array [
       ],
       "callee": Node {
         "end": 53,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -602,14 +532,9 @@ Array [
         },
         "name": "a",
         "start": 52,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 57,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 7,
@@ -621,7 +546,6 @@ Array [
         },
       },
       "start": 52,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -723,19 +647,6 @@ Array [
       ],
       "callee": Node {
         "end": 266,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -748,14 +659,9 @@ Array [
         },
         "name": "a",
         "start": 265,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 270,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 7,
@@ -767,7 +673,6 @@ Array [
         },
       },
       "start": 265,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -1380,19 +1285,6 @@ Array [
       ],
       "callee": Node {
         "end": 43,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "string",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "string",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -1405,14 +1297,9 @@ Array [
         },
         "name": "a",
         "start": 42,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 50,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "string",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 10,
@@ -1424,7 +1311,6 @@ Array [
         },
       },
       "start": 42,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -1642,19 +1528,6 @@ Array [
       ],
       "callee": Node {
         "end": 78,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -1667,14 +1540,9 @@ Array [
         },
         "name": "a",
         "start": 77,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 81,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 6,
@@ -1686,7 +1554,6 @@ Array [
         },
       },
       "start": 77,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -1776,19 +1643,6 @@ Array [
       ],
       "callee": Node {
         "end": 58,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 5,
@@ -1801,14 +1655,9 @@ Array [
         },
         "name": "a",
         "start": 57,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 69,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 16,
@@ -1820,7 +1669,6 @@ Array [
         },
       },
       "start": 57,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -1910,19 +1758,6 @@ Array [
       ],
       "callee": Node {
         "end": 58,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 5,
@@ -1935,14 +1770,9 @@ Array [
         },
         "name": "a",
         "start": 57,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 69,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 16,
@@ -1954,7 +1784,6 @@ Array [
         },
       },
       "start": 57,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -2044,19 +1873,6 @@ Array [
       ],
       "callee": Node {
         "end": 58,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 5,
@@ -2069,14 +1885,9 @@ Array [
         },
         "name": "a",
         "start": 57,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 69,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 16,
@@ -2088,7 +1899,6 @@ Array [
         },
       },
       "start": 57,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -2242,19 +2052,6 @@ Array [
       ],
       "callee": Node {
         "end": 78,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 3,
@@ -2267,14 +2064,9 @@ Array [
         },
         "name": "a",
         "start": 77,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 81,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 6,
@@ -2286,7 +2078,6 @@ Array [
         },
       },
       "start": 77,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {
@@ -2376,19 +2167,6 @@ Array [
       ],
       "callee": Node {
         "end": 58,
-        "inferredType": Object {
-          "kind": "function",
-          "parameterTypes": Array [
-            Object {
-              "kind": "primitive",
-              "name": "number",
-            },
-          ],
-          "returnType": Object {
-            "kind": "primitive",
-            "name": "number",
-          },
-        },
         "loc": SourceLocation {
           "end": Position {
             "column": 5,
@@ -2401,14 +2179,9 @@ Array [
         },
         "name": "a",
         "start": 57,
-        "typability": "Typed",
         "type": "Identifier",
       },
       "end": 69,
-      "inferredType": Object {
-        "kind": "primitive",
-        "name": "number",
-      },
       "loc": SourceLocation {
         "end": Position {
           "column": 16,
@@ -2420,7 +2193,6 @@ Array [
         },
       },
       "start": 57,
-      "typability": "Typed",
       "type": "CallExpression",
     },
     "head": Object {

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -142,6 +142,7 @@ export const createEmptyContext = <T>(
     nativeStorage: createNativeStorage(),
     executionMethod: 'auto',
     variant,
+    unTypecheckedCode: [],
     typeEnvironment: createTypeEnvironment(chapter),
     previousCode: []
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { RuntimeSourceError } from './errors/runtimeSourceError'
 import { findDeclarationNode, findIdentifierNode } from './finder'
 import { evaluate } from './interpreter/interpreter'
-import { parse, looseParse, parseAt, parseForNames } from './parser/parser'
+import { parse, looseParse, typedParse, parseAt, parseForNames } from './parser/parser'
 import { AsyncScheduler, PreemptiveScheduler, NonDetScheduler } from './schedulers'
 import { getAllOccurrencesInScopeHelper, getScopeHelper } from './scope-refactoring'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
@@ -287,14 +287,6 @@ export async function getNames(
   return [progNames.concat(keywords), displaySuggestions]
 }
 
-function typedParse(code: any, context: Context) {
-  const program: Program | undefined = looseParse(code, context)
-  if (program === undefined) {
-    return null
-  }
-  return validateAndAnnotate(program, context)
-}
-
 export function getTypeInformation(
   code: string,
   context: Context,
@@ -425,7 +417,7 @@ export async function runInContext(
     return resolvedErrorPromise
   }
   validateAndAnnotate(program as Program, context)
-  typeCheck(program, context)
+  context.unTypecheckedCode.push(code)
   if (context.errors.length > 0) {
     return resolvedErrorPromise
   }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -13,6 +13,7 @@ import { Context, ErrorSeverity, ErrorType, Rule, SourceError } from '../types'
 import { stripIndent } from '../utils/formatters'
 import rules from './rules'
 import syntaxBlacklist from './syntaxBlacklist'
+import { validateAndAnnotate } from '../validator/validator'
 
 export class DisallowedConstructError implements SourceError {
   public type = ErrorType.SYNTAX
@@ -185,6 +186,14 @@ export function looseParse(source: string, context: Context) {
     createAcornParserOptions(context)
   ) as unknown as es.Program
   return program
+}
+
+export function typedParse(code: any, context: Context) {
+  const program: es.Program | undefined = looseParse(code, context)
+  if (program === undefined) {
+    return null
+  }
+  return validateAndAnnotate(program, context)
 }
 
 function createWalkers(

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,10 @@ export interface Context<T = any> {
    */
   variant: Variant
 
+  /**
+   * Contains the evaluated code that has not yet been typechecked.
+   */
+  unTypecheckedCode: string[]
   typeEnvironment: TypeEnvironment
 
   /**


### PR DESCRIPTION
Should speed up Source 2 to Source 4 by approx 100ms (~150ms to ~25ms).

Test with tiny programs like

`1;`