### PR TITLE
Add HTML runner

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export { SourceDocumentation } from './editors/ace/docTooltip'
 import * as es from 'estree'
 
 import { getKeywords, getProgramNames, NameDeclaration } from './name-extractor'
-import { fullJSRunner, hasVerboseErrors, sourceRunner } from './runner'
+import { fullJSRunner, hasVerboseErrors, htmlRunner, sourceRunner } from './runner'
 import { typeCheck } from './typeChecker/typeChecker'
 import { typeToString } from './utils/stringify'
 
@@ -286,6 +286,10 @@ export async function runInContext(
 ): Promise<Result> {
   if (context.chapter === Chapter.FULL_JS) {
     return fullJSRunner(code, context, options)
+  }
+
+  if (context.chapter === Chapter.HTML) {
+    return htmlRunner(code, context, options)
   }
 
   verboseErrors = hasVerboseErrors(code)

--- a/src/runner/__tests__/runners.ts
+++ b/src/runner/__tests__/runners.ts
@@ -5,6 +5,7 @@ import { FatalSyntaxError } from '../../parser/parser'
 import { Chapter, Variant } from '../../types'
 import { locationDummyNode } from '../../utils/astCreator'
 import { CodeSnippetTestCase } from '../../utils/testing'
+import { ERROR_HANDLING_SCRIPT } from '../htmlRunner'
 
 const JAVASCRIPT_CODE_SNIPPETS_NO_ERRORS: CodeSnippetTestCase[] = [
   {
@@ -176,4 +177,15 @@ describe('Additional JavaScript features are not available in Source Native', ()
       }
     }
   )
+})
+
+// HTML Unit Tests
+
+test('Error handling script is injected in HTML code', async () => {
+  const htmlDocument: string = '<p>Hello World!</p>'
+  const htmlContext: Context = mockContext(Chapter.HTML, Variant.DEFAULT)
+  const result = await runInContext(htmlDocument, htmlContext)
+
+  expect(result.status).toStrictEqual('finished')
+  expect((result as any).value).toStrictEqual(ERROR_HANDLING_SCRIPT + htmlDocument)
 })

--- a/src/runner/__tests__/runners.ts
+++ b/src/runner/__tests__/runners.ts
@@ -2,10 +2,10 @@ import { Context, Result, runInContext } from '../..'
 import { UndefinedVariable } from '../../errors/errors'
 import { mockContext } from '../../mocks/context'
 import { FatalSyntaxError } from '../../parser/parser'
-import { Chapter, Variant } from '../../types'
+import { Chapter, Finished, Variant } from '../../types'
 import { locationDummyNode } from '../../utils/astCreator'
 import { CodeSnippetTestCase } from '../../utils/testing'
