### PR TITLE
Lodash Memoize Fix

### DIFF
--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -55,8 +55,9 @@ function getModuleManifest(): Modules {
  */
 
 const memoizedGetModuleFileInternal = memoize(getModuleFile)
-export const memoizedGetModuleFile = (name: string, type: 'tab' | 'bundle') => memoizedGetModuleFileInternal({name, type})
-function getModuleFile({name, type}: {name: string, type: 'tab' | 'bundle'}): string {
+export const memoizedGetModuleFile = (name: string, type: 'tab' | 'bundle') =>
+  memoizedGetModuleFileInternal({ name, type })
+function getModuleFile({ name, type }: { name: string; type: 'tab' | 'bundle' }): string {
   return httpGet(`${MODULES_STATIC_URL}/${type}s/${name}.js`)
 }
 

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -54,8 +54,9 @@ function getModuleManifest(): Modules {
  * @return String of module file contents
  */
 
-export const memoizedGetModuleFile = memoize(getModuleFile)
-function getModuleFile(name: string, type: 'tab' | 'bundle'): string {
+const memoizedGetModuleFileInternal = memoize(getModuleFile)
+export const memoizedGetModuleFile = (name: string, type: 'tab' | 'bundle') => memoizedGetModuleFileInternal({name, type})
+function getModuleFile({name, type}: {name: string, type: 'tab' | 'bundle'}): string {
   return httpGet(`${MODULES_STATIC_URL}/${type}s/${name}.js`)
 }
 


### PR DESCRIPTION
The [`memoize`](https://lodash.com/docs/#memoize) function provided by lodash only memoizes based on the first parameter of the function. This occasionally causes incorrect values to be passed to `loadModuleTabs` and `loadModuleBundle`, creating errors when evaluating tabs or bundles.

```ts
const memoizedGetModuleFileInternal = memoize(getModuleFile)
export const memoizedGetModuleFile = (name: string, type: 'tab' | 'bundle') =>
  memoizedGetModuleFileInternal({ name, type })

// Make getModuleFile a single parameter function instead
function getModuleFile({ name, type }: { name: string; type: 'tab' | 'bundle' }): string {
  return httpGet(`${MODULES_STATIC_URL}/${type}s/${name}.js`)
}
```
The above changes should fix this issue from occurring in the future.