### PR TITLE
Fix Source Typed handling of higher order functions

### DIFF
--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -467,14 +467,14 @@ export class TypeNotCallableError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
 
-  constructor(public node: tsEs.CallExpression, public name: string) {}
+  constructor(public node: tsEs.CallExpression, public typeName: string) {}
 
   get location() {
     return this.node.loc!
   }
 
   public explain() {
-    return `'${this.name}' is not callable.`
+    return `Type '${this.typeName}' is not callable.`
   }
 
   public elaborate() {


### PR DESCRIPTION
The current version of Source 1 Typed fails to account for higher order functions, resulting in the following error:
![image](https://user-images.githubusercontent.com/54243224/207487989-d85a52f6-b199-4bfd-afe1-7ff10d68aa85.png)

This PR adds support for higher order functions to Source 1 Typed, and adds testcases for higher order functions.