### PR TITLE
Modify SICP package to use ES6 imports

### DIFF
--- a/scripts/build_sicp_package.sh
+++ b/scripts/build_sicp_package.sh
@@ -42,7 +42,7 @@ write() {
     #Write prelude names
     while read -r CURRENT_LINE
     do 
-        echo "global.$CURRENT_LINE = $CURRENT_LINE;" >> $SICPJSPATH
+        echo "exports.$CURRENT_LINE = $CURRENT_LINE;" >> $SICPJSPATH
     done < "sicp_publish/prelude_names.txt"
 
     #Write Functions
@@ -50,7 +50,7 @@ write() {
     do 
         if [ "$CURRENT_LINE" != "undefined" -a "$CURRENT_LINE" != "NaN" -a "$CURRENT_LINE" != "Infinity" ]
         then
-            echo "global.$CURRENT_LINE = dict.get(\"$CURRENT_LINE\");" >> $SICPJSPATH
+            echo "exports.$CURRENT_LINE = dict.get(\"$CURRENT_LINE\");" >> $SICPJSPATH
         fi
     done < "sicp_publish/names.txt"
 }

--- a/sicp_publish/README.md
+++ b/sicp_publish/README.md
@@ -22,13 +22,13 @@ Install the package `sicp` as follows:
 ``` {.}
 $ yarn add sicp
 ```
-To use the `sicp` package, you need to import it in your program by writing
+To use any functions in the `sicp` package, you need to import them in your program by writing
 ``` {.}
-import 'sicp';
+import { <Functions here> } from 'sicp';
 ```
 For example, if your file `test.js` contains:
 ``` {.}
-import 'sicp';
+import { display, head, list, tail } from 'sicp';
 
 const p = list("I", "love", "sicp");
 display(head(tail(p)));


### PR DESCRIPTION
Modifies the `build_sicp_package` script to change `global` to `exports`; this allows functions in the package to be imported ES6-style. Also changed documentation accordingly.

Note that `import 'sicp'` no longer works now; if we wish to support both import styles, the script needs to be edited such that the functions are written both to `global` and `exports`.

More work is still needed before SICP can work with TypeScript; we will likely need to look into automatically generating/manually adding a TypeScript declaration file.