### PR TITLE
Fix bug in stringifying objects

### DIFF
--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -376,13 +376,13 @@ export function valueToStringDag(value: Value): StringDag {
     return [result, isCircular]
   }
 
-  function convertObject(obj: Value): [StringDag, boolean] {
+  function convertObject(value: Value): [StringDag, boolean] {
     const memoResult = memo.get(value)
     if (memoResult !== undefined) {
       return [memoResult, false]
     }
-    ancestors.set(obj, ancestors.size)
-    const entries = Object.entries(obj)
+    ancestors.set(value, ancestors.size)
+    const entries = Object.entries(value)
     const converted = entries.map(kv => convert(kv[1]))
     let length = 2 + Math.max(0, entries.length - 1) * 2 + entries.length * 2
     let isCircular = false


### PR DESCRIPTION
Fixed inconsistent naming of function arguments in `convertObject` which causes objects to be wrongly memoized when the `stringify` util function is called, resulting in code related to objects to be wrongly displayed on the frontend.

Before fix:
![image](https://user-images.githubusercontent.com/54243224/188906723-851f1228-aa65-48f5-bfd9-5b78e508ded2.png)

After fix:
![image](https://user-images.githubusercontent.com/54243224/188907409-a2c18ffa-b10e-4ce6-8bd4-157233a3fb44.png)

