### PR TITLE
Add Source 2 Typed Variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can set additional options:
 Usage: js-slang [PROGRAM_STRING] [OPTION]
 
   -c, --chapter=CHAPTER set the Source chapter number (i.e., 1-4)                                                              (default: 1)
-  -v, --variant=VARIANT set the Source variant (i.e., default, interpreter, substituter, lazy, non-det, concurrent, wasm, gpu) (default: default)
+  -v, --variant=VARIANT set the Source variant (i.e., default, interpreter, substituter, typed, lazy, non-det, concurrent, wasm, gpu) (default: default)
   -h, --help            display this help
   -e, --eval            don't show REPL, only display output of evaluation
 ```
@@ -55,10 +55,12 @@ Currently, valid CHAPTER/VARIANT combinations are:
 * `--chapter=1 --variant=lazy`
 * `--chapter=1 --variant=substituter`
 * `--chapter=1 --variant=interpreter`
+* `--chapter=1 --variant=typed`
 * `--chapter=2 --variant=default`
 * `--chapter=2 --variant=lazy`
 * `--chapter=2 --variant=substituter`
 * `--chapter=2 --variant=interpreter`
+* `--chapter=2 --variant=typed`
 * `--chapter=3 --variant=default`
 * `--chapter=3 --variant=concurrent`
 * `--chapter=3 --variant=non-det`

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -594,7 +594,7 @@ export class InvalidNumberOfArgumentsTypeError implements SourceError {
   }
 }
 
-export class IncorrectNumberOfTypeArgumentsError implements SourceError {
+export class InvalidNumberOfTypeArgumentsForGenericTypeError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
   public calleeStr: string

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -613,3 +613,23 @@ export class InvalidNumberOfTypeArgumentsForGenericTypeError implements SourceEr
     return this.explain()
   }
 }
+
+export class TypeAliasNameNotAllowedError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+  public calleeStr: string
+
+  constructor(public node: tsEs.TSTypeAliasDeclaration, public name: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Type alias name cannot be '${this.name}'.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -593,3 +593,23 @@ export class InvalidNumberOfArgumentsTypeError implements SourceError {
     return `Try calling function ${calleeStr} again, but with ${this.expected} argument${pluralS} instead. Remember that arguments are separated by a ',' (comma).`
   }
 }
+
+export class IncorrectNumberOfTypeArgumentsError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+  public calleeStr: string
+
+  constructor(public node: tsEs.TSTypeReference, public name: string, public expected: number) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Generic type '${this.name}' requires ${this.expected} type argument(s).`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}

--- a/src/typeChecker/__tests__/source1Typed.test.ts
+++ b/src/typeChecker/__tests__/source1Typed.test.ts
@@ -451,6 +451,31 @@ describe('type aliases', () => {
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
   })
