### PR TITLE
Refactor full JS language representation

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -2,7 +2,7 @@
 
 import { GLOBAL, JSSLANG_PROPERTIES } from './constants'
 import * as gpu_lib from './gpu/lib'
-import { isFullJSChapter } from './runner'
+import { isFullJSLanguage } from './runner'
 import { AsyncScheduler } from './schedulers'
 import { lazyListPrelude } from './stdlib/lazyList.prelude'
 import * as list from './stdlib/list'
@@ -432,18 +432,19 @@ const createContext = <T>(
   externalBuiltIns: CustomBuiltIns = defaultBuiltIns,
   moduleParams?: any
 ): Context => {
-  if (isFullJSChapter(chapter)) {
+  if (isFullJSLanguage(chapter, variant)) {
     // fullJS will include all builtins and preludes of source 4
     return {
       ...createContext(
         4,
-        variant,
+        'default',
         externalSymbols,
         externalContext,
         externalBuiltIns,
         moduleParams
       ),
-      chapter: -1
+      chapter: -1,
+      variant: 'js'
     } as Context
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export { SourceDocumentation } from './editors/ace/docTooltip'
 import * as es from 'estree'
 
 import { getKeywords, getProgramNames } from './name-extractor'
-import { fullJSRunner, hasVerboseErrors, isFullJSChapter, sourceRunner } from './runner'
+import { fullJSRunner, hasVerboseErrors, isFullJSLanguage, sourceRunner } from './runner'
 import { typeCheck } from './typeChecker/typeChecker'
 import { typeToString } from './utils/stringify'
 
@@ -276,7 +276,7 @@ export async function runInContext(
   context: Context,
   options: Partial<IOptions> = {}
 ): Promise<Result> {
-  if (isFullJSChapter(context.chapter)) {
+  if (isFullJSLanguage(context.chapter, context.variant)) {
     return fullJSRunner(code, context, options)
   }
 

--- a/src/runner/__tests__/runners.ts
+++ b/src/runner/__tests__/runners.ts
@@ -107,14 +107,14 @@ test('Source builtins are accessible in fullJS program', async () => {
   const fullJSProgram: string = `
     parse('head(list(1,2,3));');
     `
-  const fullJSContext: Context = mockContext(-1, 'default')
+  const fullJSContext: Context = mockContext(-1, 'js')
   await runInContext(fullJSProgram, fullJSContext)
 
   expect(fullJSContext.errors.length).toBeLessThanOrEqual(0)
 })
 
 test('Simulate fullJS REPL', async () => {
-  const fullJSContext: Context = mockContext(-1, 'default')
+  const fullJSContext: Context = mockContext(-1, 'js')
   const replStatements: [string, any][] = [
     ['const x = 1;', undefined],
     ['x;', 1],
@@ -135,7 +135,7 @@ describe('Native javascript programs are valid in fullJSRunner', () => {
   it.each([...JAVASCRIPT_CODE_SNIPPETS_NO_ERRORS])(
     `%p`,
     async ({ snippet, value, errors }: CodeSnippetTestCase) => {
-      const fullJSContext: Context = mockContext(-1, 'default')
+      const fullJSContext: Context = mockContext(-1, 'js')
       const result = await runInContext(snippet, fullJSContext)
 
       expect(result.status).toStrictEqual('finished')
@@ -149,7 +149,7 @@ describe('Error locations are handled well in fullJS', () => {
   it.each([...JAVASCRIPT_CODE_SNIPPETS_ERRORS])(
     `%p`,
     async ({ snippet, value, errors }: CodeSnippetTestCase) => {
-      const fullJSContext: Context = mockContext(-1, 'default')
+      const fullJSContext: Context = mockContext(-1, 'js')
       const result = await runInContext(snippet, fullJSContext)
 
       expect(result.status).toStrictEqual('error')

--- a/src/runner/utils.ts
+++ b/src/runner/utils.ts
@@ -10,8 +10,12 @@ import { simple } from '../utils/walkers'
 
 // Context Utils
 
-export function isFullJSChapter(chapter: number): boolean {
-  return chapter == -1
+export const isOtherLanguage = (chapter: number) => {
+  return chapter === -1
+}
+
+export const isFullJSLanguage = (chapter: number, variant: Variant) => {
+  return isOtherLanguage(chapter) && variant === 'js'
 }
 
 /**

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -6,7 +6,7 @@ import { RawSourceMap, SourceMapGenerator } from 'source-map'
 import { MODULE_CONTEXTS_ID, MODULE_PARAMS_ID, NATIVE_STORAGE_ID } from '../constants'
 import { UndefinedVariable } from '../errors/errors'
 import { memoizedGetModuleFile } from '../modules/moduleLoader'
-import { isFullJSChapter } from '../runner'
+import { isFullJSLanguage } from '../runner'
 import { AllowedDeclarations, Context, NativeStorage } from '../types'
 import * as create from '../utils/astCreator'
 import {
@@ -665,7 +665,7 @@ export function transpile(
   context: Context,
   skipUndefined = false
 ): TranspiledResult {
-  if (isFullJSChapter(context.chapter) || context.variant == 'native') {
+  if (isFullJSLanguage(context.chapter, context.variant) || context.variant == 'native') {
     return transpileToFullJS(program)
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,8 +59,19 @@ export interface Comment {
 }
 
 export type ExecutionMethod = 'native' | 'interpreter' | 'auto'
-export type Variant = 'native' | 'wasm' | 'lazy' | 'non-det' | 'concurrent' | 'gpu' | 'default' // this might replace EvaluationMethod
 
+// Includes languages that are not part of Source (e.g. full JS)
+export type Variant =
+  | 'native'
+  | 'wasm'
+  | 'lazy'
+  | 'non-det'
+  | 'concurrent'
+  | 'gpu'
+  | 'default'
+  | 'js'
+
+// Languages that are not part of Source have chapter set to -1
 export interface SourceLanguage {
   chapter: number
   variant: Variant


### PR DESCRIPTION
As HTML will soon be added SA, after discussion, it was agreed to have languages that are not part of Source (e.g. full JS, HTML) share the chapter number (-1), and differ in variant. This PR is to make the necessary refactoring first before adding HTML support.