### PR TITLE
Fix `ChromeEvalErrorLocator` regex

### DIFF
--- a/src/runner/__tests__/fullJSRunner.ts
+++ b/src/runner/__tests__/fullJSRunner.ts
@@ -124,7 +124,19 @@ describe('Error locations are handled well in fullJS', () => {
     ]
   }
 
-  it.each([UNDEFINED_VARIABLE, SYNTAX_ERROR])(
+  const REFERENCE_ERROR: CodeSnippetTestCase = {
+    name: 'REFERENCE ERROR',
+    snippet: `
+            function h() {
+              g();
+            }
+            h();
+            `,
+    value: undefined,
+    errors: [new UndefinedVariable('g', locationDummyNode(3, 14))]
+  }
+
+  it.each([UNDEFINED_VARIABLE, SYNTAX_ERROR, REFERENCE_ERROR])(
     `%p`,
     async ({ snippet, value, errors }: CodeSnippetTestCase) => {
       const fullJSContext: Context = mockContext(-1, 'default')

--- a/src/runner/errors.ts
+++ b/src/runner/errors.ts
@@ -17,7 +17,7 @@ interface EvalErrorLocator {
 }
 
 const ChromeEvalErrorLocator = {
-  regex: /at eval.+<anonymous>:(\d+):(\d+)/gm,
+  regex: /eval at.+<anonymous>:(\d+):(\d+)/gm,
   browser: BrowserType.Chrome
 }
 


### PR DESCRIPTION
Fixes https://github.com/source-academy/frontend/issues/2124

## Description

The existing regex used to extract error messages fails to get the correct error for the following snippet:

```javascript
function h() {
    g();
}
h();
```
Expected: **Line 2: Name g not declared.**
Return: **Line 4: Name h not declared.**

The error stack is as follows:

```
at g (eval at nativeStorage.evaller (eval at fullJSEval (http://localhost:8000/static/js/main.chunk.js:14490:12)), <anonymous>:2:3)
at eval (eval at nativeStorage.evaller (eval at fullJSEval (http://localhost:8000/static/js/main.chunk.js:14490:12)), <anonymous>:4:1)
```

The problem lies in the fact that the current regex matches the prefix `at eval` which only captures errors that occur in the first stack frame of the evaluation.

Therefore, the fix will instead match error messages during the entire `eval` process and return the first error on the top of the error stack.

```diff
- `at eval.+<anonymous>:(\d+):(\d+)`
+ `eval at.+<anonymous>:(\d+):(\d+)`
```