### PR TITLE
Implement primitives in Source 3 Concurrent

### DIFF
--- a/docs/lib/stream.js
+++ b/docs/lib/stream.js
@@ -49,7 +49,7 @@ function is_stream(xs) {
     return is_null(xs) ||
         (is_pair(xs) &&
         is_function(tail(xs)) &&
-        array_length(tail(xs)) === 0 &&
+        arity(tail(xs)) === 0 &&
         is_stream(stream_tail(xs)));
 }
 

--- a/src/__tests__/__snapshots__/display.ts.snap
+++ b/src/__tests__/__snapshots__/display.ts.snap
@@ -155,6 +155,19 @@ Object {
 }
 `;
 
+exports[`display with no arguments throws an error: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display();",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "Line 1: Expected 1 or more arguments, but got 0.",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`raw_display can be used to display (unescaped) strings directly: expectDisplayResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/__tests__/__snapshots__/draw_data.ts.snap
+++ b/src/__tests__/__snapshots__/draw_data.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`draw_data returns first argument if exactly one argument: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "draw_data(1);",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 1,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [
+    Array [
+      1,
+    ],
+  ],
+}
+`;
+
+exports[`draw_data returns first argument if more than one argument: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "draw_data(1, 2);",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 1,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [
+    Array [
+      1,
+      2,
+    ],
+  ],
+}
+`;
+
+exports[`draw_data with no arguments throws error: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "draw_data();",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "Line 1: Expected 1 or more arguments, but got 0.",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;

--- a/src/__tests__/display.ts
+++ b/src/__tests__/display.ts
@@ -87,3 +87,9 @@ Array [
 ]
 `)
 })
+
+test('display with no arguments throws an error', () => {
+  return expectParsedError(`display();`, { chapter: 100 }).toMatchInlineSnapshot(
+    `"Line 1: Expected 1 or more arguments, but got 0."`
+  )
+})

--- a/src/__tests__/draw_data.ts
+++ b/src/__tests__/draw_data.ts
@@ -1,0 +1,15 @@
+import { expectParsedError, expectResult } from '../utils/testing'
+
+test('draw_data returns first argument if more than one argument', () => {
+  return expectResult(`draw_data(1, 2);`, { chapter: 3 }).toMatchInlineSnapshot(`1`)
+})
+
+test('draw_data returns first argument if exactly one argument', () => {
+  return expectResult(`draw_data(1);`, { chapter: 3 }).toMatchInlineSnapshot(`1`)
+})
+
+test('draw_data with no arguments throws error', () => {
+  return expectParsedError(`draw_data();`, { chapter: 3 }).toMatchInlineSnapshot(
+    `"Line 1: Expected 1 or more arguments, but got 0."`
+  )
+})

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -260,7 +260,10 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
     externalBuiltIns.alert(v, '', context.externalContext)
     context.nativeStorage.maxExecTime += Date.now() - start
   }
-  const visualiseList = (...v: Value) => externalBuiltIns.visualiseList(v, context.externalContext)
+  const visualiseList = (...v: Value) => {
+    externalBuiltIns.visualiseList(v, context.externalContext)
+    return v[0]
+  }
 
   if (context.chapter >= 1) {
     defineBuiltin(context, 'get_time()', misc.get_time)
@@ -312,7 +315,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, 'head(xs)', new LazyBuiltIn(list.head, true))
       defineBuiltin(context, 'tail(xs)', new LazyBuiltIn(list.tail, true))
       defineBuiltin(context, 'is_null(val)', new LazyBuiltIn(list.is_null, true))
-      defineBuiltin(context, 'draw_data(...xs)', new LazyBuiltIn(visualiseList, true), 0)
+      defineBuiltin(context, 'draw_data(...xs)', new LazyBuiltIn(visualiseList, true), 1)
       defineBuiltin(context, 'is_list(val)', new LazyBuiltIn(list.is_list, true))
     } else {
       defineBuiltin(context, 'pair(left, right)', list.pair)
@@ -321,7 +324,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, 'tail(xs)', list.tail)
       defineBuiltin(context, 'is_null(val)', list.is_null)
       defineBuiltin(context, 'list(...values)', list.list, 0)
