### PR TITLE
Add ES2021.String type definitions to TypeScript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "target": "es2016",
     "lib": [
+      "es2021.string",
       "es2018",
       "es2017.object",
       "es2016",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,6 @@
       "es2021.string",
       "es2018",
       "es2017.object",
-      "es2016",
-      "es2015",
       "dom"
     ],
     "sourceMap": true,


### PR DESCRIPTION
This is so that the type definition of [`String.prototype.replaceAll()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) is available in TypeScript. `String.prototype.replaceAll()` is compatible with [all major browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility) as of the time of this PR.

Also removed useless options in `lib`. Since `target` is already set to `es2016`, there is no need for `es2015` and `es2016` in `lib` as these type definitions are already enabled.

> TypeScript also includes APIs for newer JS features matching the target you specify; for example the definition for Map is available if target is ES6 or newer.
>
> -- https://www.typescriptlang.org/tsconfig#lib