-import { ERROR_HANDLING_SCRIPT } from '../htmlRunner'
+import { htmlErrorScript } from '../htmlRunner'
 
 const JAVASCRIPT_CODE_SNIPPETS_NO_ERRORS: CodeSnippetTestCase[] = [
   {
@@ -187,5 +187,5 @@ test('Error handling script is injected in HTML code', async () => {
   const result = await runInContext(htmlDocument, htmlContext)
 
   expect(result.status).toStrictEqual('finished')
-  expect((result as any).value).toStrictEqual(ERROR_HANDLING_SCRIPT + htmlDocument)
+  expect((result as Finished).value).toStrictEqual(htmlErrorScript + htmlDocument)
 })

--- a/src/runner/__tests__/runners.ts
+++ b/src/runner/__tests__/runners.ts
@@ -5,7 +5,7 @@ import { FatalSyntaxError } from '../../parser/parser'
 import { Chapter, Finished, Variant } from '../../types'
 import { locationDummyNode } from '../../utils/astCreator'
 import { CodeSnippetTestCase } from '../../utils/testing'
-import { htmlErrorScript } from '../htmlRunner'
+import { htmlErrorHandlingScript } from '../htmlRunner'
 
 const JAVASCRIPT_CODE_SNIPPETS_NO_ERRORS: CodeSnippetTestCase[] = [
   {
@@ -187,5 +187,5 @@ test('Error handling script is injected in HTML code', async () => {
   const result = await runInContext(htmlDocument, htmlContext)
 
   expect(result.status).toStrictEqual('finished')
-  expect((result as Finished).value).toStrictEqual(htmlErrorScript + htmlDocument)
+  expect((result as Finished).value).toStrictEqual(htmlErrorHandlingScript + htmlDocument)
 })

--- a/src/runner/htmlRunner.ts
+++ b/src/runner/htmlRunner.ts
@@ -1,7 +1,7 @@
 import { IOptions, Result } from '..'
 import { Context } from '../types'
 
-const ERROR_HANDLING_SCRIPT = `<script>
+export const ERROR_HANDLING_SCRIPT = `<script>
   window.onerror = (msg, url, lineNum) => {
     window.parent.postMessage("Line " + Math.max(lineNum - 5, 0) + ": " + msg, "*");
   };

--- a/src/runner/htmlRunner.ts
+++ b/src/runner/htmlRunner.ts
@@ -1,11 +1,17 @@
 import { IOptions, Result } from '..'
 import { Context } from '../types'
 
-export const ERROR_HANDLING_SCRIPT = `<script>
+const ERROR_HANDLING_SCRIPT_TEMPLATE = `<script>
   window.onerror = (msg, url, lineNum) => {
-    window.parent.postMessage("Line " + Math.max(lineNum - 5, 0) + ": " + msg, "*");
+    window.parent.postMessage("Line " + Math.max(lineNum - %d, 0) + ": " + msg, "*");
   };
 </script>\n`
+
+const errorScriptLines = ERROR_HANDLING_SCRIPT_TEMPLATE.split('\n').length - 1
+export const htmlErrorScript = ERROR_HANDLING_SCRIPT_TEMPLATE.replace(
+  '%d',
+  errorScriptLines.toString()
+)
 
 export async function htmlRunner(
   code: string,
@@ -15,6 +21,6 @@ export async function htmlRunner(
   return Promise.resolve({
     status: 'finished',
     context,
-    value: ERROR_HANDLING_SCRIPT + code
+    value: htmlErrorScript + code
   })
 }

--- a/src/runner/htmlRunner.ts
+++ b/src/runner/htmlRunner.ts
@@ -1,17 +1,20 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { IOptions, Result } from '..'
 import { Context } from '../types'
+
+const ERROR_HANDLING_SCRIPT = `<script>
+  window.onerror = (msg, url, lineNum) => {
+    window.parent.postMessage("Line " + Math.max(lineNum - 5, 0) + ": " + msg, "*");
+  };
+</script>\n`
 
 export async function htmlRunner(
   code: string,
   context: Context,
   options: Partial<IOptions> = {}
 ): Promise<Result> {
-  // Currently returns the HTML code without any changes,
-  // more changes will be made in the future (e.g. adding modules support)
   return Promise.resolve({
     status: 'finished',
     context,
-    value: code
+    value: ERROR_HANDLING_SCRIPT + code
   })
 }

--- a/src/runner/htmlRunner.ts
+++ b/src/runner/htmlRunner.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { IOptions, Result } from '..'
+import { Context } from '../types'
+
+export async function htmlRunner(
+  code: string,
+  context: Context,
+  options: Partial<IOptions> = {}
+): Promise<Result> {
+  // Currently returns the HTML code without any changes,
+  // more changes will be made in the future (e.g. adding modules support)
+  return Promise.resolve({
+    status: 'finished',
+    context,
+    value: code
+  })
+}

--- a/src/runner/htmlRunner.ts
+++ b/src/runner/htmlRunner.ts
@@ -1,14 +1,14 @@
 import { IOptions, Result } from '..'
 import { Context } from '../types'
 
-const ERROR_HANDLING_SCRIPT_TEMPLATE = `<script>
+const HTML_ERROR_HANDLING_SCRIPT_TEMPLATE = `<script>
   window.onerror = (msg, url, lineNum) => {
     window.parent.postMessage("Line " + Math.max(lineNum - %d, 0) + ": " + msg, "*");
   };
 </script>\n`
 
-const errorScriptLines = ERROR_HANDLING_SCRIPT_TEMPLATE.split('\n').length - 1
-export const htmlErrorScript = ERROR_HANDLING_SCRIPT_TEMPLATE.replace(
+const errorScriptLines = HTML_ERROR_HANDLING_SCRIPT_TEMPLATE.split('\n').length - 1
+export const htmlErrorHandlingScript = HTML_ERROR_HANDLING_SCRIPT_TEMPLATE.replace(
   '%d',
   errorScriptLines.toString()
 )
@@ -21,6 +21,6 @@ export async function htmlRunner(
   return Promise.resolve({
     status: 'finished',
     context,
-    value: htmlErrorScript + code
+    value: htmlErrorHandlingScript + code
   })
 }

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -1,3 +1,4 @@
 export * from './fullJSRunner'
+export * from './htmlRunner'
 export * from './sourceRunner'
 export * from './utils'

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export enum Chapter {
   SOURCE_3 = 3,
   SOURCE_4 = 4,
   FULL_JS = -1,
+  HTML = -2,
   LIBRARY_PARSER = 100
 }
 


### PR DESCRIPTION
Adds HTML runner to js-slang. 

The HTML runner currently takes the input code, injects a script to the top of the code that handles error handling, and returns the code without any further checks. This is because the bulk of error handling is done when the document is rendered in the frontend iframe component; the injected script serves to route any console errors to the frontend.

More substantial changes will likely be made once module support is considered.