### PR TITLE
Add Source predeclared constants as literal types in Source Typed

### DIFF
--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -352,6 +352,17 @@ export const temporaryStreamFuncs: [string, BindableType][] = [
 
 // Prelude function type overrides for Source Typed variant
 export const source1TypeOverrides: [string, BindableType][] = [
+  // constants
+  ['Infinity', tPrimitive('number', Infinity)],
+  ['NaN', tPrimitive('number', NaN)],
+  ['math_E', tPrimitive('number', Math.E)],
+  ['math_LN2', tPrimitive('number', Math.LN2)],
+  ['math_LN10', tPrimitive('number', Math.LN10)],
+  ['math_LOG2E', tPrimitive('number', Math.LOG2E)],
+  ['math_LOG10E', tPrimitive('number', Math.LOG10E)],
+  ['math_PI', tPrimitive('number', Math.PI)],
+  ['math_SQRT1_2', tPrimitive('number', Math.SQRT1_2)],
+  ['math_SQRT2', tPrimitive('number', Math.SQRT2)],
   // is something functions
   ['is_boolean', tFunc(tAny, tBool)],
   ['is_number', tFunc(tAny, tBool)],
@@ -362,6 +373,19 @@ export const source1TypeOverrides: [string, BindableType][] = [
   ['stringify', tFunc(tAny, tString)],
   ['arity', tFunc(tAny, tNumber)],
   ['char_at', tFunc(tString, tNumber, tUnion(tString, tUndef))]
+]
+
+const predeclaredConstTypes: [string, Type][] = [
+  ['Infinity', tLiteral(Infinity)],
+  ['NaN', tLiteral(NaN)],
+  ['math_E', tLiteral(Math.E)],
+  ['math_LN2', tLiteral(Math.LN2)],
+  ['math_LN10', tLiteral(Math.LN10)],
+  ['math_LOG2E', tLiteral(Math.LOG2E)],
+  ['math_LOG10E', tLiteral(Math.LOG10E)],
+  ['math_PI', tLiteral(Math.PI)],
+  ['math_SQRT1_2', tLiteral(Math.SQRT1_2)],
+  ['math_SQRT2', tLiteral(Math.SQRT2)]
 ]
 
 // Creates type environment for the appropriate Source chapter
@@ -380,7 +404,7 @@ export function createTypeEnvironment(chapter: Chapter): TypeEnvironment {
     {
       typeMap: new Map(initialTypeMappings),
       declKindMap: new Map(initialTypeMappings.map(val => [val[0], 'const'])),
-      typeAliasMap: new Map()
+      typeAliasMap: new Map(predeclaredConstTypes)
     }
   ]
 }


### PR DESCRIPTION
Adds type aliases for each of the Source predeclared constants, so that they can be used as literal types (e.g. `const x: Infinity = Infinity;`)