### PR TITLE
Fix for reduction of empty block expressions

### DIFF
--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -1,5 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`#1109: Empty function bodies don't break execution Constant declaration of lambda 1`] = `
+"const a = () => {};
+\\"other statement\\";
+a();
+\\"Gets returned by normal run\\";
+
+const a = () => {};
+\\"other statement\\";
+a();
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+(() => {})();
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+(() => {})();
+\\"Gets returned by normal run\\";
+
+(() => {})();
+\\"Gets returned by normal run\\";
+
+(() => {})();
+\\"Gets returned by normal run\\";
+
+{};
+\\"Gets returned by normal run\\";
+
+{};
+\\"Gets returned by normal run\\";
+
+undefined;
+\\"Gets returned by normal run\\";
+
+undefined;
+\\"Gets returned by normal run\\";
+
+\\"Gets returned by normal run\\";
+
+\\"Gets returned by normal run\\";
+"
+`;
+
+exports[`#1109: Empty function bodies don't break execution Function declaration 1`] = `
+"function a() {}
+\\"other statement\\";
+a();
+\\"Gets returned by normal run\\";
+
+function a() {}
+\\"other statement\\";
+a();
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+a();
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+a();
+\\"Gets returned by normal run\\";
+
+a();
+\\"Gets returned by normal run\\";
+
+a();
+\\"Gets returned by normal run\\";
+
+{};
+\\"Gets returned by normal run\\";
+
+{};
+\\"Gets returned by normal run\\";
+
+undefined;
+\\"Gets returned by normal run\\";
+
+undefined;
+\\"Gets returned by normal run\\";
+
+\\"Gets returned by normal run\\";
+
+\\"Gets returned by normal run\\";
+"
+`;
+
 exports[`Infinite recursion 1`] = `
 "function f() {
   return f();

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -1419,3 +1419,33 @@ describe(`redeclaration of predeclared functions work`, () => {
     expect(getLastStepAsString(steps)).toEqual('0;')
   })
 })
+
+describe(`#1109: Empty function bodies don't break execution`, () => {
+  test('Function declaration', () => {
+    const code = `
+    function a() {}
+    "other statement";
+    a();
+    "Gets returned by normal run";
+    `
+    const context = mockContext(2)
+    const program = parse(code, context)!
+    const steps = getEvaluationSteps(program, context, 1000)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('"Gets returned by normal run";')
+  })
+
+  test('Constant declaration of lambda', () => {
+    const code = `
+    const a = () => {};
+    "other statement";
+    a();
+    "Gets returned by normal run";
+    `
+    const context = mockContext(2)
+    const program = parse(code, context)!
+    const steps = getEvaluationSteps(program, context, 1000)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('"Gets returned by normal run";')
+  })
+})

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1278,7 +1278,7 @@ function apply(
   }
 
   const firstStatement: es.Statement = (substedBody as es.BlockStatement).body[0]
-  return firstStatement.type === 'ReturnStatement'
+  return firstStatement && firstStatement.type === 'ReturnStatement'
     ? (firstStatement.argument as es.Expression)
     : ast.blockExpression((substedBody as es.BlockStatement).body)
 }
