### PR TITLE
Fix exposed global functions in Source Native

### DIFF
--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -655,10 +655,15 @@ function transpileToSource(
   return { transpiled, sourceMapJson }
 }
 
-function transpileToFullJS(program: es.Program, context: Context, skipUndefined: boolean): TranspiledResult {
+function transpileToFullJS(
+  program: es.Program,
+  context: Context,
+  skipUndefined: boolean
+): TranspiledResult {
   const usedIdentifiers = new Set<string>([
     ...getIdentifiersInProgram(program),
-    ...getIdentifiersInNativeStorage(context.nativeStorage)])
+    ...getIdentifiersInNativeStorage(context.nativeStorage)
+  ])
 
   const globalIds = getNativeIds(program, usedIdentifiers)
   checkForUndefinedVariables(program, context.nativeStorage, globalIds, skipUndefined)


### PR DESCRIPTION
## Description

Functions such as `compose_filter` is accessible globally on client side (see below). Since source native variants, relies on browser `eval` source native programs will be able to call such global functions.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/47914880/195231619-a54991c1-fa2d-4a42-8c22-c8468097a33b.png">

## Fix

- Add a new check during source native transpilation to check for undefined variables
    - This will do a check against the source program context (imports, precludes, builtins) and not the global browser context

https://github.com/source-academy/js-slang/blob/46c02cd45bc5b7077aa93bfb41aa04d410be54ad/src/transpiler/transpiler.ts#L663-L664