-      defineBuiltin(context, 'draw_data(...xs)', visualiseList, 0)
+      defineBuiltin(context, 'draw_data(...xs)', visualiseList, 1)
       defineBuiltin(context, 'display_list(val, prepend = undefined)', displayList, 0)
       defineBuiltin(context, 'is_list(val)', list.is_list)
     }

--- a/src/stdlib/stream.prelude.ts
+++ b/src/stdlib/stream.prelude.ts
@@ -10,7 +10,7 @@ function is_stream(xs) {
   return is_null(xs) ||
     (is_pair(xs) &&
     is_function(tail(xs)) &&
-    array_length(tail(xs)) === 0 &&
+    arity(tail(xs)) === 0 &&
     is_stream(stream_tail(xs)));
 }
 

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -1,6 +1,6 @@
 import { SVMFunction, Program } from '../vm/svml-compiler'
 import OpCodes from '../vm/opcodes'
-import { get_time, parse_int } from './misc'
+import { char_at, get_time, parse_int } from './misc'
 
 // functions should be sorted in alphabetical order. Refer to SVML spec on wiki
 // placeholders should be manually replaced with the correct machine code.
@@ -550,7 +550,10 @@ function _display_list(args) {
   return args[0] % args[1];
 }
 
-// hack to make the call to Program easier, just replace the index 93 (number of primitive functions + 2)
+// 93 placeholder
+function _char_at(str,index) {}
+
+// hack to make the call to Program easier, just replace the index 94 (number of primitive functions + 2)
 (() => 0)();
 `
 
@@ -651,7 +654,8 @@ export const PRIMITIVE_FUNCTION_NAMES = [
   'tail',
   'stringify',
   'prompt',
-  'display_list'
+  'display_list',
+  'char_at'
 ]
 
 export const VARARGS_NUM_ARGS = -1
@@ -727,7 +731,8 @@ export const BINARY_PRIMITIVES: [string, number, any?][] = [
   ['math_atan2', OpCodes.MATH_ATAN2, Math.atan2],
   ['math_imul', OpCodes.MATH_IMUL, Math.imul],
   ['math_pow', OpCodes.MATH_POW, Math.pow],
-  ['parse_int', OpCodes.PARSE_INT, parse_int]
+  ['parse_int', OpCodes.PARSE_INT, parse_int],
+  ['char_at', OpCodes.CHAR_AT, char_at]
 ]
 
 export const EXTERNAL_PRIMITIVES: [string, number][] = [

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -50,8 +50,19 @@ function _display(args) {
   return args[0] % args[1];
 }
 
-// 6 placeholder
-function _draw_data(args) {}
+// 6 custom
+// following math_hypot's implementation style
+// using the ... operator on the machine
+// change number of arguments to varargs (-1)
+// replace NOTG opcode with DRAW_DATA opcode
+function _draw_data(args) {
+  !args;
+  if (array_length(args) === 1) {
+    return args[0]; // Return argument without array container
+  } else {
+    return args; // If 0 args or more than 1 args, keep array container
+  }
+}
 
 // 7
 function _enum_list(start, end) {
@@ -683,7 +694,7 @@ const VARARG_PRIMITIVES: [string, number?, number?][] = [
   ['math_min', OpCodes.MODG, OpCodes.MATH_MIN],
   ['math_hypot', OpCodes.NOTG, OpCodes.MATH_HYPOT],
   ['list'],
-  ['draw_data'],
+  ['draw_data', OpCodes.NOTG, OpCodes.DRAW_DATA],
   ['stream'],
   ['prompt', OpCodes.NOTG, OpCodes.PROMPT],
   ['display_list', OpCodes.MODG, OpCodes.DISPLAY_LIST]
@@ -746,6 +757,7 @@ export const BINARY_PRIMITIVES: [string, number, any?][] = [
 
 export const EXTERNAL_PRIMITIVES: [string, number][] = [
   ['display', OpCodes.DISPLAY],
+  ['draw_data', OpCodes.DRAW_DATA],
   ['error', OpCodes.ERROR],
   ['prompt', OpCodes.PROMPT],
   ['display_list', OpCodes.DISPLAY_LIST]

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -553,7 +553,10 @@ function _display_list(args) {
 // 93 placeholder
 function _char_at(str,index) {}
 
-// hack to make the call to Program easier, just replace the index 94 (number of primitive functions + 2)
+// 94 placeholder
+function _arity(f) {}
+
+// hack to make the call to Program easier, just replace the index 95 (number of primitive functions + 2)
 (() => 0)();
 `
 
