### PR TITLE
Ignore unused arguments starting with underscore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
     "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/restrict-plus-operands": "off",


### PR DESCRIPTION
This is useful for when we need to declare functions that take in unused arguments. For example, the argument `context` is not used in the following code snippet, yet cannot be removed:
https://github.com/source-academy/js-slang/blob/e549211a7356708e5df34f86c56897e4da55dbdd/src/interpreter/interpreter.ts#L336-L340

This results in a warning being thrown by ESLint.

By convention, arguments are denoted as unused by prepending their names with `_`:
```
Literal: function*(node: es.Literal, _context: Context) { 
  return node.value
}, 
```

We can make ESLint ignore arguments that start with an underscore by making use of the `argsIgnorePattern` option (see [here](https://eslint.org/docs/latest/rules/no-unused-vars#argsignorepattern) for more information).