### PR TITLE
Introduction of Modules Context objects

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const TRY_AGAIN = 'retry' // command for Source 4.3
 export const GLOBAL = typeof window === 'undefined' ? global : window
 export const NATIVE_STORAGE_ID = 'nativeStorage'
 export const MODULE_PARAMS_ID = 'moduleParams'
+export const MODULE_STATE_ID = 'moduleContext'
 export const MAX_LIST_DISPLAY_LENGTH = 100
 export const UNKNOWN_LOCATION: es.SourceLocation = {
   start: {

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -13,7 +13,7 @@ import * as parser from './stdlib/parser'
 import * as stream from './stdlib/stream'
 import { streamPrelude } from './stdlib/stream.prelude'
 import { createTypeEnvironment, tForAll, tVar } from './typeChecker/typeChecker'
-import { Context, CustomBuiltIns, Environment, NativeStorage, Value, Variant } from './types'
+import { Context, CustomBuiltIns, Environment, ModuleContext, NativeStorage, Value, Variant } from './types'
 import { makeWrapper } from './utils/makeWrapper'
 import * as operators from './utils/operators'
 import { stringify } from './utils/stringify'
@@ -128,14 +128,18 @@ export const createEmptyContext = <T>(
   variant: Variant = 'default',
   externalSymbols: string[],
   externalContext?: T,
-  moduleParams?: any
+  moduleParams?: Map<string, any>
 ): Context<T> => {
+
+  if (moduleParams == null) {
+    moduleParams = new Map<string, any>();
+  }
+
   return {
     chapter,
     externalSymbols,
     errors: [],
     externalContext,
-    moduleParams,
     runtime: createEmptyRuntime(),
     numberOfOuterEnvironments: 1,
     prelude: null,
@@ -143,6 +147,8 @@ export const createEmptyContext = <T>(
     nativeStorage: createNativeStorage(),
     executionMethod: 'auto',
     variant,
+    moduleParams,
+    moduleContexts: new Map<string, ModuleContext>(),
     unTypecheckedCode: [],
     typeEnvironment: createTypeEnvironment(chapter),
     previousCode: []

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -128,12 +128,8 @@ export const createEmptyContext = <T>(
   variant: Variant = 'default',
   externalSymbols: string[],
   externalContext?: T,
-  moduleParams?: Map<string, any>
+  moduleParams?: any
 ): Context<T> => {
-
-  if (moduleParams == null) {
-    moduleParams = new Map<string, any>();
-  }
 
   return {
     chapter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
   redexify
 } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
-import { transpile } from './transpiler/transpiler'
+import { reduceImportDeclarations, transpile } from './transpiler/transpiler'
 import {
   Context,
   Error as ResultError,
@@ -500,7 +500,9 @@ export async function runInContext(
     let transpiled
     let sourceMapJson: RawSourceMap | undefined
     try {
+      reduceImportDeclarations(program);
       appendModuleTabsToContext(program, context)
+      
       // Mutates program
       switch (context.variant) {
         case 'gpu':

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,12 @@ import {
   redexify
 } from './stepper/stepper'
 import { sandboxedEval } from './transpiler/evalContainer'
-import { reduceImportDeclarations, transpile } from './transpiler/transpiler'
+import { hoistImportDeclarations, transpile } from './transpiler/transpiler'
 import {
   Context,
   Error as ResultError,
   ExecutionMethod,
   Finished,
-  ModuleContext,
   ModuleState,
   Result,
   Scheduler,
@@ -500,7 +499,7 @@ export async function runInContext(
     let transpiled
     let sourceMapJson: RawSourceMap | undefined
     try {
-      reduceImportDeclarations(program);
+      hoistImportDeclarations(program);
       appendModuleTabsToContext(program, context)
       
       // Mutates program
@@ -651,4 +650,4 @@ export function compile(
   }
 }
 
-export { createContext, Context, ModuleContext, ModuleState, Result, setBreakpointAtLine, assemble }
+export { createContext, Context, ModuleState, Result, setBreakpointAtLine, assemble }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   Error as ResultError,
   ExecutionMethod,
   Finished,
+  ModuleContext,
   ModuleState,
   Result,
   Scheduler,
@@ -651,4 +652,4 @@ export function compile(
   }
 }
 
-export { createContext, Context, ModuleState, Result, setBreakpointAtLine, assemble }
+export { createContext, Context, ModuleContext, ModuleState, Result, setBreakpointAtLine, assemble }

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,18 +478,18 @@ export async function runInContext(
       value: redexedSteps
     })
   }
-  
+
   const isNativeRunnable = determineExecutionMethod(theOptions, context, program)
-
-  hoistImportDeclarations(program);
-  appendModuleTabsToContext(program, context)
-
   if (context.prelude !== null) {
     const prelude = context.prelude
     context.prelude = null
     await runInContext(prelude, context, { ...options, isPrelude: true })
     return runInContext(code, context, options)
   }
+  
+  hoistImportDeclarations(program);
+  appendModuleTabsToContext(program, context)
+
   if (isNativeRunnable) {
     if (previousCode === code && isPreviousCodeTimeoutError) {
       context.nativeStorage.maxExecTime *= JSSLANG_PROPERTIES.factorToIncreaseBy

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,8 +478,12 @@ export async function runInContext(
       value: redexedSteps
     })
   }
-
+  
   const isNativeRunnable = determineExecutionMethod(theOptions, context, program)
+
+  hoistImportDeclarations(program);
+  appendModuleTabsToContext(program, context)
+
   if (context.prelude !== null) {
     const prelude = context.prelude
     context.prelude = null
@@ -498,10 +502,7 @@ export async function runInContext(
     }
     let transpiled
     let sourceMapJson: RawSourceMap | undefined
-    try {
-      hoistImportDeclarations(program);
-      appendModuleTabsToContext(program, context)
-      
+    try {      
       // Mutates program
       switch (context.variant) {
         case 'gpu':

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -6,7 +6,7 @@ import * as constants from '../constants'
 import { LazyBuiltIn } from '../createContext'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
-import { loadModuleBundle } from '../modules/moduleLoader'
+import { loadModuleBundle, loadModuleTabs } from '../modules/moduleLoader'
 import { checkEditorBreakpoints } from '../stdlib/inspector'
 import { Context, ContiguousArrayElements, Environment, Frame, Value } from '../types'
 import { conditionalExpression, literal, primitive } from '../utils/astCreator'
@@ -304,7 +304,7 @@ function* reduceIf(
 
 export type Evaluator<T extends es.Node> = (node: T, context: Context) => IterableIterator<Value>
 
-function* evaluateBlockSatement(context: Context, node: es.BlockStatement) {
+function* evaluateBlockStatement(context: Context, node: es.BlockStatement) {
   declareFunctionsAndVariables(context, node)
   let result
   for (const statement of node.body) {
@@ -644,38 +644,51 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     // Create a new environment (block scoping)
     const environment = createBlockEnvironment(context, 'blockEnvironment')
     pushEnvironment(context, environment)
-    const result: Value = yield* evaluateBlockSatement(context, node)
+    const result: Value = yield* evaluateBlockStatement(context, node)
     popEnvironment(context)
     return result
   },
 
   ImportDeclaration: function*(node: es.ImportDeclaration, context: Context) {
-    const moduleName = node.source.value as string
-    const neededSymbols = node.specifiers.map(spec => {
-      if (spec.type !== 'ImportSpecifier') {
-        throw new Error(
-          `I expected only ImportSpecifiers to be allowed, but encountered ${spec.type}.`
-        )
+    try {
+      const moduleName = node.source.value as string
+      const neededSymbols = node.specifiers.map(spec => {
+        if (spec.type !== 'ImportSpecifier') {
+          throw new Error(
+            `I expected only ImportSpecifiers to be allowed, but encountered ${spec.type}.`
+          )
+        }
+
+        return {
+          imported: spec.imported.name,
+          local: spec.local.name
+        }
+      })
+      
+      if (!context.moduleContexts.has(moduleName)) {
+        context.moduleContexts.set(moduleName, {
+          state: null,
+          tabs: loadModuleTabs(moduleName, node)
+        });
       }
 
-      return {
-        imported: spec.imported.name,
-        local: spec.local.name
+      const functions = loadModuleBundle(moduleName, context, node)
+      declareImports(context, node)
+      for (const name of neededSymbols) {
+        defineVariable(context, name.local, functions[name.imported], true);
       }
-    })
-    const functions = loadModuleBundle(moduleName, context, node)
-    declareImports(context, node)
-    for (const name of neededSymbols) {
-      defineVariable(context, name.local, functions[name.imported], true);
+
+      return undefined
+    } catch(error) {
+      return handleRuntimeError(context, error)
     }
-    return undefined
   },
 
   Program: function*(node: es.BlockStatement, context: Context) {
     context.numberOfOuterEnvironments += 1
     const environment = createBlockEnvironment(context, 'programEnvironment')
     pushEnvironment(context, environment)
-    const result = yield *forceIt(yield* evaluateBlockSatement(context, node), context);
+    const result = yield *forceIt(yield* evaluateBlockStatement(context, node), context);
     return result;
   }
 }
@@ -742,7 +755,7 @@ export function* apply(
       const bodyEnvironment = createBlockEnvironment(context, 'functionBodyEnvironment')
       bodyEnvironment.thisContext = thisContext
       pushEnvironment(context, bodyEnvironment)
-      result = yield* evaluateBlockSatement(context, fun.node.body as es.BlockStatement)
+      result = yield* evaluateBlockStatement(context, fun.node.body as es.BlockStatement)
       popEnvironment(context)
       if (result instanceof TailCallReturnValue) {
         fun = result.callee

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -6,9 +6,9 @@ import * as constants from '../constants'
 import { LazyBuiltIn } from '../createContext'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
-import { loadModuleBundle } from '../modules/moduleLoader'
+import { loadModuleBundle, loadModuleTabs } from '../modules/moduleLoader'
 import { checkEditorBreakpoints } from '../stdlib/inspector'
-import { Context, ContiguousArrayElements, Environment, Frame, Value } from '../types'
+import { Context, ContiguousArrayElements, Environment, Frame, ModuleContext, Value } from '../types'
 import { conditionalExpression, literal, primitive } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
@@ -818,4 +818,43 @@ export function* apply(
     popEnvironment(context)
   }
   return result
+}
+
+export function appendModulesToContextUpdated(program: es.Program, context: Context): void {
+  if (context.modules == null) context.modules = new Map<string, ModuleContext>();
+
+  for (const node of program.body) {
+    if (node.type !== 'ImportDeclaration') break
+    const moduleName = (node.source.value as string).trim()
+    
+    if (!context.modules.has(moduleName)) {
+      // Load the module's tabs
+      let moduleContext = {
+        state: null,
+        tabs: loadModuleTabs(moduleName)
+      }
+      context.modules.set(moduleName, moduleContext)
+    }
+
+    // Figure out what needs to be imported
+    const neededSymbols = node.specifiers.map(spec => {
+      if (spec.type !== 'ImportSpecifier') {
+        throw new Error(
+          `I expected only ImportSpecifiers to be allowed, but encountered ${spec.type}.`
+        )
+      }
+
+      return {
+        imported: spec.imported.name,
+        local: spec.local.name
+      }
+    })
+
+    // Load the module's bundle
+    const functions = loadModuleBundle(moduleName, context, node)
+    declareImports(context, node)
+    for (const name of neededSymbols) {
+      defineVariable(context, name.local, functions[name.imported], true);
+    }
+  }
 }

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -76,7 +76,7 @@ export function loadModuleBundle(path: string, context: Context, node?: es.Node)
   const moduleText = memoizedGetModuleFile(path, 'bundle')
   try {
     const moduleBundle: ModuleBundle = eval(moduleText)
-    return moduleBundle(context)
+    return moduleBundle(context.moduleParams, context.moduleContexts);
   } catch (error) {
     throw new ModuleInternalError(path, node)
   }

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -2,7 +2,7 @@ import es from 'estree'
 import { memoize } from 'lodash'
 import { XMLHttpRequest as NodeXMLHttpRequest } from 'xmlhttprequest-ts'
 
-import { Context } from '..'
+import { Context, ModuleContext } from '..'
 import {
   ModuleConnectionError,
   ModuleInternalError,
@@ -66,6 +66,8 @@ function getModuleFile(name: string, type: 'tab' | 'bundle'): string {
  * @returns the module's functions object
  */
 export function loadModuleBundle(path: string, context: Context, node?: es.Node): ModuleFunctions {
+  if (context.modules != null) context.modules = new Map<string, ModuleContext>();
+
   const modules = memoizedGetModuleManifest()
   // Check if the module exists
   const moduleList = Object.keys(modules)
@@ -98,6 +100,7 @@ export function loadModuleTabs(path: string, node?: es.Node) {
   // Check if the module exists
   const moduleList = Object.keys(modules)
   if (moduleList.includes(path) === false) throw new ModuleNotFoundError(path, node)
+
   // Retrieves the tabs the module has from modules.json
   const sideContentTabPaths: string[] = modules[path].tabs
   // Load the tabs for the current module
@@ -112,10 +115,12 @@ export function loadModuleTabs(path: string, node?: es.Node) {
 }
 
 /**
+ * Remove this function since it is not used anywhere
+ * 
  * Retrieves and appends the imported modules' tabs to the context
  * @param program
  * @param context
- */
+ *
 export function appendModuleTabsToContext(program: es.Program, context: Context): void {
   // Rest the modules to empty array everytime
   context.modules = []
@@ -128,4 +133,4 @@ export function appendModuleTabsToContext(program: es.Program, context: Context)
       Array.prototype.push.apply(context.modules, moduleTab)
     }
   }
-}
+}*/

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -112,26 +112,3 @@ export function loadModuleTabs(path: string, node?: es.Node) {
     }
   })
 }
-
-/**
- * Retrieves and appends the imported modules' tabs to the context
- * @param program
- * @param context
- */
-export function appendModuleTabsToContext(program: es.Program, context: Context): void {
-  for (const node of program.body) {
-    if (node.type !== 'ImportDeclaration') break
-    const moduleName = (node.source.value as string).trim()
-    
-    // Load the module's tabs
-    if (!context.moduleContexts.has(moduleName)) {
-      let moduleContext = {
-        state: null,
-        tabs: loadModuleTabs(moduleName)
-      }
-      context.moduleContexts.set(moduleName, moduleContext)
-    } else {
-      context.moduleContexts.get(moduleName)!.tabs = loadModuleTabs(moduleName);
-    }
-  }
-}

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -2,7 +2,7 @@ import es from 'estree'
 import { memoize } from 'lodash'
 import { XMLHttpRequest as NodeXMLHttpRequest } from 'xmlhttprequest-ts'
 
-import { Context, ModuleContext } from '..'
+import { Context } from '..'
 import {
   ModuleConnectionError,
   ModuleInternalError,
@@ -53,6 +53,7 @@ function getModuleManifest(): Modules {
  * Send a HTTP GET request to the modules endpoint to retrieve the specified file
  * @return String of module file contents
  */
+
 export const memoizedGetModuleFile = memoize(getModuleFile)
 function getModuleFile(name: string, type: 'tab' | 'bundle'): string {
   return httpGet(`${MODULES_STATIC_URL}/${type}s/${name}.js`)
@@ -66,18 +67,20 @@ function getModuleFile(name: string, type: 'tab' | 'bundle'): string {
  * @returns the module's functions object
  */
 export function loadModuleBundle(path: string, context: Context, node?: es.Node): ModuleFunctions {
-  if (context.modules != null) context.modules = new Map<string, ModuleContext>();
-
+  // if (context.modules == null) context.modules = new Map<string, ModuleContext>();
   const modules = memoizedGetModuleManifest()
+
   // Check if the module exists
   const moduleList = Object.keys(modules)
   if (moduleList.includes(path) === false) throw new ModuleNotFoundError(path, node)
+
   // Get module file
   const moduleText = memoizedGetModuleFile(path, 'bundle')
   try {
+    // For some reason eval calls the inner function i
+    // have no idea what's going on
     const moduleBundle: ModuleBundle = eval(moduleText)
-    const moduleFunctions = moduleBundle(context)
-    return moduleFunctions
+    return moduleBundle(context)
   } catch (error) {
     throw new ModuleInternalError(path, node)
   }

--- a/src/modules/moduleTypes.ts
+++ b/src/modules/moduleTypes.ts
@@ -1,4 +1,4 @@
-import { Context } from '../index'
+import { ModuleContext } from '../types'
 
 export type Modules = {
   [module: string]: {
@@ -6,7 +6,7 @@ export type Modules = {
   }
 }
 
-export type ModuleBundle = (context: Context<any>) => ModuleFunctions
+export type ModuleBundle = (params: Map<string, any>, context: Map<string, ModuleContext>) => ModuleFunctions
 
 export type ModuleFunctions = {
   [functionName: string]: Function

--- a/src/transpiler/evalContainer.ts
+++ b/src/transpiler/evalContainer.ts
@@ -1,7 +1,8 @@
-import { MODULE_PARAMS_ID, NATIVE_STORAGE_ID } from '../constants'
+import { ModuleState } from '..'
+import { MODULE_PARAMS_ID, MODULE_STATE_ID, NATIVE_STORAGE_ID } from '../constants'
 import { NativeStorage } from '../types'
 
-type Evaler = (code: string, nativeStorage: NativeStorage, moduleParams: any) => any
+type Evaler = (code: string, nativeStorage: NativeStorage, moduleParams: any, moduleState: ModuleState) => any
 
 /*
   We need to use new Function here to ensure that the parameter names do not get
@@ -12,6 +13,7 @@ export const sandboxedEval: Evaler = new Function(
   'code',
   NATIVE_STORAGE_ID,
   MODULE_PARAMS_ID,
+  MODULE_STATE_ID,
   `
   if (${NATIVE_STORAGE_ID}.evaller === null) {
     return eval(code);

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -634,7 +634,7 @@ export function reduceImportDeclarations(program: es.Program) {
     const baseNode = baseNodes.get(key)!;
     return {
       ...baseNode,
-      specfiers: specifiers.get(key)!
+      specifiers: specifiers.get(key)!
     } as es.ModuleDeclaration;
   });
 

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -593,51 +593,6 @@ function getDeclarationsToAccessTranspilerInternals(
 }
 
 /**
- * Hoists all import declarations to the top of the program,
- * and also collates different import statements from the same 
- * module as a single import statement
- * 
- * @param program Program to parse
- */
-export function hoistImportDeclarations(program: es.Program) {
-  const importNodes = (program.body.filter(node => node.type === "ImportDeclaration") as es.ImportDeclaration[]);
-
-  const specifiers = new Map<string, es.ImportSpecifier[]>();
-  const baseNodes = new Map<string, es.ImportDeclaration>();
-
-  for (const node of importNodes) {
-    const moduleName = (node.source.value as string).trim()
-
-    if(!specifiers.has(moduleName)) {
-      specifiers.set(moduleName, []);
-      baseNodes.set(moduleName, node);
-    }
-
-    for (const specifier of node.specifiers) {
-      if (specifier.type !== 'ImportSpecifier') {
-        throw new Error(
-          `I expected only ImportSpecifiers to be allowed, but encountered ${specifier.type}.`
-        )
-      }
-      
-      specifiers.get(moduleName)!.push(specifier);
-    }
-  }
-
-  // Create new collated import specifiers
-  const newImports = Array.from(specifiers.keys()).map((key) => {
-    const baseNode = baseNodes.get(key)!;
-    return {
-      ...baseNode,
-      specifiers: specifiers.get(key)!
-    } as es.ModuleDeclaration;
-  });
-
-  // Insert the import specifiers at the top of the program
-  program.body = (newImports as (es.ModuleDeclaration | es.Statement | es.Declaration)[]).concat(program.body.filter(node => node.type !== "ImportDeclaration"));
-}
-
-/**
  * Retrieves and appends the imported modules' tabs to the context.
  * Used only by the transpiler
  * @param program

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -2,7 +2,7 @@ import { generate } from 'astring'
 import * as es from 'estree'
 import { SourceMapGenerator } from 'source-map'
 
-import { MODULE_PARAMS_ID, NATIVE_STORAGE_ID } from '../constants'
+import { MODULE_PARAMS_ID, MODULE_STATE_ID, NATIVE_STORAGE_ID } from '../constants'
 import { UndefinedVariable } from '../errors/errors'
 import { memoizedGetModuleFile } from '../modules/moduleLoader'
 import { AllowedDeclarations, Context, NativeStorage } from '../types'
@@ -47,7 +47,7 @@ function prefixModule(program: es.Program): string {
     prefix += `const __MODULE_${moduleCounter}__ = (${moduleText.substring(
       0,
       moduleText.length - 1
-    )})(${MODULE_PARAMS_ID});\n`
+    )})(${MODULE_PARAMS_ID}, ${MODULE_STATE_ID});\n`
     moduleCounter++
   }
   return prefix

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ import { SourceLocation } from 'acorn'
 import * as es from 'estree'
 
 import { EnvTree } from './createContext'
-import { ModuleBundle } from './modules/moduleTypes'
+// import { ModuleBundle } from './modules/moduleTypes'
 
 /**
  * Defines functions that act as built-ins, but might rely on
@@ -178,7 +178,6 @@ export interface ModuleState {}
  */
 export type ModuleContext = {
   tabs: any
-  //bundle: ModuleBundle
   state?: ModuleState | null
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import { SourceLocation } from 'acorn'
 import * as es from 'estree'
 
 import { EnvTree } from './createContext'
+import { ModuleBundle } from './modules/moduleTypes'
 
 /**
  * Defines functions that act as built-ins, but might rely on
@@ -161,12 +162,24 @@ export interface Context<T = any> {
   /**
    * The side content components to be displayed after the evaluation
    */
-  modules?: any[]
+  modules?: Map<string, ModuleContext>
 
   /**
    * Code previously executed in this context
    */
   previousCode: string[]
+}
+
+export interface ModuleState {}
+
+/**
+ * Used to store state and contextual information for
+ * each module
+ */
+export type ModuleContext = {
+  tabs: any
+  //bundle: ModuleBundle
+  state?: ModuleState | null
 }
 
 export interface BlockFrame {

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export interface Context<T = any> {
   /**
    * Parameters to pass to a module during module initialization
    */
-  moduleParams: Map<string, any>
+  moduleParams: any
   
   /**
    * Storage container for module specific information and state
@@ -180,7 +180,7 @@ export interface ModuleState {}
  * each module
  */
 export type ModuleContext = {
-  tabs: any
+  tabs: any[]
   state?: ModuleState | null
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,8 +114,6 @@ export interface Context<T = any> {
     nodes: es.Node[]
   }
 
-  moduleParams?: any
-
   numberOfOuterEnvironments: number
 
   prelude: string | null
@@ -160,9 +158,14 @@ export interface Context<T = any> {
   typeEnvironment: TypeEnvironment
 
   /**
-   * The side content components to be displayed after the evaluation
+   * Parameters to pass to a module during module initialization
    */
-  modules?: Map<string, ModuleContext>
+  moduleParams: Map<string, any>
+  
+  /**
+   * Storage container for module specific information and state
+   */
+  moduleContexts: Map<string, ModuleContext>
 
   /**
    * Code previously executed in this context


### PR DESCRIPTION
This branch changes how modules are imported by js-slang.

### Modules State
This branch introduces the module state interface for modules to store their own state information that is accessible wherever `Context` is accessible
```.ts
interface ModuleState {}
```
Example:
```.ts
class CurvesModuleState implements ModuleState {
    public drawnCurves: ShapeDrawn[];
}
```

### Module Context
`ModuleState` objects are stored in `ModuleContext`s, which also store the module's tabs.
```.ts
type ModuleContext = {
    state?: ModuleState;
    tabs: any[]
}
```
### Context
`ModuleContext`s are stored in the `Context` object in a map, the key of the map being the name of the module (e.g. `curve`). This map is passed to modules during initalization, making the context of other modules available to the module being imported. The previous `moduleParams` object is still passed to modules.
```.ts
type Context <T = any> = {
    moduleContexts: Map<string, ModuleContext>
    moduleParams: any
}
```

To make use of the new context object, modules should take two parameters:
```.ts
export function curves(params, contexts: Map<string, ModuleContext>) {
    const moduleContext = contexts.get('curve');
    moduleContext.state = {
        drawnCurves: []
    };
}
```

### Issues Resolved
- Fixes [Modules Issue #65](https://github.com/source-academy/modules/issues/65) - Drawing should not depend on evaluation result
- Fixes [Modules Issue #118](https://github.com/source-academy/modules/issues/118) - Importing pixnflix and sound crashes the frontend
    - Also fixes a possibly related issue where importing the curves and sound modules crashes the frontend
- Fixes [Modules Issue #29](https://github.com/source-academy/modules/issues/29) - Module errors not caught in interpreter mode 
    - The interpreter will now also properly load side content tabs
- Fixes [js-slang Issue #1097](https://github.com/source-academy/js-slang/issues/1097) - Multiple import statements cause multiple tabs to be spawned
- Import statements will now be hoisted to the top of the source program to follow Javascript's behaviour, and multiple import statements to the same module will be treated as a single import statement.