@@ -655,7 +658,8 @@ export const PRIMITIVE_FUNCTION_NAMES = [
   'stringify',
   'prompt',
   'display_list',
-  'char_at'
+  'char_at',
+  'arity'
 ]
 
 export const VARARGS_NUM_ARGS = -1
@@ -724,7 +728,8 @@ export const UNARY_PRIMITIVES: [string, number, any?][] = [
   ['math_tan', OpCodes.MATH_TAN, Math.tan],
   ['math_tanh', OpCodes.MATH_TANH, Math.tanh],
   ['math_trunc', OpCodes.MATH_TRUNC, Math.trunc],
-  ['stringify', OpCodes.STRINGIFY]
+  ['stringify', OpCodes.STRINGIFY],
+  ['arity', OpCodes.ARITY]
 ]
 
 export const BINARY_PRIMITIVES: [string, number, any?][] = [

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -541,7 +541,16 @@ function _prompt(args) {
   }
 }
 
-// hack to make the call to Program easier, just replace the index 92 (number of primitive functions + 2)
+// 92 custom
+// replace MODG opcode (25) with display_list opcode
+// change number of arguments to varargs (-1)
+function _display_list(args) {
+  // display_list(args[0], args[1]);
+  // compile this instead for easier replacing
+  return args[0] % args[1];
+}
+
+// hack to make the call to Program easier, just replace the index 93 (number of primitive functions + 2)
 (() => 0)();
 `
 
@@ -641,7 +650,8 @@ export const PRIMITIVE_FUNCTION_NAMES = [
   'stream_to_list',
   'tail',
   'stringify',
-  'prompt'
+  'prompt',
+  'display_list'
 ]
 
 export const VARARGS_NUM_ARGS = -1
@@ -663,7 +673,8 @@ const VARARG_PRIMITIVES: [string, number?, number?][] = [
   ['list'],
   ['draw_data'],
   ['stream'],
-  ['prompt', OpCodes.NOTG, OpCodes.PROMPT]
+  ['prompt', OpCodes.NOTG, OpCodes.PROMPT],
+  ['display_list', OpCodes.MODG, OpCodes.DISPLAY_LIST]
 ]
 
 // primitives without a function should be manually implemented
@@ -722,7 +733,8 @@ export const BINARY_PRIMITIVES: [string, number, any?][] = [
 export const EXTERNAL_PRIMITIVES: [string, number][] = [
   ['display', OpCodes.DISPLAY],
   ['error', OpCodes.ERROR],
-  ['prompt', OpCodes.PROMPT]
+  ['prompt', OpCodes.PROMPT],
+  ['display_list', OpCodes.DISPLAY_LIST]
 ]
 
 export const CONSTANT_PRIMITIVES: [string, any][] = [

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -47,7 +47,11 @@ function _build_stream(n, fun) {
 function _display(args) {
   // display(args[0], args[1]);
   // compile this instead for easier replacing
-  return args[0] % args[1];
+  if (array_length(args) === 0) {
+    error('Expected 1 or more arguments, but got ' + stringify(array_length(args)) + '.');
+  } else {
+    return args[0] % args[1];
+  }
 }
 
 // 6 custom
@@ -56,11 +60,11 @@ function _display(args) {
 // change number of arguments to varargs (-1)
 // replace NOTG opcode with DRAW_DATA opcode
 function _draw_data(args) {
-  !args;
-  if (array_length(args) === 1) {
-    return args[0]; // Return argument without array container
+  if (array_length(args) === 0) {
+    error('Expected 1 or more arguments, but got ' + stringify(array_length(args)) + '.');
   } else {
-    return args; // If 0 args or more than 1 args, keep array container
+    !args;
+    return args[0];
   }
 }
 

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -150,7 +150,11 @@ function _is_pair(x) {
 
 // 23
 function _is_stream(xs) {
-  return is_null(xs) || (is_pair(xs) && is_stream(stream_tail(xs)));
+  return is_null(xs) ||
+    (is_pair(xs) &&
+    is_function(tail(xs)) &&
+    arity(tail(xs)) === 0 &&
+    is_stream(stream_tail(xs)));
 }
 
 // 24 placeholder

--- a/src/stepper/lib.ts
+++ b/src/stepper/lib.ts
@@ -148,6 +148,10 @@ export function list(...values: substituterNodes[]): es.ArrayExpression {
   return ret as es.ArrayExpression
 }
 //   defineBuiltin(context, 'draw_data(xs)', visualiseList)
-export function draw_data(...xs: substituterNodes[]): es.Identifier {
-  return ast.primitive(undefined) as es.Identifier
+export function draw_data(...xs: substituterNodes[]): substituterNodes {
+  if (xs.length === 0) {
+    return ast.primitive(undefined)
+  } else {
+    return xs[0]
+  }
 }

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -243,6 +243,15 @@ export function expectDisplayResult(code: string, options: TestOptions = {}) {
   ).resolves
 }
 
+export function expectVisualiseListResult(code: string, options: TestOptions = {}) {
+  return expect(
+    testSuccess(code, options)
+      .then(snapshot('expectVisualiseListResult'))
+      .then(testResult => testResult.visualiseListResult)
+      .catch(e => console.log(e))
+  ).resolves
+}
+
 // for use in concurrent testing
 export async function getDisplayResult(code: string, options: TestOptions = {}) {
   return await testSuccess(code, options).then(testResult => testResult.displayResult!)

--- a/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
+++ b/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
@@ -134,6 +134,21 @@ display(array_length(p));",
 }
 `;
 
