### PR TITLE
Align CI/CD pipeline Node.js major version with that in the README

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install TeX Live
         run: |
           sudo apt-get update -y

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The major version of Node.js recommended in the README is 16:
https://github.com/source-academy/js-slang/blob/bc17193ce41edf18d27f76e718c7b22333c2b147/README.md?plain=1#L7-L11

However, the CI/CD pipeline makes use of Node.js 14:
https://github.com/source-academy/js-slang/blob/bc17193ce41edf18d27f76e718c7b22333c2b147/.github/workflows/deploy-docs.yml#L11-L14
https://github.com/source-academy/js-slang/blob/bc17193ce41edf18d27f76e718c7b22333c2b147/.github/workflows/nodejs.yml#L17-L19

This PR aligns the major Node.js version of the CI/CD pipeline to 16 so that the environments are consistent. Note that this PR does not make use of Node.js 18 (the current LTS version) as there might be breaking changes - Node.js 16 has already been proven to work.