### PR TITLE
Migration to `renovate`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   schedule:
     interval: monthly
     time: "07:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0 # disabled for `renovate` migration (might switch back in the future)

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base", ":dependencyDashboard", "group:allNonMajor"
+    "config:base", ":dependencyDashboard", "group:allNonMajor", ":label(dependencies)"
   ],
   "major": {
     "dependencyDashboardApproval": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base", ":dependencyDashboard", ":preserveSemverRanges", "group:allNonMajor"
+    "config:base", ":dependencyDashboard", "group:allNonMajor"
   ],
   "major": {
     "dependencyDashboardApproval": true
   },
+  "packageRules": [
+	  {
+		  "matchPackagePatterns": ["*"],
+		  "rangeStrategy": "update-lockfile"
+	  }
+  ],
   "enabledManagers": ["npm"]
 }


### PR DESCRIPTION
Closes https://github.com/source-academy/js-slang/issues/1260

This PR disables `dependabot` PRs to test potential full migration to `renovate`.

- Modify semver range handling
- Add tags to `renovate` PRs