+
+  it('should throw errors for reserved types', () => {
+    const code = `type string = number;
+      type number = string;
+      type boolean = number;
+      type undefined = number;
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 1: Type alias name cannot be 'string'.
+      Line 2: Type alias name cannot be 'number'.
+      Line 3: Type alias name cannot be 'boolean'.
+      Line 4: Type alias name cannot be 'undefined'."
+    `)
+  })
+
+  it('should not throw errors for types that are not introduced yet', () => {
+    const code = `type Pair = number;
+      type List = string;
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
 })
 
 describe('typecasting', () => {

--- a/src/typeChecker/__tests__/source1Typed.test.ts
+++ b/src/typeChecker/__tests__/source1Typed.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 })
 
 describe('basic types', () => {
-  it('does not throw errors for allowed primitive types', () => {
+  it('does not throw errors for allowed basic types', () => {
     const code = `const x1: number = 1;
       const x2: string = '1';
       const x3: boolean = true;
@@ -22,7 +22,7 @@ describe('basic types', () => {
     expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
   })
 
-  it('throws errors for disallowed primitive types', () => {
+  it('throws errors for disallowed basic types', () => {
     const code = `const x1: unknown = 1;
       const x2: never = 1;
       const x3: bigint = 1;

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -11,10 +11,11 @@ beforeEach(() => {
 
 describe('null type', () => {
   it('handles type mismatches correctly', () => {
-    const code = `const x1: null = null;
-      const x2: null = '1';
-      const x3: boolean = null;
-      const x4: undefined = null;
+    const code = `const x1: null = null; // no error
+      const x2: null = '1'; // error
+      const x3: boolean = null; // error
+      const x4: undefined = null; // error
+      const x5: null = list(); // no error as null is empty list
     `
 
     parse(code, context)
@@ -22,6 +23,155 @@ describe('null type', () => {
       "Line 2: Type 'string' is not assignable to type 'null'.
       Line 3: Type 'null' is not assignable to type 'boolean'.
       Line 4: Type 'null' is not assignable to type 'undefined'."
+    `)
+  })
+})
+
+describe('pair', () => {
+  it('handles type mismatches correctly', () => {
+    const code = `const x1: Pair<number, number> = pair(1, 2); // no error
+      const x2: Pair<number, number> = pair(1, '2'); // error
+      const x3: Pair<number, number> = 1; // error
+      const x4: Pair<number> = pair(1, 2); // error
+      const x5: Pair<number, number> = list(1, 2); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 4: Generic type 'Pair' requires 2 type argument(s).
+      Line 2: Type 'Pair<number, string>' is not assignable to type 'Pair<number, number>'.
+      Line 3: Type 'number' is not assignable to type 'Pair<number, number>'.
+      Line 5: Type 'List<number>' is not assignable to type 'Pair<number, number>'."
+    `)
+  })
+
+  it('pair() must take in 2 arguments', () => {
+    const code = `pair(1, 2); // no error
+      pair(1); // error
+      pair(1, 2, 3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 2: Expected 2 arguments, but got 1.
+      Line 3: Expected 2 arguments, but got 3."
+    `)
+  })
+})
+
+describe('list', () => {
+  it('handles type mismatches correctly', () => {
+    const code = `const x1: List<number> = list(1, 2, 3); // no error
+      const x2: List<number> = list(); // no error
+      const x3: List<number> = list('1'); // error
+      const x4: List<number> = 1; // error
+      const x5: List<number> = list(1, '2'); // error
+      const x6: List<number | string> = list(1, '2'); // no error
+      const x7: List<number, string> = list(1, '2'); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 7: Generic type 'List' requires 1 type argument(s).
+      Line 3: Type 'List<string>' is not assignable to type 'List<number>'.
+      Line 4: Type 'number' is not assignable to type 'List<number>'.
+      Line 5: Type 'List<number | string>' is not assignable to type 'List<number>'."
+    `)
+  })
+})
+
+describe('head', () => {
+  it('takes in 1 pair or list as argument only', () => {
+    const code = `head(pair(1, 2)); // no error
+      head(list(1)); // no error
+      head(null); // no error, error will be caught at runtime
+      head(list(1, 2), 3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 4: Expected 1 arguments, but got 2."`
+    )
+  })
+
+  it('return type is type of first element in pair', () => {
+    const code = `const x1: Pair<number, number> = pair(1, 2);
+    const x2: Pair<string, number> = pair('1', 2);
+    const x3: Pair<string | number, number> = pair('1', 2);
+    const x4: number = head(x1); // no error
+    const x5: string = head(x2); // no error
+    const x6: string = head(pair('1', 2)); // no error
+    const x7: string = head(x3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 7: Type 'string | number' is not assignable to type 'string'."`
+    )
+  })
+
+  it('return type is element type in list', () => {
+    const code = `const x1: List<number> = list(1, 2);
+    const x2: List<string> = list('1', '2');
+    const x3: List<string | number> = list('1', 2);
+    const x4: number = head(x1); // no error
+    const x5: string = head(x2); // no error
+    const x6: string = head(list('1', 2)); // error
+    const x7: string = head(x3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 6: Type 'string | number' is not assignable to type 'string'.
+      Line 7: Type 'string | number' is not assignable to type 'string'."
+    `)
+  })
+})
+
+describe('tail', () => {
+  it('takes in 1 pair or list as argument only', () => {
+    const code = `tail(pair(1, 2)); // no error
+      tail(list(1)); // no error
+      tail(null); // no error, error will be caught at runtime
+      tail(list(1, 2), 3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 4: Expected 1 arguments, but got 2."`
+    )
+  })
+
+  it('return type is type of second element in pair', () => {
+    const code = `const x1: Pair<number, number> = pair(1, 2);
+    const x2: Pair<number, string> = pair(1, '2');
+    const x3: Pair<number, string | number> = pair(1, '2');
+    const x4: number = tail(x1); // no error
+    const x5: string = tail(x2); // no error
+    const x6: string = tail(pair(1, '2')); // no error
+    const x7: string = tail(x3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 7: Type 'string | number' is not assignable to type 'string'."`
+    )
+  })
+
+  it('return type for list is same as original list', () => {
+    const code = `const x1: List<number> = list(1, 2);
+    const x2: List<string> = list('1', '2');
+    const x3: List<string | number> = list('1', 2);
+    const x4: List<number> = tail(x1); // no error
+    const x5: List<string> = tail(x2); // no error
+    const x6: List<number> = tail(list('1', 2)); // error
+    const x7: List<string> = tail(x3); // error
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 6: Type 'List<string | number>' is not assignable to type 'List<number>'.
+      Line 7: Type 'List<string | number>' is not assignable to type 'List<string>'."
     `)
   })
 })

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -57,6 +57,15 @@ describe('pair', () => {
       Line 3: Expected 2 arguments, but got 3."
     `)
   })
+
+  it('lists are pairs', () => {
+    const code = `const x1: Pair<number, null> = list(1);
+      const x2: Pair<number, Pair<string, null>> = list(1, '2');
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
 })
 
 describe('list', () => {
@@ -77,6 +86,16 @@ describe('list', () => {
       Line 4: Type 'number' is not assignable to type 'List<number>'.
       Line 5: Type 'List<number | string>' is not assignable to type 'List<number>'."
     `)
+  })
+
+  it('pair with list as tail type is considered a list', () => {
+    const code = `const x1: List<number> = pair(1, null);
+      const x2: List<number | string> = pair(1, pair('1', null));
+      const x3: List<number | string> = pair(1, list('1'));
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
   })
 })
 

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -58,13 +58,16 @@ describe('pair', () => {
     `)
   })
 
-  it('lists are pairs', () => {
+  it('lists (except null) are pairs', () => {
     const code = `const x1: Pair<number, null> = list(1);
       const x2: Pair<number, Pair<string, null>> = list(1, '2');
+      const x3: Pair<number, null> = null;
     `
 
     parse(code, context)
-    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 3: Type 'null' is not assignable to type 'Pair<number, null>'."`
+    )
   })
 })
 