+exports[`primitive opcodes self-implemented CHAR_AT works: expectDisplayResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display(char_at(\\"test\\", 1));",
+  "displayResult": Array [
+    "\\"e\\"",
+  ],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": "all threads terminated",
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`primitive opcodes self-implemented DISPLAY works for circular references: expectDisplayResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
+++ b/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
@@ -222,6 +222,46 @@ display_list(pair(1, pair(2, null)), \\"test\\");",
 }
 `;
 
+exports[`primitive opcodes self-implemented DRAW_DATA works: expectDisplayResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display(draw_data(pair(true, [1])));
+display(draw_data());
+display(draw_data(null, list(undefined, 2), \\"3\\"));",
+  "displayResult": Array [
+    "[true, [1]]",
+    "[]",
+    "[null, [undefined, [2, null]], \\"3\\"]",
+  ],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": "all threads terminated",
+  "resultStatus": "finished",
+  "visualiseListResult": Array [
+    Array [
+      Array [
+        true,
+        Array [
+          1,
+        ],
+      ],
+    ],
+    Array [],
+    Array [
+      null,
+      Array [
+        undefined,
+        Array [
+          2,
+          null,
+        ],
+      ],
+      "3",
+    ],
+  ],
+}
+`;
+
 exports[`primitive opcodes self-implemented ERROR works: expectParsedError 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
+++ b/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
@@ -153,6 +153,23 @@ display(p);",
 }
 `;
 
+exports[`primitive opcodes self-implemented DISPLAY_LIST works: expectDisplayResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display_list(pair(1, null));
+display_list(pair(1, pair(2, null)), \\"test\\");",
+  "displayResult": Array [
+    "list(1)",
+    "test list(1, 2)",
+  ],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": "all threads terminated",
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`primitive opcodes self-implemented ERROR works: expectParsedError 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
+++ b/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
@@ -96,6 +96,43 @@ display(NaN);",
 }
 `;
 