@@ -1443,7 +1443,8 @@ function reduceMain(
 
       Program: (target: es.Program): string => bodify(target.body[0]),
 
-      BlockExpression: (target: BlockExpression): string => bodify(target.body[0]),
+      BlockExpression: (target: BlockExpression): string =>
+        target.body.length === 0 ? 'Empty block statement evaluated' : bodify(target.body[0]),
 
       BlockStatement: (target: es.BlockStatement): string =>
         target.body.length === 0 ? 'Empty block statement evaluated' : bodify(target.body[0]),
@@ -2066,165 +2067,169 @@ function reduceMain(
       context: Context,
       paths: string[][]
     ): [substituterNodes, Context, string[][], string] {
-      const [firstStatement, ...otherStatements] = node.body
-      if (firstStatement.type === 'ReturnStatement') {
-        const arg = firstStatement.argument as es.Expression
-        return [arg, context, paths, explain(node)]
-      } else if (firstStatement.type === 'IfStatement') {
-        paths[0].push('body[0]')
-        const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
-        if (reduced.type === 'BlockStatement') {
-          const body = reduced.body as es.Statement[]
-          if (body.length > 1) {
-            path[1] = [...path[0].slice(0, path[0].length - 1)]
-          }
-          const wholeBlock = body.concat(...(otherStatements as es.Statement[]))
-          return [ast.blockExpression(wholeBlock), cont, path, str]
-        } else {
-          return [
-            ast.blockExpression([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
-            cont,
-            path,
-            str
-          ]
-        }
-      } else if (
-        firstStatement.type === 'ExpressionStatement' &&
-        isIrreducible(firstStatement.expression)
-      ) {
-        let stmt
-        if (otherStatements.length > 0) {
+      if (node.body.length === 0) {
+        return [ast.identifier('undefined'), context, paths, explain(node)]
+      } else {
+        const [firstStatement, ...otherStatements] = node.body
+        if (firstStatement.type === 'ReturnStatement') {
+          const arg = firstStatement.argument as es.Expression
+          return [arg, context, paths, explain(node)]
+        } else if (firstStatement.type === 'IfStatement') {
           paths[0].push('body[0]')
-          paths.push([])
-          stmt = ast.blockExpression(otherStatements as es.Statement[])
-        } else {
-          stmt = ast.identifier('undefined')
-        }
-        return [stmt, context, paths, explain(node)]
-      } else if (firstStatement.type === 'FunctionDeclaration') {
-        let funDecExp = ast.functionDeclarationExpression(
-          firstStatement.id!,
-          firstStatement.params,
-          firstStatement.body
-        ) as FunctionDeclarationExpression
-        // substitute body
-        funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
-          []
-        ])[0] as FunctionDeclarationExpression
-        // substitute the rest of the blockExpression
-        const remainingBlockExpression = ast.blockExpression(otherStatements as es.Statement[])
-        // substitution within the same block, add " same" so that substituter can differentiate between
-        // substitution within the block and substitution from outside the block
-        const newId = ast.identifier(funDecExp.id.name + ' same', funDecExp.id.loc)
-        const subst = substituteMain(newId, funDecExp, remainingBlockExpression, paths)
-        // concats paths such that:
-        // paths[0] -> path to the program to be substituted, pre-redex
-        // paths[1...] -> path(s) to the parts of the remaining program
-        // that were substituted, post-redex
-        paths[0].push('body[0]')
-        const allPaths = paths.concat(subst[1])
-        if (subst[1].length === 0) {
-          allPaths.push([])
-        }
-        return [subst[0], context, allPaths, explain(node)]
-      } else if (firstStatement.type === 'VariableDeclaration') {
-        const { kind, declarations } = firstStatement
-        if (kind !== 'const') {
-          // TODO: cannot use let or var
-          return [dummyBlockExpression(), context, paths, 'cannot use let or var']
-        } else if (
-          declarations.length <= 0 ||
-          declarations.length > 1 ||
-          declarations[0].type !== 'VariableDeclarator' ||
-          !declarations[0].init
-        ) {
-          // TODO: syntax error
-          return [dummyBlockExpression(), context, paths, 'syntax error']
-        } else {
-          const declarator = declarations[0] as es.VariableDeclarator
-          const rhs = declarator.init!
-          if (declarator.id.type !== 'Identifier') {
-            // TODO: source does not allow destructuring
-            return [dummyBlockExpression(), context, paths, 'source does not allow destructuring']
-          } else if (isIrreducible(rhs)) {
-            const remainingBlockExpression = ast.blockExpression(otherStatements as es.Statement[])
-            // forced casting for some weird errors
-            // substitution within the same block, add " same" so that substituter can differentiate between
-            // substitution within the block and substitution from outside the block
-            const newId = ast.identifier(declarator.id.name + ' same', declarator.id.loc)
-            const subst = substituteMain(
-              newId,
-              rhs as es.ArrayExpression,
-              remainingBlockExpression,
-              paths
-            )
-            // concats paths such that:
-            // paths[0] -> path to the program to be substituted, pre-redex
-            // paths[1...] -> path(s) to the parts of the remaining program
-            // that were substituted, post-redex
-            paths[0].push('body[0]')
-            const allPaths = paths.concat(subst[1])
-            if (subst[1].length === 0) {
-              allPaths.push([])
+          const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
+          if (reduced.type === 'BlockStatement') {
+            const body = reduced.body as es.Statement[]
+            if (body.length > 1) {
+              path[1] = [...path[0].slice(0, path[0].length - 1)]
             }
-            return [subst[0], context, allPaths, explain(node)]
-          } else if (rhs.type === 'ArrowFunctionExpression' || rhs.type === 'FunctionExpression') {
-            let funDecExp = ast.functionDeclarationExpression(
-              declarator.id,
-              rhs.params,
-              rhs.body.type === 'BlockStatement'
-                ? rhs.body
-                : ast.blockStatement([ast.returnStatement(rhs.body)])
-            ) as FunctionDeclarationExpression
-            // substitute body
-            funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
-              []
-            ])[0] as FunctionDeclarationExpression
-            // substitute the rest of the blockExpression
-            const remainingBlockExpression = ast.blockExpression(otherStatements as es.Statement[])
-            // substitution within the same block, add " same" so that substituter can differentiate between
-            // substitution within the block and substitution from outside the block
-            const newId = ast.identifier(funDecExp.id.name + ' same', funDecExp.id.loc)
-            const subst = substituteMain(newId, funDecExp, remainingBlockExpression, paths)
-            // concats paths such that:
-            // paths[0] -> path to the program to be substituted, pre-redex
-            // paths[1...] -> path(s) to the parts of the remaining program
-            // that were substituted, post-redex
-            paths[0].push('body[0]')
-            const allPaths = paths.concat(subst[1])
-            if (subst[1].length === 0) {
-              allPaths.push([])
-            }
-            return [subst[0], context, allPaths, explain(node)]
+            const wholeBlock = body.concat(...(otherStatements as es.Statement[]))
+            return [ast.blockExpression(wholeBlock), cont, path, str]
           } else {
-            paths[0].push('body[0]')
-            paths[0].push('declarations[0]')
-            paths[0].push('init')
-            const [reducedRhs, cont, path, str] = reduce(rhs, context, paths)
             return [
-              ast.blockExpression([
-                ast.declaration(
-                  declarator.id.name,
-                  'const',
-                  reducedRhs as es.Expression
-                ) as es.Statement,
-                ...(otherStatements as es.Statement[])
-              ]),
+              ast.blockExpression([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
               cont,
               path,
               str
             ]
           }
+        } else if (
+          firstStatement.type === 'ExpressionStatement' &&
+          isIrreducible(firstStatement.expression)
+        ) {
+          let stmt
+          if (otherStatements.length > 0) {
+            paths[0].push('body[0]')
+            paths.push([])
+            stmt = ast.blockExpression(otherStatements as es.Statement[])
+          } else {
+            stmt = ast.identifier('undefined')
+          }
+          return [stmt, context, paths, explain(node)]
+        } else if (firstStatement.type === 'FunctionDeclaration') {
+          let funDecExp = ast.functionDeclarationExpression(
+            firstStatement.id!,
+            firstStatement.params,
+            firstStatement.body
+          ) as FunctionDeclarationExpression
+          // substitute body
+          funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
+            []
+          ])[0] as FunctionDeclarationExpression
+          // substitute the rest of the blockExpression
+          const remainingBlockExpression = ast.blockExpression(otherStatements as es.Statement[])
+          // substitution within the same block, add " same" so that substituter can differentiate between
+          // substitution within the block and substitution from outside the block
+          const newId = ast.identifier(funDecExp.id.name + ' same', funDecExp.id.loc)
+          const subst = substituteMain(newId, funDecExp, remainingBlockExpression, paths)
+          // concats paths such that:
+          // paths[0] -> path to the program to be substituted, pre-redex
+          // paths[1...] -> path(s) to the parts of the remaining program
+          // that were substituted, post-redex
+          paths[0].push('body[0]')
+          const allPaths = paths.concat(subst[1])
+          if (subst[1].length === 0) {
+            allPaths.push([])
+          }
+          return [subst[0], context, allPaths, explain(node)]
+        } else if (firstStatement.type === 'VariableDeclaration') {
+          const { kind, declarations } = firstStatement
+          if (kind !== 'const') {
+            // TODO: cannot use let or var
+            return [dummyBlockExpression(), context, paths, 'cannot use let or var']
+          } else if (
+            declarations.length <= 0 ||
+            declarations.length > 1 ||
+            declarations[0].type !== 'VariableDeclarator' ||
+            !declarations[0].init
+          ) {
+            // TODO: syntax error
+            return [dummyBlockExpression(), context, paths, 'syntax error']
+          } else {
+            const declarator = declarations[0] as es.VariableDeclarator
+            const rhs = declarator.init!
+            if (declarator.id.type !== 'Identifier') {
+              // TODO: source does not allow destructuring
+              return [dummyBlockExpression(), context, paths, 'source does not allow destructuring']
+            } else if (isIrreducible(rhs)) {
+              const remainingBlockExpression = ast.blockExpression(otherStatements as es.Statement[])
+              // forced casting for some weird errors
+              // substitution within the same block, add " same" so that substituter can differentiate between
+              // substitution within the block and substitution from outside the block
+              const newId = ast.identifier(declarator.id.name + ' same', declarator.id.loc)
+              const subst = substituteMain(
+                newId,
+                rhs as es.ArrayExpression,
+                remainingBlockExpression,
+                paths
+              )
+              // concats paths such that:
+              // paths[0] -> path to the program to be substituted, pre-redex
+              // paths[1...] -> path(s) to the parts of the remaining program
+              // that were substituted, post-redex
+              paths[0].push('body[0]')
+              const allPaths = paths.concat(subst[1])
+              if (subst[1].length === 0) {
+                allPaths.push([])
+              }
+              return [subst[0], context, allPaths, explain(node)]
+            } else if (rhs.type === 'ArrowFunctionExpression' || rhs.type === 'FunctionExpression') {
+              let funDecExp = ast.functionDeclarationExpression(
+                declarator.id,
+                rhs.params,
+                rhs.body.type === 'BlockStatement'
+                  ? rhs.body
+                  : ast.blockStatement([ast.returnStatement(rhs.body)])
+              ) as FunctionDeclarationExpression
+              // substitute body
+              funDecExp = substituteMain(funDecExp.id, funDecExp, funDecExp, [
+                []
+              ])[0] as FunctionDeclarationExpression
+              // substitute the rest of the blockExpression
+              const remainingBlockExpression = ast.blockExpression(otherStatements as es.Statement[])
+              // substitution within the same block, add " same" so that substituter can differentiate between
+              // substitution within the block and substitution from outside the block
+              const newId = ast.identifier(funDecExp.id.name + ' same', funDecExp.id.loc)
+              const subst = substituteMain(newId, funDecExp, remainingBlockExpression, paths)
+              // concats paths such that:
+              // paths[0] -> path to the program to be substituted, pre-redex
+              // paths[1...] -> path(s) to the parts of the remaining program
+              // that were substituted, post-redex
+              paths[0].push('body[0]')
+              const allPaths = paths.concat(subst[1])
+              if (subst[1].length === 0) {
+                allPaths.push([])
+              }
+              return [subst[0], context, allPaths, explain(node)]
+            } else {
+              paths[0].push('body[0]')
+              paths[0].push('declarations[0]')
+              paths[0].push('init')
+              const [reducedRhs, cont, path, str] = reduce(rhs, context, paths)
+              return [
+                ast.blockExpression([
+                  ast.declaration(
+                    declarator.id.name,
+                    'const',
+                    reducedRhs as es.Expression
+                  ) as es.Statement,
+                  ...(otherStatements as es.Statement[])
+                ]),
+                cont,
+                path,
+                str
+              ]
+            }
+          }
         }
+        paths[0].push('body[0]')
+        const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
+        return [
+          ast.blockExpression([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
+          cont,
+          path,
+          str
+        ]
       }
-      paths[0].push('body[0]')
-      const [reduced, cont, path, str] = reduce(firstStatement, context, paths)
-      return [
-        ast.blockExpression([reduced as es.Statement, ...(otherStatements as es.Statement[])]),
-        cont,
-        path,
-        str
-      ]
     },
 
     // source 1


### PR DESCRIPTION
Fixes #1109

Follows suggested fix by prof Henz; it also turns out that reduction of block expressions is missing the empty block handling that's present in the block statement code, so I copied that over too