@@ -77,6 +80,7 @@ describe('list', () => {
       const x5: List<number> = list(1, '2'); // error
       const x6: List<number | string> = list(1, '2'); // no error
       const x7: List<number, string> = list(1, '2'); // error
+      const x8: List<null> = list(null, null); // no error
     `
 
     parse(code, context)
@@ -177,20 +181,19 @@ describe('tail', () => {
     )
   })
 
-  it('return type for list is same as original list', () => {
+  it('return type for list is tail type of list', () => {
     const code = `const x1: List<number> = list(1, 2);
     const x2: List<string> = list('1', '2');
     const x3: List<string | number> = list('1', 2);
     const x4: List<number> = tail(x1); // no error
     const x5: List<string> = tail(x2); // no error
-    const x6: List<number> = tail(list('1', 2)); // error
+    const x6: List<number> = tail(list('1', 2)); // no error
     const x7: List<string> = tail(x3); // error
     `
 
     parse(code, context)
-    expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 6: Type 'List<string | number>' is not assignable to type 'List<number>'.
-      Line 7: Type 'List<string | number>' is not assignable to type 'List<string>'."
-    `)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 7: Type 'List<string | number>' is not assignable to type 'List<string>'."`
+    )
   })
 })

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -69,6 +69,15 @@ describe('pair', () => {
       `"Line 3: Type 'null' is not assignable to type 'Pair<number, null>'."`
     )
   })
