### PR TITLE
typeChecker: import should bind local name, not imported name

### DIFF
--- a/src/typeChecker/__tests__/typeChecker.test.ts
+++ b/src/typeChecker/__tests__/typeChecker.test.ts
@@ -2069,21 +2069,23 @@ describe('Type context from previous executions get saved', () => {
 describe('imported vars have any type', () => {
   it('import', () => {
     const code1 = `
-      import {show, heart} from 'runes';
+      import {show, heart, nova as supernova} from 'runes';
       const a = show;
       const b = heart;
+      const c = supernova;
 
       // error
-      const c = not_imported;
+      const illegal = not_imported;
     `
     const [program, errors] = parseAndTypeCheck(code1, 1)
     expect(topLevelTypesToString(program)).toMatchInlineSnapshot(`
       "a: T0
       b: T0
-      c: T0"
+      c: T0
+      illegal: T0"
     `)
     expect(parseError(errors)).toMatchInlineSnapshot(`
-      "Line 7: One or more undeclared names detected (e.g. 'not_imported').
+      "Line 8: One or more undeclared names detected (e.g. 'not_imported').
       If there aren't actually any undeclared names, then is either a Source or misconfiguration bug.
       Please report this to the administrators!"
     `)

--- a/src/typeChecker/typeChecker.ts
+++ b/src/typeChecker/typeChecker.ts
@@ -1082,9 +1082,9 @@ function _infer(
       for (const statement of node.body) {
         if (statement.type === 'ImportDeclaration') {
           for (const specifier of statement.specifiers) {
-            if (specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier') {
-              setType(specifier.imported.name, tForAll(tVar('T1')), env)
-              setDeclKind(specifier.imported.name, 'const', env)
+            if (specifier.type === 'ImportSpecifier' && specifier.local.type === 'Identifier') {
+              setType(specifier.local.name, tForAll(tVar('T1')), env)
+              setDeclKind(specifier.local.name, 'const', env)
             }
           }
         }


### PR DESCRIPTION
Fixes #1191 by creating a binding for the local field and not the imported field.

When an import doesn't rename the imported object, e.g. `import { show } from 'runes';`, the `imported` and `local` fields are identical, which is why the bug wasn't caught sooner. In `import { show as tell } from 'runes';`, show is the imported field while tell is the local field.