+exports[`primitive opcodes self-implemented ARITY fails for ill-typed argument: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "arity(1);",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "Error: execution aborted: Expected closure, got number for arity.",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;
+
+exports[`primitive opcodes self-implemented ARITY works: expectDisplayResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display(arity(math_random));
+display(arity(accumulate));
+display(arity(display));
+display(arity((x, y) => x));
+function f() {}
+display(arity(f));",
+  "displayResult": Array [
+    "0",
+    "3",
+    "0",
+    "2",
+    "0",
+  ],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": "all threads terminated",
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`primitive opcodes self-implemented ARRAY_LEN fails for ill-typed argument: expectParsedError 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
+++ b/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
@@ -222,17 +222,13 @@ display_list(pair(1, pair(2, null)), \\"test\\");",
 }
 `;
 
-exports[`primitive opcodes self-implemented DRAW_DATA works: expectDisplayResult 1`] = `
+exports[`primitive opcodes self-implemented DRAW_DATA works: expectVisualiseListResult 1`] = `
 Object {
   "alertResult": Array [],
-  "code": "display(draw_data(pair(true, [1])));
-display(draw_data());
-display(draw_data(null, list(undefined, 2), \\"3\\"));",
-  "displayResult": Array [
-    "[true, [1]]",
-    "[]",
-    "[null, [undefined, [2, null]], \\"3\\"]",
-  ],
+  "code": "draw_data(pair(true, [1]));
+draw_data();
+draw_data(null, list(undefined, 2), \\"3\\");",
+  "displayResult": Array [],
   "numErrors": 0,
   "parsedErrors": "",
   "result": "all threads terminated",

--- a/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
+++ b/src/vm/__tests__/__snapshots__/svml-machine.ts.snap
@@ -186,6 +186,19 @@ Object {
 }
 `;
 
+exports[`primitive opcodes self-implemented DISPLAY throws error if no argumentns: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display();",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "Error: \\"Expected 1 or more arguments, but got 0.\\"",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`primitive opcodes self-implemented DISPLAY works for circular references: expectDisplayResult 1`] = `
 Object {
   "alertResult": Array [],
@@ -222,11 +235,60 @@ display_list(pair(1, pair(2, null)), \\"test\\");",
 }
 `;
 
+exports[`primitive opcodes self-implemented DRAW_DATA returns correct values: expectDisplayResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "display(draw_data(pair(true, [1])));
+display(draw_data(null, list(undefined, 2), \\"3\\"));",
+  "displayResult": Array [
+    "[true, [1]]",
+    "null",
+  ],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": "all threads terminated",
+  "resultStatus": "finished",
+  "visualiseListResult": Array [
+    Array [
+      Array [
+        true,
+        Array [
+          1,
+        ],
+      ],
+    ],
+    Array [
+      null,
+      Array [
+        undefined,
+        Array [
+          2,
+          null,
+        ],
+      ],
+      "3",
+    ],
+  ],
+}
+`;
+
+exports[`primitive opcodes self-implemented DRAW_DATA throws error if no argumentns: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "draw_data();",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "Error: \\"Expected 1 or more arguments, but got 0.\\"",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`primitive opcodes self-implemented DRAW_DATA works: expectVisualiseListResult 1`] = `
 Object {
   "alertResult": Array [],
   "code": "draw_data(pair(true, [1]));
-draw_data();
 draw_data(null, list(undefined, 2), \\"3\\");",
   "displayResult": Array [],
   "numErrors": 0,
@@ -242,7 +304,6 @@ draw_data(null, list(undefined, 2), \\"3\\");",
         ],
       ],
     ],
-    Array [],
     Array [
       null,
       Array [

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -1,6 +1,7 @@
 import {
   expectParsedError,
   expectDisplayResult,
+  expectVisualiseListResult,
   expectResult,
   getDisplayResult,
   snapshotSuccess
@@ -648,11 +649,11 @@ describe('primitive opcodes', () => {
 
     // Also note the result in visualiseListResult in the .snap file
     test('DRAW_DATA works', () => {
-      return expectDisplayResult(
+      return expectVisualiseListResult(
         stripIndent`