+
+  it('type alias with the same name cannot be declared', () => {
+    const code = 'type Pair = string;'
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 1: Type alias name cannot be 'Pair'."`
+    )
+  })
 })
 
 describe('list', () => {
@@ -100,6 +109,15 @@ describe('list', () => {
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
+
+  it('type alias with the same name cannot be declared', () => {
+    const code = 'type List = string;'
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 1: Type alias name cannot be 'List'."`
+    )
   })
 })
 

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -1,0 +1,27 @@
+import { parseError } from '../..'
+import { mockContext } from '../../mocks/context'
+import { parse } from '../../parser/parser'
+import { Chapter, Variant } from '../../types'
+
+let context = mockContext(Chapter.SOURCE_2, Variant.TYPED)
+
+beforeEach(() => {
+  context = mockContext(Chapter.SOURCE_2, Variant.TYPED)
+})
+
+describe('null type', () => {
+  it('handles type mismatches correctly', () => {
+    const code = `const x1: null = null;
+      const x2: null = '1';
+      const x3: boolean = null;
+      const x4: undefined = null;
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 2: Type 'string' is not assignable to type 'null'.
+      Line 3: Type 'null' is not assignable to type 'boolean'.
+      Line 4: Type 'null' is not assignable to type 'undefined'."
+    `)
+  })
+})

