### PR TITLE
Enforce auto pre-commit/pre-push formatting and testing via Husky

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,10 @@
     "project": "tsconfig.json",
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint",
+    "simple-import-sort"
+  ],
   "rules": {
     "@typescript-eslint/ban-ts-comment": "warn",
     "@typescript-eslint/ban-types": "off",
@@ -39,6 +42,7 @@
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
     "@typescript-eslint/unbound-method": "off",
-    "prefer-rest-params": "off"
+    "prefer-rest-params": "off",
+    "simple-import-sort/imports": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "acorn-loose": "^8.0.0",
     "acorn-walk": "^8.0.0",
     "astring": "^1.4.3",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "gpu.js": "^2.10.4",
     "lodash": "^4.17.20",
     "node-getopt": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "docs": "yarn jsdoc && yarn autocomplete",
     "build": "yarn docs && yarn tsc",
     "build_sicp_package": "./scripts/build_sicp_package.sh",
-    "publish_sicp_package": "./scripts/publish_sicp_package.sh"
+    "publish_sicp_package": "./scripts/publish_sicp_package.sh",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/environment.ts
+++ b/src/__tests__/environment.ts
@@ -1,4 +1,5 @@
 import { Program } from 'estree'
+
 import { evaluate } from '../interpreter/interpreter'
 import { mockContext } from '../mocks/context'
 import { parse } from '../parser/parser'

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,3 +1,7 @@
+import { Position } from 'acorn/dist/acorn'
+import { SourceLocation } from 'estree'
+
+import { findDeclaration, getScope } from '../index'
 import { Value } from '../types'
 import { stripIndent } from '../utils/formatters'
 import {
@@ -9,9 +13,6 @@ import {
   expectToLooselyMatchJS,
   expectToMatchJS
 } from '../utils/testing'
-import { findDeclaration, getScope } from '../index'
-import { Position } from 'acorn/dist/acorn'
-import { SourceLocation } from 'estree'
 
 const toString = (x: Value) => '' + x
 

--- a/src/__tests__/mode.ts
+++ b/src/__tests__/mode.ts
@@ -1,5 +1,6 @@
 import * as ace from 'ace-builds'
 import DefaultMode from 'ace-builds/src-noconflict/mode-javascript'
+
 import { HighlightRulesSelector, ModeSelector } from '../editors/ace/modes/source'
 import { Variant } from '../types'
 

--- a/src/__tests__/non-det-interpreter.ts
+++ b/src/__tests__/non-det-interpreter.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:max-line-length */
-import { runInContext, resume, IOptions, Result, parseError } from '../index'
+import { IOptions, parseError, Result, resume, runInContext } from '../index'
 import { mockContext } from '../mocks/context'
-import { SuspendedNonDet, Finished, Context } from '../types'
+import { Context, Finished, SuspendedNonDet } from '../types'
 
 test('Empty code returns undefined', async () => {
   await testDeterministicCode('', undefined)

--- a/src/__tests__/scope-refactoring.ts
+++ b/src/__tests__/scope-refactoring.ts
@@ -1,16 +1,17 @@
 import { Program } from 'estree'
+
 import { default as createContext } from '../createContext'
 import { getAllOccurrencesInScope } from '../index'
-import { BlockFrame } from '../types'
-import {
-  scopeVariables,
-  getBlockFromLoc,
-  getAllIdentifiers,
-  getNodeLocsInCurrentBlockFrame,
-  getBlockFramesInCurrentBlockFrame,
-  getScopeHelper
-} from '../scope-refactoring'
 import { looseParse } from '../parser/parser'
+import {
+  getAllIdentifiers,
+  getBlockFramesInCurrentBlockFrame,
+  getBlockFromLoc,
+  getNodeLocsInCurrentBlockFrame,
+  getScopeHelper,
+  scopeVariables
+} from '../scope-refactoring'
+import { BlockFrame } from '../types'
 /* tslint:disable:max-classes-per-file */
 
 class Target {

--- a/src/__tests__/stringify-benchmark.ts
+++ b/src/__tests__/stringify-benchmark.ts
@@ -1,7 +1,7 @@
-import { stripIndent } from '../utils/formatters'
-import { testSuccess } from '../utils/testing'
 import * as list from '../stdlib/list'
+import { stripIndent } from '../utils/formatters'
 import { stringify } from '../utils/stringify'
+import { testSuccess } from '../utils/testing'
 
 test('stringify is fast', () => {
   return expect(

--- a/src/__tests__/stringify.ts
+++ b/src/__tests__/stringify.ts
@@ -2,8 +2,8 @@ import { stripIndent } from '../utils/formatters'
 import {
   lineTreeToString,
   stringDagToLineTree,
-  valueToStringDag,
-  stringify
+  stringify,
+  valueToStringDag
 } from '../utils/stringify'
 import { expectResult } from '../utils/testing'
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 import { Options } from 'acorn'
 import * as es from 'estree'
+
 import { SourceLanguage } from './types'
 
 export const CUT = 'cut' // cut operator for Source 4.3

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -1,22 +1,22 @@
 // Variable determining chapter of Source is contained in this file.
 
 import { GLOBAL, JSSLANG_PROPERTIES } from './constants'
+import * as gpu_lib from './gpu/lib'
 import { AsyncScheduler } from './schedulers'
+import { lazyListPrelude } from './stdlib/lazyList.prelude'
 import * as list from './stdlib/list'
 import { list_to_vector } from './stdlib/list'
 import { listPrelude } from './stdlib/list.prelude'
-import { nonDetPrelude } from './stdlib/non-det.prelude'
 import * as misc from './stdlib/misc'
+import { nonDetPrelude } from './stdlib/non-det.prelude'
 import * as parser from './stdlib/parser'
 import * as stream from './stdlib/stream'
 import { streamPrelude } from './stdlib/stream.prelude'
-import { Context, CustomBuiltIns, Environment, NativeStorage, Value, Variant } from './types'
-import * as operators from './utils/operators'
-import * as gpu_lib from './gpu/lib'
-import { stringify } from './utils/stringify'
-import { lazyListPrelude } from './stdlib/lazyList.prelude'
 import { createTypeEnvironment, tForAll, tVar } from './typeChecker/typeChecker'
+import { Context, CustomBuiltIns, Environment, NativeStorage, Value, Variant } from './types'
 import { makeWrapper } from './utils/makeWrapper'
+import * as operators from './utils/operators'
+import { stringify } from './utils/stringify'
 
 export class LazyBuiltIn {
   func: (...arg0: any) => any

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -2,6 +2,7 @@
 /* tslint:disable:max-line-length */
 import { baseGenerator, generate } from 'astring'
 import * as es from 'estree'
+
 import { ErrorSeverity, ErrorType, SourceError, Value } from '../types'
 import { stringify } from '../utils/stringify'
 import { RuntimeSourceError } from './runtimeSourceError'

--- a/src/errors/moduleErrors.ts
+++ b/src/errors/moduleErrors.ts
@@ -1,5 +1,6 @@
 /* tslint:disable: max-classes-per-file */
 import * as es from 'estree'
+
 import { RuntimeSourceError } from './runtimeSourceError'
 
 export class ModuleConnectionError extends RuntimeSourceError {

--- a/src/errors/runtimeSourceError.ts
+++ b/src/errors/runtimeSourceError.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { UNKNOWN_LOCATION } from '../constants'
 import { ErrorSeverity, ErrorType, SourceError } from '../types'
 

--- a/src/errors/timeoutErrors.ts
+++ b/src/errors/timeoutErrors.ts
@@ -1,10 +1,10 @@
 /* tslint:disable:max-classes-per-file */
 import * as es from 'estree'
-import { JSSLANG_PROPERTIES } from '../constants'
-import { stringify } from '../utils/stringify'
 
+import { JSSLANG_PROPERTIES } from '../constants'
 import { ErrorSeverity, ErrorType } from '../types'
 import { stripIndent } from '../utils/formatters'
+import { stringify } from '../utils/stringify'
 import { RuntimeSourceError } from './runtimeSourceError'
 
 function getWarningMessage(maxExecTime: number) {

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -1,8 +1,9 @@
+import { generate } from 'astring'
 import * as es from 'estree'
-import { ErrorSeverity, ErrorType, SourceError, SArray, Type, TypeAnnotatedNode } from '../types'
+
+import { ErrorSeverity, ErrorType, SArray, SourceError, Type, TypeAnnotatedNode } from '../types'
 import { simplify, stripIndent } from '../utils/formatters'
 import { typeToString } from '../utils/stringify'
-import { generate } from 'astring'
 
 // tslint:disable:max-classes-per-file
 

--- a/src/errors/validityErrors.ts
+++ b/src/errors/validityErrors.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { ErrorSeverity, ErrorType, SourceError } from '../types'
 
 export class NoAssignmentToForVariable implements SourceError {

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -1,12 +1,4 @@
 import {
-  ancestor,
-  findNodeAt,
-  recursive,
-  WalkerCallback,
-  base,
-  FullWalkerCallback
-} from './utils/walkers'
-import {
   ArrowFunctionExpression,
   BlockStatement,
   ForStatement,
@@ -17,7 +9,16 @@ import {
   SourceLocation,
   VariableDeclarator
 } from 'estree'
+
 import { Context } from './types'
+import {
+  ancestor,
+  base,
+  findNodeAt,
+  FullWalkerCallback,
+  recursive,
+  WalkerCallback
+} from './utils/walkers'
 
 // Finds the innermost node that matches the given location
 export function findIdentifierNode(

--- a/src/gpu/__tests__/noTranspile.ts
+++ b/src/gpu/__tests__/noTranspile.ts
@@ -1,8 +1,9 @@
 import { generate } from 'astring'
+
+import { transpileToGPU } from '../../gpu/gpu'
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
 import { stripIndent } from '../../utils/formatters'
-import { transpileToGPU } from '../../gpu/gpu'
 
 test('empty for loop does not get transpiled', () => {
   const code = stripIndent`

--- a/src/gpu/__tests__/runtimeError.ts
+++ b/src/gpu/__tests__/runtimeError.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:only-arrow-functions */
-import { __createKernel } from '../lib'
 import { TypeError } from '../../utils/rttc'
+import { __createKernel } from '../lib'
 
 test('__createKernel with uninitialized array throws error', () => {
   const bounds = [5, 4]

--- a/src/gpu/__tests__/transpile.ts
+++ b/src/gpu/__tests__/transpile.ts
@@ -1,8 +1,9 @@
 import { generate } from 'astring'
+
+import { transpileToGPU } from '../../gpu/gpu'
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
 import { stripIndent } from '../../utils/formatters'
-import { transpileToGPU } from '../../gpu/gpu'
 
 test('simple for loop gets transpiled correctly', () => {
   const code = stripIndent`

--- a/src/gpu/gpu.ts
+++ b/src/gpu/gpu.ts
@@ -1,7 +1,8 @@
-import GPUTransformer from './transfomer'
-import * as create from '../utils/astCreator'
 import * as es from 'estree'
+
+import * as create from '../utils/astCreator'
 import { getIdentifiersInProgram } from '../utils/uniqueIds'
+import GPUTransformer from './transfomer'
 
 // top-level gpu functions that call our code
 

--- a/src/gpu/lib.ts
+++ b/src/gpu/lib.ts
@@ -1,10 +1,11 @@
-import { GPU } from 'gpu.js'
-import { TypeError } from '../utils/rttc'
 import { parse } from 'acorn'
 import { generate } from 'astring'
 import * as es from 'estree'
-import { gpuRuntimeTranspile } from './transfomer'
+import { GPU } from 'gpu.js'
+
 import { ACORN_PARSE_OPTIONS } from '../constants'
+import { TypeError } from '../utils/rttc'
+import { gpuRuntimeTranspile } from './transfomer'
 
 // Heuristic : Only use GPU if array is bigger than this
 const MAX_SIZE = 200

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -1,8 +1,9 @@
 import * as es from 'estree'
-import { ancestor, simple, make } from '../utils/walkers'
+
 import * as create from '../utils/astCreator'
-import GPULoopVerifier from './verification/loopVerifier'
+import { ancestor, make, simple } from '../utils/walkers'
 import GPUBodyVerifier from './verification/bodyVerifier'
+import GPULoopVerifier from './verification/loopVerifier'
 
 let currentKernelId = 0
 /*

--- a/src/gpu/verification/bodyVerifier.ts
+++ b/src/gpu/verification/bodyVerifier.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
-import { simple, make } from '../../utils/walkers'
+
+import { make, simple } from '../../utils/walkers'
 
 /*
  * GPU Body verifier helps to ensure the body is parallelizable

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { simple, findNodeAt } from './utils/walkers'
 import { DebuggerStatement, Literal, Program, SourceLocation } from 'estree'
 import { RawSourceMap, SourceMapConsumer } from 'source-map'
+
 import { JSSLANG_PROPERTIES, UNKNOWN_LOCATION } from './constants'
 import createContext from './createContext'
 import {
@@ -11,22 +11,23 @@ import {
 } from './errors/errors'
 import { RuntimeSourceError } from './errors/runtimeSourceError'
 import { findDeclarationNode, findIdentifierNode } from './finder'
+import { transpileToGPU } from './gpu/gpu'
 import { evaluate } from './interpreter/interpreter'
-import { parse, looseParse, typedParse, parseAt, parseForNames } from './parser/parser'
-import { AsyncScheduler, PreemptiveScheduler, NonDetScheduler } from './schedulers'
+import { nonDetEvaluate } from './interpreter/interpreter-non-det'
+import { transpileToLazy } from './lazy/lazy'
+import { looseParse, parse, parseAt, parseForNames, typedParse } from './parser/parser'
+import { AsyncScheduler, NonDetScheduler, PreemptiveScheduler } from './schedulers'
 import { getAllOccurrencesInScopeHelper, getScopeHelper } from './scope-refactoring'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
 import {
   callee,
-  redexify,
   getEvaluationSteps,
+  getRedex,
   IStepperPropContents,
-  getRedex
+  redexify
 } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
 import { transpile } from './transpiler/transpiler'
-import { transpileToGPU } from './gpu/gpu'
-import { transpileToLazy } from './lazy/lazy'
 import {
   Context,
   Error as ResultError,
@@ -35,27 +36,28 @@ import {
   Result,
   Scheduler,
   SourceError,
-  Variant,
-  TypeAnnotatedNode,
   SVMProgram,
-  TypeAnnotatedFuncDecl
+  TypeAnnotatedFuncDecl,
+  TypeAnnotatedNode,
+  Variant
 } from './types'
-import { nonDetEvaluate } from './interpreter/interpreter-non-det'
 import { locationDummyNode } from './utils/astCreator'
+import { findNodeAt, simple } from './utils/walkers'
 import { validateAndAnnotate } from './validator/validator'
-import { compileForConcurrent, compileToIns } from './vm/svml-compiler'
 import { assemble } from './vm/svml-assembler'
+import { compileForConcurrent, compileToIns } from './vm/svml-compiler'
 import { runWithProgram } from './vm/svml-machine'
 export { SourceDocumentation } from './editors/ace/docTooltip'
-import { getProgramNames, getKeywords } from './name-extractor'
 import * as es from 'estree'
-import { typeCheck } from './typeChecker/typeChecker'
-import { typeToString } from './utils/stringify'
-import { forceIt } from './utils/operators'
+
 import { TimeoutError } from './errors/timeoutErrors'
-import { loadModuleTabs } from './modules/moduleLoader'
-import { testForInfiniteLoop } from './infiniteLoops/runtime'
 import { isPotentialInfiniteLoop } from './infiniteLoops/errors'
+import { testForInfiniteLoop } from './infiniteLoops/runtime'
+import { loadModuleTabs } from './modules/moduleLoader'
+import { getKeywords, getProgramNames } from './name-extractor'
+import { typeCheck } from './typeChecker/typeChecker'
+import { forceIt } from './utils/operators'
+import { typeToString } from './utils/stringify'
 
 export interface IOptions {
   scheduler: 'preemptive' | 'async'

--- a/src/infiniteLoops/__tests__/instrument.ts
+++ b/src/infiniteLoops/__tests__/instrument.ts
@@ -1,12 +1,13 @@
-import { evaluateBinaryExpression, evaluateUnaryExpression } from '../../utils/operators'
-import {
-  instrument,
-  InfiniteLoopRuntimeFunctions as functionNames,
-  InfiniteLoopRuntimeObjectNames
-} from '../instrument'
+import { Program } from 'estree'
+
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
-import { Program } from 'estree'
+import { evaluateBinaryExpression, evaluateUnaryExpression } from '../../utils/operators'
+import {
+  InfiniteLoopRuntimeFunctions as functionNames,
+  InfiniteLoopRuntimeObjectNames,
+  instrument
+} from '../instrument'
 
 function mockFunctionsAndState() {
   const theState = undefined

--- a/src/infiniteLoops/__tests__/runtime.ts
+++ b/src/infiniteLoops/__tests__/runtime.ts
@@ -1,7 +1,7 @@
-import { testForInfiniteLoop } from '../runtime'
-import { getInfiniteLoopData, InfiniteLoopError, InfiniteLoopErrorType } from '../errors'
-import { mockContext } from '../../mocks/context'
 import { runInContext } from '../..'
+import { mockContext } from '../../mocks/context'
+import { getInfiniteLoopData, InfiniteLoopError, InfiniteLoopErrorType } from '../errors'
+import { testForInfiniteLoop } from '../runtime'
 
 test('works in runInContext when throwInfiniteLoops is true', async () => {
   const code = `function fib(x) {

--- a/src/infiniteLoops/detect.ts
+++ b/src/infiniteLoops/detect.ts
@@ -1,9 +1,10 @@
-import { getOriginalName } from './instrument'
 import { generate } from 'astring'
-import * as st from './state'
-import { simple } from '../utils/walkers'
 import * as es from 'estree'
+
+import { simple } from '../utils/walkers'
 import { InfiniteLoopError, InfiniteLoopErrorType } from './errors'
+import { getOriginalName } from './instrument'
+import * as st from './state'
 import { shallowConcretize } from './symbolic'
 
 const runAltErgo: any = require('@joeychenofficial/alt-ergo-modified')

--- a/src/infiniteLoops/instrument.ts
+++ b/src/infiniteLoops/instrument.ts
@@ -1,10 +1,11 @@
-import * as es from 'estree'
 import { generate } from 'astring'
-import * as create from '../utils/astCreator'
-import { simple, recursive, WalkerCallback } from '../utils/walkers'
-import { transformSingleImportDeclaration } from '../transpiler/transpiler'
+import * as es from 'estree'
+
 import { MODULE_PARAMS_ID } from '../constants'
 import { memoizedGetModuleFile } from '../modules/moduleLoader'
+import { transformSingleImportDeclaration } from '../transpiler/transpiler'
+import * as create from '../utils/astCreator'
+import { recursive, simple, WalkerCallback } from '../utils/walkers'
 // transforms AST of program
 
 const globalIds = {

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -1,18 +1,19 @@
-import * as sym from './symbolic'
-import * as create from '../utils/astCreator'
-import * as st from './state'
 import * as es from 'estree'
+
+import { MODULE_PARAMS_ID } from '../constants'
+import { createContext } from '../index'
+import { parse } from '../parser/parser'
 import * as stdList from '../stdlib/list'
+import * as create from '../utils/astCreator'
 import { checkForInfiniteLoop } from './detect'
 import { InfiniteLoopError } from './errors'
 import {
-  instrument,
   InfiniteLoopRuntimeFunctions as FunctionNames,
-  InfiniteLoopRuntimeObjectNames
+  InfiniteLoopRuntimeObjectNames,
+  instrument
 } from './instrument'
-import { parse } from '../parser/parser'
-import { createContext } from '../index'
-import { MODULE_PARAMS_ID } from '../constants'
+import * as st from './state'
+import * as sym from './symbolic'
 
 function checkTimeout(state: st.State) {
   if (state.hasTimedOut()) {

--- a/src/infiniteLoops/state.ts
+++ b/src/infiniteLoops/state.ts
@@ -1,7 +1,8 @@
-import * as sym from './symbolic'
 import { generate } from 'astring'
 import * as es from 'estree'
+
 import { identifier } from '../utils/astCreator'
+import * as sym from './symbolic'
 
 // Object + functions called during runtime to check for infinite loops
 

--- a/src/infiniteLoops/symbolic.ts
+++ b/src/infiniteLoops/symbolic.ts
@@ -1,5 +1,6 @@
-import * as create from '../utils/astCreator'
 import * as es from 'estree'
+
+import * as create from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 
 // data structure for symbolic + hybrid values

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -1,15 +1,16 @@
 /* tslint:disable:max-classes-per-file */
 import * as es from 'estree'
+import { cloneDeep, uniqueId } from 'lodash'
+
 import * as constants from '../constants'
+import { CUT } from '../constants'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { Context, Environment, Frame, Value } from '../types'
-import { primitive, conditionalExpression, literal } from '../utils/astCreator'
+import { conditionalExpression, literal, primitive } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
 import Closure from './closure'
-import { cloneDeep, uniqueId } from 'lodash'
-import { CUT } from '../constants'
 
 class BreakValue {}
 

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,17 +1,18 @@
 /* tslint:disable:max-classes-per-file */
 import * as es from 'estree'
+import { isEmpty, uniqueId } from 'lodash'
+
 import * as constants from '../constants'
+import { LazyBuiltIn } from '../createContext'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
+import { loadModuleBundle } from '../modules/moduleLoader'
 import { checkEditorBreakpoints } from '../stdlib/inspector'
 import { Context, ContiguousArrayElements, Environment, Frame, Value } from '../types'
 import { conditionalExpression, literal, primitive } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
 import Closure from './closure'
-import { LazyBuiltIn } from '../createContext'
-import { loadModuleBundle } from '../modules/moduleLoader'
-import { uniqueId, isEmpty } from 'lodash'
 
 class BreakValue {}
 

--- a/src/lazy/lazy.ts
+++ b/src/lazy/lazy.ts
@@ -1,7 +1,8 @@
-import { simple } from '../utils/walkers'
-import * as create from '../utils/astCreator'
 import * as es from 'estree'
+
+import * as create from '../utils/astCreator'
 import { getIdentifiersInProgram } from '../utils/uniqueIds'
+import { simple } from '../utils/walkers'
 
 const lazyPrimitives = new Set(['makeLazyFunction', 'wrapLazyCallee', 'forceIt', 'delayIt'])
 

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -1,6 +1,6 @@
-import * as moduleLoader from '../moduleLoader'
-import { ModuleInternalError, ModuleConnectionError } from '../../errors/moduleErrors'
 import { createEmptyContext } from '../../createContext'
+import { ModuleConnectionError, ModuleInternalError } from '../../errors/moduleErrors'
+import * as moduleLoader from '../moduleLoader'
 
 // Mock memoize function from lodash
 jest.mock('lodash', () => ({ memoize: jest.fn(func => func) }))

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -1,13 +1,14 @@
 import es from 'estree'
 import { memoize } from 'lodash'
 import { XMLHttpRequest as NodeXMLHttpRequest } from 'xmlhttprequest-ts'
-import {
-  ModuleNotFoundError,
-  ModuleInternalError,
-  ModuleConnectionError
-} from '../errors/moduleErrors'
-import { Modules, ModuleBundle, ModuleFunctions } from './moduleTypes'
+
 import { Context } from '..'
+import {
+  ModuleConnectionError,
+  ModuleInternalError,
+  ModuleNotFoundError
+} from '../errors/moduleErrors'
+import { ModuleBundle, ModuleFunctions, Modules } from './moduleTypes'
 
 // Supports both JSDom (Web Browser) environment and Node environment
 export const newHttpRequest = () =>

--- a/src/name-extractor/__tests__/autocomplete.ts
+++ b/src/name-extractor/__tests__/autocomplete.ts
@@ -1,7 +1,7 @@
 // import { parse } from '../../parser/parser'
+import { createContext } from '../..'
 import { getNames } from '../../index'
 import { NameDeclaration } from '../index'
-import { createContext } from '../..'
 
 test('Test empty program does not generate names', async () => {
   const code: string = 'f'

--- a/src/name-extractor/index.ts
+++ b/src/name-extractor/index.ts
@@ -1,6 +1,7 @@
 import * as es from 'estree'
-import { findIdentifierNode, findAncestors } from '../finder'
+
 import { Context } from '../'
+import { findAncestors, findIdentifierNode } from '../finder'
 import syntaxBlacklist from '../parser/syntaxBlacklist'
 
 export interface NameDeclaration {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -2,19 +2,20 @@
 import {
   Options as AcornOptions,
   parse as acornParse,
-  tokenizer as acornTokenizer,
   parseExpressionAt as acornParseAt,
-  Position
+  Position,
+  tokenizer as acornTokenizer
 } from 'acorn'
 import { parse as acornLooseParse } from 'acorn-loose'
-import { ancestor, AncestorWalkerFn } from '../utils/walkers'
 import * as es from 'estree'
+
 import { ACORN_PARSE_OPTIONS } from '../constants'
 import { Context, ErrorSeverity, ErrorType, Rule, SourceError } from '../types'
 import { stripIndent } from '../utils/formatters'
+import { ancestor, AncestorWalkerFn } from '../utils/walkers'
+import { validateAndAnnotate } from '../validator/validator'
 import rules from './rules'
 import syntaxBlacklist from './syntaxBlacklist'
-import { validateAndAnnotate } from '../validator/validator'
 
 export class DisallowedConstructError implements SourceError {
   public type = ErrorType.SYNTAX

--- a/src/parser/rules/index.ts
+++ b/src/parser/rules/index.ts
@@ -1,7 +1,6 @@
 import * as es from 'estree'
 
 import { Rule } from '../../types'
-
 import bracesAroundFor from './bracesAroundFor'
 import bracesAroundIfElse from './bracesAroundIfElse'
 import bracesAroundWhile from './bracesAroundWhile'
@@ -14,13 +13,13 @@ import noIfWithoutElse from './noIfWithoutElse'
 import noImplicitDeclareUndefined from './noImplicitDeclareUndefined'
 import noImplicitReturnUndefined from './noImplicitReturnUndefined'
 import noNull from './noNull'
+import noSpreadInArray from './noSpreadInArray'
+import noTemplateExpression from './noTemplateExpression'
 import noUnspecifiedLiteral from './noUnspecifiedLiteral'
 import noUnspecifiedOperator from './noUnspecifiedOperator'
 import noUpdateAssignment from './noUpdateAssignment'
 import noVar from './noVar'
 import singleVariableDeclaration from './singleVariableDeclaration'
-import noTemplateExpression from './noTemplateExpression'
-import noSpreadInArray from './noSpreadInArray'
 
 const rules: Rule<es.Node>[] = [
   bracesAroundFor,

--- a/src/repl/repl-non-det.ts
+++ b/src/repl/repl-non-det.ts
@@ -1,10 +1,11 @@
 import fs = require('fs')
 import repl = require('repl') // 'repl' here refers to the module named 'repl' in index.d.ts
-import { createContext, IOptions, parseError, runInContext, resume, Result } from '../index'
-import { SuspendedNonDet, Context } from '../types'
-import { CUT, TRY_AGAIN } from '../constants'
 import { inspect } from 'util'
+
+import { CUT, TRY_AGAIN } from '../constants'
+import { createContext, IOptions, parseError, Result, resume, runInContext } from '../index'
 import Closure from '../interpreter/closure'
+import { Context, SuspendedNonDet } from '../types'
 
 const NO_MORE_VALUES_MESSAGE: string = 'There are no more values of: '
 let previousInput: string | undefined // stores the input which is then shown when there are no more values for the program

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { start } from 'repl' // 'repl' here refers to the module named 'repl' in index.d.ts
 import { inspect } from 'util'
-import { createContext, IOptions, parseError, runInContext } from '../index'
-import { Variant, ExecutionMethod } from '../types'
-import Closure from '../interpreter/closure'
+
 import { sourceLanguages } from '../constants'
+import { createContext, IOptions, parseError, runInContext } from '../index'
+import Closure from '../interpreter/closure'
+import { ExecutionMethod, Variant } from '../types'
 
 function startRepl(
   chapter = 1,

--- a/src/repl/transpiler.ts
+++ b/src/repl/transpiler.ts
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
-import { createContext, parseError } from '../index'
-import { Variant } from '../types'
+import { generate } from 'astring'
+import { Program } from 'estree'
+
 import { sourceLanguages } from '../constants'
+import { transpileToGPU } from '../gpu/gpu'
+import { createContext, parseError } from '../index'
+import { transpileToLazy } from '../lazy/lazy'
 import { parse } from '../parser/parser'
 import { transpile } from '../transpiler/transpiler'
-import { transpileToGPU } from '../gpu/gpu'
-import { transpileToLazy } from '../lazy/lazy'
+import { Variant } from '../types'
 import { validateAndAnnotate } from '../validator/validator'
-import { Program } from 'estree'
-import { generate } from 'astring'
 
 function transpileCode(chapter = 1, variant: Variant = 'default', code = '', pretranspile = false) {
   // use defaults for everything

--- a/src/scope-refactoring.ts
+++ b/src/scope-refactoring.ts
@@ -1,7 +1,8 @@
-import { simple } from './utils/walkers'
 import * as es from 'estree'
+
 import { isInLoc } from './finder'
 import { BlockFrame, DefinitionNode } from './types'
+import { simple } from './utils/walkers'
 
 /**
  * This file parses the original AST Tree into another tree with a similar structure

--- a/src/sicp-prepare.ts
+++ b/src/sicp-prepare.ts
@@ -1,7 +1,8 @@
-import { default as createContext } from './createContext'
-import * as fs from 'fs'
-import { Program, FunctionDeclaration } from 'estree'
 import { parse } from 'acorn'
+import { FunctionDeclaration, Program } from 'estree'
+import * as fs from 'fs'
+
+import { default as createContext } from './createContext'
 
 const context = createContext(4)
 

--- a/src/stdlib/inspector.ts
+++ b/src/stdlib/inspector.ts
@@ -1,4 +1,5 @@
 import { Node } from 'estree'
+
 import { Context, Result } from '..'
 import { Scheduler, Value } from '../types'
 

--- a/src/stdlib/list.ts
+++ b/src/stdlib/list.ts
@@ -1,5 +1,5 @@
-import { stringify, ArrayLike } from '../utils/stringify'
 import { Value } from '../types'
+import { ArrayLike, stringify } from '../utils/stringify'
 
 // list.ts: Supporting lists in the Scheme style, using pairs made
 //          up of two-element JavaScript array (vector)

--- a/src/stdlib/stream.ts
+++ b/src/stdlib/stream.ts
@@ -1,7 +1,7 @@
 // stream_tail returns the second component of the given pair
 // throws an exception if the argument is not a pair
 
-import { head, is_null, is_pair, List, list, pair, Pair, tail } from './list'
+import { head, is_null, is_pair, List, list, Pair, pair, tail } from './list'
 
 type Stream = null | Pair<any, () => Stream>
 

--- a/src/stdlib/vm.prelude.ts
+++ b/src/stdlib/vm.prelude.ts
@@ -1,5 +1,5 @@
-import { SVMFunction, Program } from '../vm/svml-compiler'
 import OpCodes from '../vm/opcodes'
+import { Program, SVMFunction } from '../vm/svml-compiler'
 import { char_at, get_time, parse_int } from './misc'
 
 // functions should be sorted in alphabetical order. Refer to SVML spec on wiki

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -1,9 +1,9 @@
+import * as es from 'estree'
+
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
 import { substituterNodes } from '../../types'
 import { codify, getEvaluationSteps } from '../stepper'
-
-import * as es from 'estree'
 
 function getLastStepAsString(steps: [substituterNodes, string[][], string][]): string {
   return codify(steps[steps.length - 1][0]).trim()

--- a/src/stepper/converter.ts
+++ b/src/stepper/converter.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { mockContext } from '../mocks/context'
 import { parse } from '../parser/parser'
 import { Context, substituterNodes } from '../types'

--- a/src/stepper/lib.ts
+++ b/src/stepper/lib.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import * as misc from '../stdlib/misc'
 import { substituterNodes } from '../types'
 import * as ast from '../utils/astCreator'

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1,5 +1,6 @@
 import { generate } from 'astring'
 import * as es from 'estree'
+
 import * as errors from '../errors/errors'
 import { parse } from '../parser/parser'
 import {

--- a/src/stepper/util.ts
+++ b/src/stepper/util.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { BlockExpression, substituterNodes } from '../types'
 import * as builtin from './lib'
 

--- a/src/transpiler/__tests__/modules.ts
+++ b/src/transpiler/__tests__/modules.ts
@@ -1,12 +1,13 @@
+import { Identifier, ImportDeclaration } from 'estree'
+
+import { mockContext } from '../../mocks/context'
+import { parse } from '../../parser/parser'
+import { stripIndent } from '../../utils/formatters'
 import {
-  transformSingleImportDeclaration,
   transformImportDeclarations,
+  transformSingleImportDeclaration,
   transpile
 } from '../transpiler'
-import { stripIndent } from '../../utils/formatters'
-import { parse } from '../../parser/parser'
-import { mockContext } from '../../mocks/context'
-import { ImportDeclaration, Identifier } from 'estree'
 
 jest.mock('../../modules/moduleLoader', () => ({
   ...jest.requireActual('../../modules/moduleLoader'),

--- a/src/transpiler/evalContainer.ts
+++ b/src/transpiler/evalContainer.ts
@@ -1,5 +1,5 @@
+import { MODULE_PARAMS_ID, NATIVE_STORAGE_ID } from '../constants'
 import { NativeStorage } from '../types'
-import { NATIVE_STORAGE_ID, MODULE_PARAMS_ID } from '../constants'
 
 type Evaler = (code: string, nativeStorage: NativeStorage, moduleParams: any) => any
 

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -1,17 +1,18 @@
-import { ancestor, simple } from '../utils/walkers'
 import { generate } from 'astring'
 import * as es from 'estree'
 import { SourceMapGenerator } from 'source-map'
-import { AllowedDeclarations, Context, NativeStorage } from '../types'
+
+import { MODULE_PARAMS_ID, NATIVE_STORAGE_ID } from '../constants'
 import { UndefinedVariable } from '../errors/errors'
 import { memoizedGetModuleFile } from '../modules/moduleLoader'
+import { AllowedDeclarations, Context, NativeStorage } from '../types'
 import * as create from '../utils/astCreator'
 import {
-  getUniqueId,
+  getIdentifiersInNativeStorage,
   getIdentifiersInProgram,
-  getIdentifiersInNativeStorage
+  getUniqueId
 } from '../utils/uniqueIds'
-import { NATIVE_STORAGE_ID, MODULE_PARAMS_ID } from '../constants'
+import { ancestor, simple } from '../utils/walkers'
 
 /**
  * This whole transpiler includes many many many many hacks to get stuff working.

--- a/src/typeChecker/__tests__/typeChecker.test.ts
+++ b/src/typeChecker/__tests__/typeChecker.test.ts
@@ -1,12 +1,13 @@
 /* tslint:disable:object-literal-key-quotes no-string-literal */
-import { parse as __parse } from '../../parser/parser'
-import { typeCheck } from '../typeChecker'
-import { mockContext } from '../../mocks/context'
-import { validateAndAnnotate } from '../../validator/validator'
-import { TypeAnnotatedNode, TypeAnnotatedFuncDecl, Context } from '../../types'
-import { typeToString } from '../../utils/stringify'
-import { parseError, runInContext } from '../../index'
 import * as es from 'estree'
+
+import { parseError, runInContext } from '../../index'
+import { mockContext } from '../../mocks/context'
+import { parse as __parse } from '../../parser/parser'
+import { Context, TypeAnnotatedFuncDecl, TypeAnnotatedNode } from '../../types'
+import { typeToString } from '../../utils/stringify'
+import { validateAndAnnotate } from '../../validator/validator'
+import { typeCheck } from '../typeChecker'
 
 function parseAndTypeCheck(code: string, chapterOrContext: number | Context = 1) {
   const context =

--- a/src/typeChecker/internalTypeErrors.ts
+++ b/src/typeChecker/internalTypeErrors.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
-import { Type, TypeAnnotatedNode, SourceError, ErrorType, ErrorSeverity } from '../types'
+
+import { ErrorSeverity, ErrorType, SourceError, Type, TypeAnnotatedNode } from '../types'
 import { typeToString } from '../utils/stringify'
 
 // tslint:disable:max-classes-per-file

--- a/src/typeChecker/typeChecker.ts
+++ b/src/typeChecker/typeChecker.ts
@@ -1,47 +1,48 @@
 import * as es from 'estree'
+
 import {
-  Context,
-  TypeAnnotatedNode,
-  Primitive,
-  Variable,
-  Pair,
-  List,
-  ForAll,
-  SArray,
-  Type,
-  FunctionType,
-  PredicateType,
-  BindableType,
-  TypeAnnotatedFuncDecl,
-  SourceError,
-  AllowedDeclarations,
-  TypeEnvironment,
-  ContiguousArrayElements,
-  PredicateTest
-} from '../types'
-import {
-  TypeError,
-  InternalTypeError,
-  UnifyError,
-  InternalDifferentNumberArgumentsError,
-  InternalCyclicReferenceError
-} from './internalTypeErrors'
-import {
+  ArrayAssignmentError,
+  CallingNonFunctionType,
   ConsequentAlternateMismatchError,
-  InconsistentPredicateTestError,
-  InvalidTestConditionError,
-  DifferentNumberArgumentsError,
-  InvalidArgumentTypesError,
   CyclicReferenceError,
   DifferentAssignmentError,
-  ReassignConstError,
-  ArrayAssignmentError,
+  DifferentNumberArgumentsError,
+  InconsistentPredicateTestError,
+  InvalidArgumentTypesError,
   InvalidArrayIndexType,
-  UndefinedIdentifierError,
-  CallingNonFunctionType
+  InvalidTestConditionError,
+  ReassignConstError,
+  UndefinedIdentifierError
 } from '../errors/typeErrors'
-import { typeToString } from '../utils/stringify'
 import { typedParse } from '../parser/parser'
+import {
+  AllowedDeclarations,
+  BindableType,
+  Context,
+  ContiguousArrayElements,
+  ForAll,
+  FunctionType,
+  List,
+  Pair,
+  PredicateTest,
+  PredicateType,
+  Primitive,
+  SArray,
+  SourceError,
+  Type,
+  TypeAnnotatedFuncDecl,
+  TypeAnnotatedNode,
+  TypeEnvironment,
+  Variable
+} from '../types'
+import { typeToString } from '../utils/stringify'
+import {
+  InternalCyclicReferenceError,
+  InternalDifferentNumberArgumentsError,
+  InternalTypeError,
+  TypeError,
+  UnifyError
+} from './internalTypeErrors'
 
 /** Name of Unary negative builtin operator */
 const NEGATIVE_OP = '-_1'

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@
 
 import { SourceLocation } from 'acorn'
 import * as es from 'estree'
+
 import { EnvTree } from './createContext'
 
 /**

--- a/src/utils/__tests__/rttc.ts
+++ b/src/utils/__tests__/rttc.ts
@@ -1,4 +1,5 @@
 import { BinaryOperator, UnaryOperator } from 'estree'
+
 import { mockClosure, mockRuntimeContext } from '../../mocks/context'
 import { Value } from '../../types'
 import * as rttc from '../rttc'

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { AllowedDeclarations, BlockExpression, FunctionDeclarationExpression } from '../types'
 
 export const getVariableDecarationName = (decl: es.VariableDeclaration) =>

--- a/src/utils/dummyAstCreator.ts
+++ b/src/utils/dummyAstCreator.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { BlockExpression } from '../types'
 
 const DUMMY_STRING = '__DUMMY__'

--- a/src/utils/operators.ts
+++ b/src/utils/operators.ts
@@ -1,4 +1,6 @@
 import { BinaryOperator, UnaryOperator } from 'estree'
+
+import { LazyBuiltIn } from '../createContext'
 import {
   CallingNonFunctionValue,
   ExceptionError,
@@ -10,12 +12,11 @@ import {
   PotentialInfiniteLoopError,
   PotentialInfiniteRecursionError
 } from '../errors/timeoutErrors'
+import { NativeStorage, Thunk } from '../types'
 import { callExpression, locationDummyNode } from './astCreator'
 import * as create from './astCreator'
-import * as rttc from './rttc'
-import { LazyBuiltIn } from '../createContext'
-import { NativeStorage, Thunk } from '../types'
 import { makeWrapper } from './makeWrapper'
+import * as rttc from './rttc'
 
 export function throwIfTimeout(
   nativeStorage: NativeStorage,

--- a/src/utils/rttc.ts
+++ b/src/utils/rttc.ts
@@ -1,4 +1,5 @@
 import * as es from 'estree'
+
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { ErrorSeverity, ErrorType, Value } from '../types'
 

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -1,7 +1,7 @@
 import { MAX_LIST_DISPLAY_LENGTH } from '../constants'
 import Closure from '../interpreter/closure'
+import { Type, Value } from '../types'
 import { forceIt } from './operators'
-import { Value, Type } from '../types'
 
 export interface ArrayLike {
   replPrefix: string

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -1,13 +1,14 @@
+import { generate } from 'astring'
+
 import { default as createContext, defineBuiltin } from '../createContext'
+import { transpileToGPU } from '../gpu/gpu'
 import { parseError, Result, runInContext } from '../index'
+import { transpileToLazy } from '../lazy/lazy'
 import { mockContext } from '../mocks/context'
 import { parse } from '../parser/parser'
 import { transpile } from '../transpiler/transpiler'
-import { transpileToGPU } from '../gpu/gpu'
-import { transpileToLazy } from '../lazy/lazy'
-import { Context, CustomBuiltIns, Variant, SourceError, Value } from '../types'
+import { Context, CustomBuiltIns, SourceError, Value, Variant } from '../types'
 import { stringify } from './stringify'
-import { generate } from 'astring'
 
 export interface TestContext extends Context {
   displayResult: string[]

--- a/src/utils/uniqueIds.ts
+++ b/src/utils/uniqueIds.ts
@@ -1,6 +1,7 @@
-import { simple } from '../utils/walkers'
 import * as es from 'estree'
+
 import { NativeStorage } from '../types'
+import { simple } from '../utils/walkers'
 
 export function getUniqueId(usedIdentifiers: Set<string>, uniqueId = 'unique') {
   while (usedIdentifiers.has(uniqueId)) {

--- a/src/validator/__tests__/validator.ts
+++ b/src/validator/__tests__/validator.ts
@@ -1,11 +1,12 @@
-import { simple } from '../../utils/walkers'
 import * as es from 'estree'
+
 import { mockContext } from '../../mocks/context'
 import { parse } from '../../parser/parser'
 import { TypeAnnotatedNode } from '../../types'
 import { getVariableDecarationName } from '../../utils/astCreator'
 import { stripIndent } from '../../utils/formatters'
 import { expectParsedError } from '../../utils/testing'
+import { simple } from '../../utils/walkers'
 import { validateAndAnnotate } from '../validator'
 
 export function toValidatedAst(code: string) {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,9 +1,10 @@
-import { ancestor, base, FullWalkerCallback } from '../utils/walkers'
 import * as es from 'estree'
+
 import { ConstAssignment } from '../errors/errors'
 import { NoAssignmentToForVariable } from '../errors/validityErrors'
 import { Context, TypeAnnotatedNode } from '../types'
 import { getVariableDecarationName } from '../utils/astCreator'
+import { ancestor, base, FullWalkerCallback } from '../utils/walkers'
 
 class Declaration {
   public accessedBeforeDeclaration: boolean = false

--- a/src/vm/__tests__/svml-machine.ts
+++ b/src/vm/__tests__/svml-machine.ts
@@ -1,12 +1,12 @@
+import { stripIndent } from '../../utils/formatters'
 import {
-  expectParsedError,
   expectDisplayResult,
-  expectVisualiseListResult,
+  expectParsedError,
   expectResult,
+  expectVisualiseListResult,
   getDisplayResult,
   snapshotSuccess
 } from '../../utils/testing'
-import { stripIndent } from '../../utils/formatters'
 
 // concurrent programs return undefined so use display
 // for tests instead

--- a/src/vm/svmc.ts
+++ b/src/vm/svmc.ts
@@ -1,12 +1,12 @@
 import fs = require('fs')
 import util = require('util')
 
-import { parse } from '../parser/parser'
 import { createEmptyContext } from '../createContext'
-import { compileToIns } from './svml-compiler'
-import { assemble } from './svml-assembler'
-import { stringifyProgram } from './util'
+import { parse } from '../parser/parser'
 import { INTERNAL_FUNCTIONS as concurrentInternalFunctions } from '../stdlib/vm.prelude'
+import { assemble } from './svml-assembler'
+import { compileToIns } from './svml-compiler'
+import { stringifyProgram } from './util'
 
 interface CliOptions {
   compileTo: 'debug' | 'json' | 'binary' | 'ast'

--- a/src/vm/svml-assembler.ts
+++ b/src/vm/svml-assembler.ts
@@ -1,6 +1,6 @@
 import Buffer from '../utils/buffer'
-import { Program, SVMFunction, Instruction } from './svml-compiler'
-import OpCodes, { OPCODE_MAX, getInstructionSize } from './opcodes'
+import OpCodes, { getInstructionSize, OPCODE_MAX } from './opcodes'
+import { Instruction, Program, SVMFunction } from './svml-compiler'
 
 const SVM_MAGIC = 0x5005acad
 const MAJOR_VER = 0

--- a/src/vm/svml-compiler.ts
+++ b/src/vm/svml-compiler.ts
@@ -1,16 +1,17 @@
-import { recursive, simple } from '../utils/walkers'
 import * as es from 'estree'
-import * as create from '../utils/astCreator'
-import { UndefinedVariable, ConstAssignment } from '../errors/errors'
+
+import { ConstAssignment, UndefinedVariable } from '../errors/errors'
+import { parse } from '../parser/parser'
 import {
-  vmPrelude,
-  generatePrimitiveFunctionCode,
-  PRIMITIVE_FUNCTION_NAMES,
   CONSTANT_PRIMITIVES,
-  INTERNAL_FUNCTIONS
+  generatePrimitiveFunctionCode,
+  INTERNAL_FUNCTIONS,
+  PRIMITIVE_FUNCTION_NAMES,
+  vmPrelude
 } from '../stdlib/vm.prelude'
 import { Context, ContiguousArrayElements } from '../types'
-import { parse } from '../parser/parser'
+import * as create from '../utils/astCreator'
+import { recursive, simple } from '../utils/walkers'
 import OpCodes from './opcodes'
 
 const VALID_UNARY_OPERATORS = new Map([

--- a/src/vm/svml-machine.ts
+++ b/src/vm/svml-machine.ts
@@ -1,20 +1,20 @@
-import { Program, Instruction, SVMFunction, Address } from './svml-compiler'
-import { ThreadId, RoundRobinScheduler, Scheduler } from './svml-scheduler'
-import { getName } from './util'
-import OpCodes from './opcodes'
+import { JSSLANG_PROPERTIES } from '../constants'
+import { PotentialInfiniteLoopError } from '../errors/timeoutErrors'
 import {
-  NULLARY_PRIMITIVES,
-  UNARY_PRIMITIVES,
   BINARY_PRIMITIVES,
   EXTERNAL_PRIMITIVES,
-  VARARGS_NUM_ARGS,
-  INTERNAL_FUNCTIONS
+  INTERNAL_FUNCTIONS,
+  NULLARY_PRIMITIVES,
+  UNARY_PRIMITIVES,
+  VARARGS_NUM_ARGS
 } from '../stdlib/vm.prelude'
 import { Context } from '../types'
-import { JSSLANG_PROPERTIES } from '../constants'
-import { stringify } from '../utils/stringify'
-import { PotentialInfiniteLoopError } from '../errors/timeoutErrors'
 import { locationDummyNode } from '../utils/astCreator'
+import { stringify } from '../utils/stringify'
+import OpCodes from './opcodes'
+import { Address, Instruction, Program, SVMFunction } from './svml-compiler'
+import { RoundRobinScheduler, Scheduler, ThreadId } from './svml-scheduler'
+import { getName } from './util'
 
 const LDCI_VALUE_OFFSET = 1
 const LDCF32_VALUE_OFFSET = 1

--- a/src/vm/util.ts
+++ b/src/vm/util.ts
@@ -1,5 +1,5 @@
-import { Program } from './svml-compiler'
 import { OpCodes } from './opcodes'
+import { Program } from './svml-compiler'
 
 const OPCODES_STR = {
   [OpCodes.NOP]: 'NOP   ',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2444,6 +2444,11 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
## Description
Husky is already added in #167, but not automatically installed to the working directory. It is a bit annoying to find commits failed the tests with a red cross only due to format issues after pushing to GitHub.

## Change
I added one line to `package.json` under `scripts` and Husky seems to work fine.
https://github.com/source-academy/js-slang/blob/659ecd8d0d2f0f5da4b36a7b77c112089e0333ab/package.json#L53
Also, `eslint-plugin-simple-import-sort` is added as a dependency to enforce import sorting, since this repository's Action warns this.
https://github.com/source-academy/js-slang/blob/659ecd8d0d2f0f5da4b36a7b77c112089e0333ab/.eslintrc.json#L46
This PR also formats all existing code with respect to current rules.