-          display(draw_data(pair(true, [1])));
-          display(draw_data());
-          display(draw_data(null, list(undefined, 2), "3"));
+          draw_data(pair(true, [1]));
+          draw_data();
+          draw_data(null, list(undefined, 2), "3");
         `,
         {
           chapter: 3,
@@ -660,9 +661,26 @@ describe('primitive opcodes', () => {
         }
       ).toMatchInlineSnapshot(`
                 Array [
-                  "[true, [1]]",
-                  "[]",
-                  "[null, [undefined, [2, null]], \\"3\\"]",
+                  Array [
+                    Array [
+                      true,
+                      Array [
+                        1,
+                      ],
+                    ],
+                  ],
+                  Array [],
+                  Array [
+                    null,
+                    Array [
+                      undefined,
+                      Array [
+                        2,
+                        null,
+                      ],
+                    ],
+                    "3",
+                  ],
                 ]
               `)
     })

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -806,6 +806,37 @@ describe('primitive opcodes', () => {
               `)
     })
 
+    test('ARITY works', () => {
+      return expectDisplayResult(
+        stripIndent`
+          display(arity(math_random));
+          display(arity(accumulate));
+          display(arity(display));
+          display(arity((x, y) => x));
+          function f() {}
+          display(arity(f));
+        `,
+        { chapter: 3, variant: 'concurrent' }
+      ).toMatchInlineSnapshot(`
+                Array [
+                  "0",
+                  "3",
+                  "0",
+                  "2",
+                  "0",
+                ]
+              `)
+    })
+
+    test('ARITY fails for ill-typed argument', () => {
+      return expectParsedError('arity(1);', {
+        chapter: 3,
+        variant: 'concurrent'
+      }).toMatchInlineSnapshot(
+        `"Error: execution aborted: Expected closure, got number for arity."`
+      )
+    })
+
     // variadic test
     test('list works', () => {
       return expectDisplayResult(

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -646,6 +646,27 @@ describe('primitive opcodes', () => {
       )
     })
 
+    // Also note the result in visualiseListResult in the .snap file
+    test('DRAW_DATA works', () => {
+      return expectDisplayResult(
+        stripIndent`
+          display(draw_data(pair(true, [1])));
+          display(draw_data());
+          display(draw_data(null, list(undefined, 2), "3"));
+        `,
+        {
+          chapter: 3,
+          variant: 'concurrent'
+        }
+      ).toMatchInlineSnapshot(`
+                Array [
+                  "[true, [1]]",
+                  "[]",
+                  "[null, [undefined, [2, null]], \\"3\\"]",
+                ]
+              `)
+    })
+
     test('ERROR works', () => {
       return expectParsedError('error(123);', {
         chapter: 3,

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -778,6 +778,21 @@ describe('primitive opcodes', () => {
               `)
     })
 
+    test('DISPLAY_LIST works', () => {
+      return expectDisplayResult(
+        stripIndent`
+          display_list(pair(1, null));
+          display_list(pair(1, pair(2, null)), "test");
+        `,
+        { chapter: 3, variant: 'concurrent' }
+      ).toMatchInlineSnapshot(`
+                Array [
+                  "list(1)",
+                  "test list(1, 2)",
+                ]
+              `)
+    })
+
     // variadic test
     test('list works', () => {
       return expectDisplayResult(

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -615,6 +615,18 @@ describe('primitive opcodes', () => {
               `)
     })
 
+    test('DISPLAY throws error if no argumentns', () => {
+      return expectParsedError(
+        stripIndent`
+          display();
+        `,
+        {
+          chapter: 3,
+          variant: 'concurrent'
+        }
+      ).toMatchInlineSnapshot(`"Error: \\"Expected 1 or more arguments, but got 0.\\""`)
+    })
+
     test('ARRAY_LEN works', () => {
       return expectDisplayResult(
         stripIndent`
@@ -647,12 +659,10 @@ describe('primitive opcodes', () => {
       )
     })
 
-    // Also note the result in visualiseListResult in the .snap file
     test('DRAW_DATA works', () => {
       return expectVisualiseListResult(
         stripIndent`
           draw_data(pair(true, [1]));
-          draw_data();
           draw_data(null, list(undefined, 2), "3");
         `,
         {
@@ -669,7 +679,6 @@ describe('primitive opcodes', () => {
                       ],
                     ],
                   ],
-                  Array [],
                   Array [
                     null,
                     Array [
@@ -683,6 +692,36 @@ describe('primitive opcodes', () => {
                   ],
                 ]
               `)
+    })
+
+    test('DRAW_DATA returns correct values', () => {
+      return expectDisplayResult(
+        stripIndent`
+          display(draw_data(pair(true, [1])));
+          display(draw_data(null, list(undefined, 2), "3"));
+        `,
+        {
+          chapter: 3,
+          variant: 'concurrent'
+        }
+      ).toMatchInlineSnapshot(`
+                Array [
+                  "[true, [1]]",
+                  "null",
+                ]
+              `)
+    })
+
+    test('DRAW_DATA throws error if no argumentns', () => {
+      return expectParsedError(
+        stripIndent`
+          draw_data();
+        `,
+        {
+          chapter: 3,
+          variant: 'concurrent'
+        }
+      ).toMatchInlineSnapshot(`"Error: \\"Expected 1 or more arguments, but got 0.\\""`)
     })
 
     test('ERROR works', () => {

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -793,6 +793,19 @@ describe('primitive opcodes', () => {
               `)
     })
 
+    test('CHAR_AT works', () => {
+      return expectDisplayResult(
+        stripIndent`
+          display(char_at("test", 1));
+        `,
+        { chapter: 3, variant: 'concurrent' }
+      ).toMatchInlineSnapshot(`
+                Array [
+                  "\\"e\\"",
+                ]
+              `)
+    })
+
     // variadic test
     test('list works', () => {
       return expectDisplayResult(

--- a/src/vm/opcodes.ts
+++ b/src/vm/opcodes.ts
@@ -139,6 +139,7 @@ export enum OpCodes {
   PROMPT = 1050,
   DISPLAY_LIST = 1051,
   CHAR_AT = 1052,
+  ARITY = 1053,
 
   // Source 3 Concurrenct Opcodes
   EXECUTE = 2000,

--- a/src/vm/opcodes.ts
+++ b/src/vm/opcodes.ts
@@ -138,6 +138,7 @@ export enum OpCodes {
   STRINGIFY = 1049,
   PROMPT = 1050,
   DISPLAY_LIST = 1051,
+  CHAR_AT = 1052,
 
   // Source 3 Concurrenct Opcodes
   EXECUTE = 2000,

--- a/src/vm/opcodes.ts
+++ b/src/vm/opcodes.ts
@@ -137,6 +137,7 @@ export enum OpCodes {
   STREAM = 1048,
   STRINGIFY = 1049,
   PROMPT = 1050,
+  DISPLAY_LIST = 1051,
 
   // Source 3 Concurrenct Opcodes
   EXECUTE = 2000,

--- a/src/vm/svml-machine.ts
+++ b/src/vm/svml-machine.ts
@@ -1412,10 +1412,9 @@ M[OpCodes.DISPLAY] = () => {
   PC = PC + 1
 }
 
-// only works with lists and numbers
 M[OpCodes.DRAW_DATA] = () => {
   POP_OS()
-  externalFunctions.get(OpCodes.DRAW_DATA)(convertToJsFormat(RES))
+  externalFunctions.get(OpCodes.DRAW_DATA)(...convertToJsFormat(RES))
   A = RES
   PUSH_OS()
   PC = PC + 1

--- a/src/vm/svml-machine.ts
+++ b/src/vm/svml-machine.ts
@@ -1534,6 +1534,30 @@ M[OpCodes.DISPLAY_LIST] = () => {
   PC = PC + 1
 }
 
+M[OpCodes.ARITY] = () => {
+  POP_OS()
+  D = RES
+  G = HEAP[D + TAG_SLOT] === CLOSURE_TAG
+  if (G) {
+    H = HEAP[D + CLOSURE_FUNC_INDEX_SLOT]
+    H = FUNC[H]
+    A = H[FUNC_NUM_ARGS_OFFSET]
+    if (A === VARARGS_NUM_ARGS) {
+      A = 0
+    }
+    NEW_NUMBER()
+    A = RES
+    PUSH_OS()
+    PC = PC + 1
+  } else {
+    STATE = TYPE_ERROR
+    ERROR_MSG_ARGS[0] = 'closure'
+    ERROR_MSG_ARGS[1] = `${node_kind(HEAP[D + TAG_SLOT])}`
+    ERROR_MSG_ARGS[2] = 'arity'
+    RUNNING = false
+  }
+}
+
 addPrimitiveOpCodeHandlers()
 
 // Internal functions. They are called directly in internal function calls

--- a/src/vm/svml-machine.ts
+++ b/src/vm/svml-machine.ts
@@ -1523,6 +1523,17 @@ M[OpCodes.PROMPT] = () => {
   PC = PC + 1
 }
 
+M[OpCodes.DISPLAY_LIST] = () => {
+  POP_OS()
+  C = RES
+  POP_OS()
+  D = RES
+  externalFunctions.get(OpCodes.DISPLAY_LIST)(convertToJsFormat(D), convertToJsFormat(C))
+  A = D
+  PUSH_OS()
+  PC = PC + 1
+}
+
 addPrimitiveOpCodeHandlers()
 
 // Internal functions. They are called directly in internal function calls

--- a/src/vm/util.ts
+++ b/src/vm/util.ts
@@ -145,6 +145,7 @@ const OPCODES_STR = {
   [OpCodes.STRINGIFY]: 'STRINGIFY',
   [OpCodes.PROMPT]: 'PROMPT',
   [OpCodes.DISPLAY_LIST]: 'DISPLAY_LIST',
+  [OpCodes.CHAR_AT]: 'CHAR_AT',
 
   // Concurrency Opcodes
   [OpCodes.EXECUTE]: 'EXEC  ',

--- a/src/vm/util.ts
+++ b/src/vm/util.ts
@@ -144,6 +144,7 @@ const OPCODES_STR = {
   [OpCodes.STREAM]: 'STREAM',
   [OpCodes.STRINGIFY]: 'STRINGIFY',
   [OpCodes.PROMPT]: 'PROMPT',
+  [OpCodes.DISPLAY_LIST]: 'DISPLAY_LIST',
 
   // Concurrency Opcodes
   [OpCodes.EXECUTE]: 'EXEC  ',

--- a/src/vm/util.ts
+++ b/src/vm/util.ts
@@ -146,6 +146,7 @@ const OPCODES_STR = {
   [OpCodes.PROMPT]: 'PROMPT',
   [OpCodes.DISPLAY_LIST]: 'DISPLAY_LIST',
   [OpCodes.CHAR_AT]: 'CHAR_AT',
+  [OpCodes.ARITY]: 'ARITY',
 
   // Concurrency Opcodes
   [OpCodes.EXECUTE]: 'EXEC  ',


### PR DESCRIPTION
This pull request resolves #1171 by implementing display_list, char_at, arity and draw_data in S3 Concurrent.
(It also resolves #1161 by swapping out array_length for arity in every definition of is_stream)

display_list: Implemented in a manner similar to display

char_at: Implemented by calling char_at from stdlib/misc

arity: Implemented in the machine. Note that the way arity behaves differs between Concurrent and regular versions of Source for variadic functions. In vanilla Source, it returns the number of parameters other than the rest parameter. In the concurrent version, since all variadic functions are indicated to have `VARARGS_NUM_ARGS = -1` arguments, there is no way to see how many compulsory arguments the function has. I have set it to return 0 for any variadic function. This may have unintended consequences if one expects a function with arity 0 to be callable with 0 arguments (like in is_stream).
```
arity(display)  // 1 in Source 3
arity(display)  // 0 in Source 3 Concurrent
```
draw_data: No longer returns undefined after adding it back to the array of `EXTERNAL_PRIMITIVES`. Also ensured the return result matches that of draw_data in normal Source (when draw_data receives exactly one argument, it returns the argument as is after drawing it, otherwise it returns an array containing its arguments)
```
draw_data(pair(1, 2))  // [1, 2]
draw_data(pair(1, 2), pair(3 4))  // [[1, 2], [3, 4]]
```