--- a/src/typeChecker/tsESTree.ts
+++ b/src/typeChecker/tsESTree.ts
@@ -754,6 +754,7 @@ export interface TSTypeAliasDeclaration extends BaseTSNode {
   type: 'TSTypeAliasDeclaration'
   id: Identifier
   typeAnnotation: TSType
+  typeParameters?: TSTypeParameterInstantiation
 }
 
 export interface TSInterfaceDeclaration extends BaseTSNode {
@@ -782,4 +783,10 @@ export interface TSAsExpression extends BaseTSNode {
 export interface TSTypeReference extends BaseTSNode {
   type: 'TSTypeReference'
   typeName: Identifier
+  typeParameters: TSTypeParameterInstantiation
+}
+
+export interface TSTypeParameterInstantiation extends BaseTSNode {
+  type: 'TSTypeParameterInstantiation'
+  params: TSType[]
 }

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -15,6 +15,7 @@ import {
 } from '../errors/typeErrors'
 import { memoizedGetModuleManifest } from '../modules/moduleLoader'
 import {
+  Chapter,
   Context,
   disallowedTypes,
   FunctionType,
@@ -40,6 +41,7 @@ import {
   tBool,
   tFunc,
   tLiteral,
+  tNull,
   tNumber,
   tPrimitive,
   tString,
@@ -93,8 +95,8 @@ function typeCheckAndReturnType(node: tsEs.Node, context: Context, env: TypeEnvi
         return tUndef
       }
       if (node.value === null) {
-        // TODO: Handle null literal types for Source 2 and above
-        return tAny
+        // For Source 1, return any type since null literals are not allowed
+        return context.chapter === Chapter.SOURCE_1 ? tAny : tNull
       }
       if (
         typeof node.value !== 'string' &&

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -297,9 +297,7 @@ function typeCheckAndReturnType(node: tsEs.Node, context: Context, env: TypeEnvi
               if (fnName === 'head') {
                 return actualType.kind === 'pair' ? actualType.headType : actualType.elementType
               }
-              return actualType.kind === 'pair'
-                ? actualType.tailType
-                : tUnion(actualType.elementType, tNull)
+              return actualType.kind === 'pair' ? actualType.tailType : actualType
             }
           }
           const fnType = lookupTypeAndRemoveForAllAndPredicateTypes(fnName, env)
@@ -719,6 +717,9 @@ function hasTypeMismatchErrors(actualType: Type, expectedType: Type): boolean {
         hasTypeMismatchErrors(actualType.tailType, expectedType.tailType)
       )
     case 'list':
+      if (isEqual(actualType, tNull)) {
+        return false
+      }
       if (actualType.kind !== 'list') {
         return true
       }
@@ -930,6 +931,9 @@ function containsType(arr: Type[], typeToCheck: Type) {
       !hasTypeMismatchErrors(typeToCheck.headType, type.headType) &&
       !hasTypeMismatchErrors(typeToCheck.tailType, type.tailType)
     ) {
+      return true
+    }
+    if (isEqual(typeToCheck, tNull) && type.kind === 'list') {
       return true
     }
     if (

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -870,6 +870,7 @@ function lookupTypeAndRemoveForAllAndPredicateTypes(
   if (type.kind === 'forall') {
     // Skip typecheck as function has variable number of arguments;
     // this only occurs for certain prelude functions
+    // TODO: Add support for ForAll type to type error checker
     return tAny
   }
   if (type.kind === 'predicate') {

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -116,6 +116,10 @@ export function formatTypeString(type: Type, formatAsLiteral?: boolean): string 
         return `"${type.value.toString()}"`
       }
       return type.value.toString()
+    case 'pair':
+      return `Pair<${formatTypeString(type.headType)}, ${formatTypeString(type.tailType)}>`
+    case 'list':
+      return `List<${formatTypeString(type.elementType)}>`
     default:
       return type.kind
   }

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -353,7 +353,7 @@ export const temporaryStreamFuncs: [string, BindableType][] = [
 
 // Prelude function type overrides for Source Typed variant
 export const source1TypeOverrides: [string, BindableType][] = [
-  // is something functions
+  // predicate functions
   ['is_boolean', tFunc(tAny, tBool)],
   ['is_number', tFunc(tAny, tBool)],
   ['is_string', tFunc(tAny, tBool)],
@@ -363,6 +363,13 @@ export const source1TypeOverrides: [string, BindableType][] = [
   ['stringify', tFunc(tAny, tString)],
   ['arity', tFunc(tAny, tNumber)],
   ['char_at', tFunc(tString, tNumber, tUnion(tString, tUndef))]
+]
+
+export const source2TypeOverrides: [string, BindableType][] = [
+  // predicate functions
+  ['is_pair', tFunc(tAny, tBool)],
+  ['is_null', tFunc(tAny, tBool)],
+  ['is_list', tFunc(tAny, tBool)]
 ]
 
 // Creates type environment for the appropriate Source chapter
@@ -384,4 +391,12 @@ export function createTypeEnvironment(chapter: Chapter): TypeEnvironment {
       typeAliasMap: new Map()
     }
   ]
+}
+
+export function getTypeOverrides(chapter: Chapter): [string, BindableType][] {
+  const typeOverrides = [...source1TypeOverrides]
+  if (chapter >= 2) {
+    typeOverrides.push(...source2TypeOverrides)
+  }
+  return typeOverrides
 }

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -362,7 +362,7 @@ export const temporaryStreamFuncs: [string, BindableType][] = [
 // Prelude function type overrides for Source Typed variant
 export const source1TypeOverrides: [string, BindableType][] = [
   // math functions
-  // TODO: Add support for ForAll type to type error checker
+  // TODO: Add support for type checking of functions with variable no. of args
   ['math_hypot', tForAll(tNumber)],
   ['math_max', tForAll(tNumber)],
   ['math_min', tForAll(tNumber)],
@@ -370,35 +370,29 @@ export const source1TypeOverrides: [string, BindableType][] = [
   ['stringify', tFunc(tAny, tString)],
   ['arity', tFunc(tAny, tNumber)],
   ['char_at', tFunc(tString, tNumber, tUnion(tString, tUndef))],
-  // TODO: Add support for ForAll type to type error checker
+  // TODO: Add support for type checking of functions with variable no. of args
   ['display', tForAll(tAny)],
   ['error', tForAll(tAny)]
 ]
 
 export const source2TypeOverrides: [string, BindableType][] = [
-  // pair/list functions
-  // TODO: Add support for ForAll type to type error checker
-  ['pair', tForAll(tFunc(headType, tailType, tPair(headType, tailType)))],
-  ['list', tForAll(tAny)],
-  ['head', tForAll(tFunc(tPair(headType, tailType), headType))],
-  ['tail', tForAll(tFunc(tPair(headType, tailType), tailType))],
   // list library functions
-  ['accumulate', tFunc(tAny, tAny, tAny, tAny)],
-  ['append', tFunc(tAny, tAny, tAny)],
-  ['build_list', tFunc(tAny, tNumber, tList(tAny))],
+  ['accumulate', tFunc(tFunc(tAny, tAny, tAny), tAny, tList(tAny), tAny)],
+  ['append', tFunc(tList(tAny), tList(tAny), tList(tAny))],
+  ['build_list', tFunc(tFunc(tAny, tAny), tNumber, tList(tAny))],
   ['enum_list', tFunc(tNumber, tNumber, tList(tNumber))],
-  ['filter', tFunc(tAny, tList(tAny), tList(tAny))],
-  ['for_each', tFunc(tAny, tList(tAny), tBool)],
+  ['filter', tFunc(tFunc(tAny, tAny), tList(tAny), tList(tAny))],
+  ['for_each', tFunc(tFunc(tAny, tAny), tList(tAny), tBool)],
   ['length', tFunc(tList(tAny), tNumber)],
   ['list_ref', tFunc(tList(tAny), tNumber, tAny)],
   ['list_to_string', tFunc(tList(tAny), tString)],
-  ['map', tFunc(tAny, tList(tAny), tList(tAny))],
+  ['map', tFunc(tFunc(tAny, tAny), tList(tAny), tList(tAny))],
   ['member', tFunc(tAny, tList(tAny), tList(tAny))],
   ['remove', tFunc(tAny, tList(tAny), tList(tAny))],
   ['remove_all', tFunc(tAny, tList(tAny), tList(tAny))],
   ['reverse', tFunc(tList(tAny), tList(tAny))],
   // misc functions
-  // TODO: Add support for ForAll type to type checker
+  // TODO: Add support for type checking of functions with variable no. of args
   ['display_list', tForAll(tAny)],
   ['draw_data', tForAll(tAny)],
   ['equal', tFunc(tAny, tAny, tBool)]

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -165,6 +165,7 @@ export function tList(var1: Type, typeAsPair?: Pair): List {
   return {
     kind: 'list',
     elementType: var1,
+    // Used in Source Typed variants to check for type mismatches against pairs
     typeAsPair
   }
 }

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -117,9 +117,12 @@ export function formatTypeString(type: Type, formatAsLiteral?: boolean): string 
       }
       return type.value.toString()
     case 'pair':
-      return `Pair<${formatTypeString(type.headType)}, ${formatTypeString(type.tailType)}>`
+      return `Pair<${formatTypeString(type.headType, formatAsLiteral)}, ${formatTypeString(
+        type.tailType,
+        formatAsLiteral
+      )}>`
     case 'list':
-      return `List<${formatTypeString(type.elementType)}>`
+      return `List<${formatTypeString(type.elementType, formatAsLiteral)}>`
     default:
       return type.kind
   }
@@ -158,10 +161,11 @@ export function tPair(var1: Type, var2: Type): Pair {
   }
 }
 
-export function tList(var1: Type): List {
+export function tList(var1: Type, typeAsPair?: Pair): List {
   return {
     kind: 'list',
-    elementType: var1
+    elementType: var1,
+    typeAsPair
   }
 }
 

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -181,6 +181,7 @@ export const tNumber = tPrimitive('number')
 export const tString = tPrimitive('string')
 export const tUndef = tPrimitive('undefined')
 export const tVoid = tPrimitive('void')
+export const tNull = tPrimitive('null')
 
 export function tFunc(...types: Type[]): FunctionType {
   const parameterTypes = types.slice(0, -1)

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -357,23 +357,47 @@ export const temporaryStreamFuncs: [string, BindableType][] = [
 
 // Prelude function type overrides for Source Typed variant
 export const source1TypeOverrides: [string, BindableType][] = [
-  // predicate functions
-  ['is_boolean', tFunc(tAny, tBool)],
-  ['is_number', tFunc(tAny, tBool)],
-  ['is_string', tFunc(tAny, tBool)],
-  ['is_undefined', tFunc(tAny, tBool)],
-  ['is_function', tFunc(tAny, tBool)],
+  // math functions
+  // TODO: Add support for ForAll type to type error checker
+  ['math_hypot', tForAll(tNumber)],
+  ['math_max', tForAll(tNumber)],
+  ['math_min', tForAll(tNumber)],
   // misc functions
   ['stringify', tFunc(tAny, tString)],
   ['arity', tFunc(tAny, tNumber)],
-  ['char_at', tFunc(tString, tNumber, tUnion(tString, tUndef))]
+  ['char_at', tFunc(tString, tNumber, tUnion(tString, tUndef))],
+  // TODO: Add support for ForAll type to type error checker
+  ['display', tForAll(tAny)],
+  ['error', tForAll(tAny)]
 ]
 
 export const source2TypeOverrides: [string, BindableType][] = [
-  // predicate functions
-  ['is_pair', tFunc(tAny, tBool)],
-  ['is_null', tFunc(tAny, tBool)],
-  ['is_list', tFunc(tAny, tBool)]
+  // pair/list functions
+  // TODO: Add support for ForAll type to type error checker
+  ['pair', tForAll(tFunc(headType, tailType, tPair(headType, tailType)))],
+  ['list', tForAll(tAny)],
+  ['head', tForAll(tFunc(tPair(headType, tailType), headType))],
+  ['tail', tForAll(tFunc(tPair(headType, tailType), tailType))],
+  // list library functions
+  ['accumulate', tFunc(tAny, tAny, tAny, tAny)],
+  ['append', tFunc(tAny, tAny, tAny)],
+  ['build_list', tFunc(tAny, tNumber, tList(tAny))],
+  ['enum_list', tFunc(tNumber, tNumber, tList(tNumber))],
+  ['filter', tFunc(tAny, tList(tAny), tList(tAny))],
+  ['for_each', tFunc(tAny, tList(tAny), tBool)],
+  ['length', tFunc(tList(tAny), tNumber)],
+  ['list_ref', tFunc(tList(tAny), tNumber, tAny)],
+  ['list_to_string', tFunc(tList(tAny), tString)],
+  ['map', tFunc(tAny, tList(tAny), tList(tAny))],
+  ['member', tFunc(tAny, tList(tAny), tList(tAny))],
+  ['remove', tFunc(tAny, tList(tAny), tList(tAny))],
+  ['remove_all', tFunc(tAny, tList(tAny), tList(tAny))],
+  ['reverse', tFunc(tList(tAny), tList(tAny))],
+  // misc functions
+  // TODO: Add support for ForAll type to type checker
+  ['display_list', tForAll(tAny)],
+  ['draw_data', tForAll(tAny)],
+  ['equal', tFunc(tAny, tAny, tBool)]
 ]
 
 // Creates type environment for the appropriate Source chapter

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,10 +318,6 @@ export const disallowedTypes = ['bigint', 'never', 'object', 'symbol', 'unknown'
 
 export type TSDisallowedTypes = typeof disallowedTypes[number]
 
-export const reservedTypes = ['Pair', 'List'] as const
-
-export type SourceTypedReservedTypes = typeof reservedTypes[number]
-
 // All types recognised by type parser as basic types
 export type TSBasicType = PrimitiveType | TSAllowedTypes | TSDisallowedTypes
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,10 @@ export const disallowedTypes = ['bigint', 'never', 'object', 'symbol', 'unknown'
 
 export type TSDisallowedTypes = typeof disallowedTypes[number]
 
+export const reservedTypes = ['Pair', 'List'] as const
+
+export type SourceTypedReservedTypes = typeof reservedTypes[number]
+
 // All types recognised by type parser as basic types
 export type TSBasicType = PrimitiveType | TSAllowedTypes | TSDisallowedTypes
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -384,6 +384,7 @@ export interface FunctionType {
 export interface List {
   kind: 'list'
   elementType: Type
+  typeAsPair?: Pair
 }
 
 export interface Pair {

--- a/src/types.ts
+++ b/src/types.ts
@@ -384,6 +384,7 @@ export interface FunctionType {
 export interface List {
   kind: 'list'
   elementType: Type
+  // Used in Source Typed variants to check for type mismatches against pairs
   typeAsPair?: Pair
 }
 


### PR DESCRIPTION
Changes:
-
- Added support for `null` to type error checker.
- Added `Pair` and `List` types to type error checker.
- Added type checking for Source 2 library functions (e.g. `pair`, `list`, `head`, `tail`).
- Added tests for Source 2 Typed.

How to Test this PR:
-
1. Without frontend: Run Source 2 Typed in the js-slang REPL.
```
$ js-slang -c 2 -v typed # if js-slang is added to PATH
$ node dist/repl/repl.js -c 2 -v typed # if js-slang is not added to PATH
```
2. With frontend: [Link local js-slang to local frontend](https://github.com/source-academy/js-slang#using-your-js-slang-in-your-local-source-academy) and checkout local frontend to source-academy/frontend#2293.
3. Check the existing unit tests in `src/typeChecker/__tests__/source2Typed.test.ts`.
```
$ yarn test src/typeChecker/__tests__/source2Typed.test.ts
```