### PR TITLE
Add Source 3 Typed Variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Currently, valid CHAPTER/VARIANT combinations are:
 * `--chapter=3 --variant=concurrent`
 * `--chapter=3 --variant=non-det`
 * `--chapter=3 --variant=interpreter`
+* `--chapter=3 --variant=typed`
 * `--chapter=4 --variant=default`
 * `--chapter=4 --variant=gpu`
 * `--chapter=4 --variant=interpreter`

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -597,7 +597,6 @@ export class InvalidNumberOfArgumentsTypeError implements SourceError {
 export class InvalidNumberOfTypeArgumentsForGenericTypeError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
-  public calleeStr: string
 
   constructor(public node: tsEs.TSTypeReference, public name: string, public expected: number) {}
 
@@ -617,7 +616,6 @@ export class InvalidNumberOfTypeArgumentsForGenericTypeError implements SourceEr
 export class TypeAliasNameNotAllowedError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
-  public calleeStr: string
 
   constructor(public node: tsEs.TSTypeAliasDeclaration, public name: string) {}
 
@@ -637,7 +635,6 @@ export class TypeAliasNameNotAllowedError implements SourceError {
 export class InvalidIndexTypeError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
-  public calleeStr: string
 
   constructor(public node: tsEs.MemberExpression, public typeName: string) {}
 
@@ -657,7 +654,6 @@ export class InvalidIndexTypeError implements SourceError {
 export class InvalidArrayAccessError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
-  public calleeStr: string
 
   constructor(public node: tsEs.MemberExpression, public typeName: string) {}
 
@@ -667,6 +663,25 @@ export class InvalidArrayAccessError implements SourceError {
 
   public explain() {
     return `Type '${this.typeName}' cannot be accessed as it is not an array.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}
+
+export class ConstNotAssignableError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.WARNING
+
+  constructor(public node: tsEs.AssignmentExpression, public name: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Cannot assign to '${this.name}' as it is a constant.`
   }
 
   public elaborate() {

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -651,7 +651,7 @@ export class InvalidIndexTypeError implements SourceError {
   }
 }
 
-export class InvalidArrayAccessError implements SourceError {
+export class InvalidArrayAccessTypeError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
 
@@ -670,7 +670,7 @@ export class InvalidArrayAccessError implements SourceError {
   }
 }
 
-export class ConstNotAssignableError implements SourceError {
+export class ConstNotAssignableTypeError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.WARNING
 

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -633,3 +633,43 @@ export class TypeAliasNameNotAllowedError implements SourceError {
     return this.explain()
   }
 }
+
+export class InvalidIndexTypeError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+  public calleeStr: string
+
+  constructor(public node: tsEs.MemberExpression, public typeName: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Type '${this.typeName}' cannot be used as an index type.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}
+
+export class InvalidArrayAccessError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+  public calleeStr: string
+
+  constructor(public node: tsEs.MemberExpression, public typeName: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Type '${this.typeName}' cannot be accessed as it is not an array.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -134,6 +134,7 @@ export function parse(source: string, context: Context) {
         sourceType: 'module',
         plugins: ['typescript', 'estree']
       }).program as unknown as tsEs.Program
+      console.log(typedProgram)
 
       // Checks for type errors, then removes any TS-related nodes as they are not compatible with acorn-walk.
       program = checkForTypeErrors(typedProgram, context)

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -134,7 +134,6 @@ export function parse(source: string, context: Context) {
         sourceType: 'module',
         plugins: ['typescript', 'estree']
       }).program as unknown as tsEs.Program
-      console.log(typedProgram)
 
       // Checks for type errors, then removes any TS-related nodes as they are not compatible with acorn-walk.
       program = checkForTypeErrors(typedProgram, context)

--- a/src/parser/typeParser.ts
+++ b/src/parser/typeParser.ts
@@ -375,7 +375,7 @@ const tsPlugin = (BaseParser: any) => {
           return
       }
 
-      if (this.type === tokTypes.bracketL) {
+      while (this.type === tokTypes.bracketL) {
         node = this._parseMaybeTSArrayType(node)
       }
 
@@ -596,7 +596,7 @@ const tsPlugin = (BaseParser: any) => {
       this.expect(tokTypes.parenL)
       this._parseTSTypeAnnotation(node)
       this.expect(tokTypes.parenR)
-      if (this.eat(tokTypes.bracketL)) {
+      while (this.eat(tokTypes.bracketL)) {
         this.expect(tokTypes.bracketR)
       }
       return this.finishNode(node, 'TSParenthesizedType')

--- a/src/typeChecker/__tests__/source3Typed.test.ts
+++ b/src/typeChecker/__tests__/source3Typed.test.ts
@@ -25,6 +25,22 @@ describe('array type', () => {
       Line 4: Type '(number | string)[]' is not assignable to type 'string[]'."
     `)
   })
+
+  it('handles nested array types', () => {
+    const code = `const arr1: number[][] = [[1], [2], [3]];
+      const arr2: string[][] = [['1'], ['2'], ['3']];
+      const arr3: number[][] = [[1], ['2'], [3]];
+      const arr4: string[][] = [[1], ['2'], [3]];
+      const arr5: (number | string)[][] = [[1], ['2'], [3]];
+      const arr6: number[][] = [];
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 3: Type '(number[] | string[])[]' is not assignable to type 'number[][]'.
+      Line 4: Type '(number[] | string[])[]' is not assignable to type 'string[][]'."
+    `)
+  })
 })
 
 describe('array access', () => {

--- a/src/typeChecker/__tests__/source3Typed.test.ts
+++ b/src/typeChecker/__tests__/source3Typed.test.ts
@@ -1,0 +1,181 @@
+import { parseError } from '../..'
+import { mockContext } from '../../mocks/context'
+import { parse } from '../../parser/parser'
+import { Chapter, Variant } from '../../types'
+
+let context = mockContext(Chapter.SOURCE_3, Variant.TYPED)
+
+beforeEach(() => {
+  context = mockContext(Chapter.SOURCE_3, Variant.TYPED)
+})
+
+describe('array type', () => {
+  it('handles type mismatches correctly', () => {
+    const code = `const arr1: number[] = [1, 2, 3];
+      const arr2: string[] = ['1', '2', '3'];
+      const arr3: number[] = [1, '2', 3];
+      const arr4: string[] = [1, '2', 3];
+      const arr5: (number | string)[] = [1, '2', 3];
+      const arr6: number[] = [];
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 3: Type '(number | string)[]' is not assignable to type 'number[]'.
+      Line 4: Type '(number | string)[]' is not assignable to type 'string[]'."
+    `)
+  })
+})
+
+describe('array access', () => {
+  it('index must be number', () => {
+    const code = `const arr: number[] = [1, 2, 3];
+      arr[0];
+      arr['1'];
+      arr[true];
+      arr[undefined];
+      arr[null];
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 3: Type '\\"1\\"' cannot be used as an index type.
+      Line 4: Type 'true' cannot be used as an index type.
+      Line 5: Type 'undefined' cannot be used as an index type.
+      Line 6: Type 'null' cannot be used as an index type."
+    `)
+  })
+
+  it('variable being accessed must be array', () => {
+    const code = `const arr: number[] = [1, 2, 3];
+      const notArr1: number = 1;
+      const notArr2: string = '1';
+      const notArr3: boolean = true;
+      const notArr4: undefined = undefined;
+      const notArr5: null = null;
+      arr[0];
+      notArr1[0];
+      notArr2[0];
+      notArr3[0];
+      notArr4[0];
+      notArr5[0];
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 8: Type 'number' cannot be accessed as it is not an array.
+      Line 9: Type 'string' cannot be accessed as it is not an array.
+      Line 10: Type 'boolean' cannot be accessed as it is not an array.
+      Line 11: Type 'undefined' cannot be accessed as it is not an array.
+      Line 12: Type 'null' cannot be accessed as it is not an array."
+    `)
+  })
+})
+
+describe('variable assignment', () => {
+  it('handles type mismatches correctly', () => {
+    const code = `let x1: number = 1;
+      let x2: number | string = 1;
+      let x3 = 1;
+      x1 = 2;
+      x1 = '2';
+      x1 = true;
+      x2 = 2;
+      x2 = '2';
+      x2 = true;
+      x3 = 2;
+      x3 = '2';
+      x3 = true;
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 5: Type 'string' is not assignable to type 'number'.
+      Line 6: Type 'boolean' is not assignable to type 'number'.
+      Line 9: Type 'boolean' is not assignable to type 'number | string'."
+    `)
+  })
+
+  it('cannot assign to const', () => {
+    const code = `const x: number = 1;
+      x = 2;
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 2: Cannot assign to 'x' as it is a constant."`
+    )
+  })
+})
+
+describe('while loops', () => {
+  it('predicate must be boolean', () => {
+    const code = `let x: number = 0;
+      let y: boolean = true;
+      while (x < 1) { // no error
+        x = x + 1;
+      }
+      while (x + 1) { // error
+        x = x + 1;
+      }
+      while (x = 1) { // error
+        x = x + 1;
+      }
+      while (x) { // error
+        x = x + 1;
+      }
+      while (y) { // no error
+        x = x + 1;
+      }
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 6: Type 'number' is not assignable to type 'boolean'.
+      Line 9: Type 'undefined' is not assignable to type 'boolean'.
+      Line 12: Type 'number' is not assignable to type 'boolean'."
+    `)
+  })
+})
+
+describe('for loops', () => {
+  it('predicate must be boolean', () => {
+    const code = `for (let x: number = 0; x < 1; x = x + 1) { // no error
+        display(x);
+      }
+      for (let x: number = 0; x + 1; x = x + 1) { // error
+        display(x);
+      }
+      for (let x: number = 0; x = 1; x = x + 1) { // error
+        display(x);
+      }
+      for (let x: number = 0; x; x = x + 1) { // error
+        display(x);
+      }
+      for (let x: boolean = true; x; x = false) { // no error
+        display(x);
+      }
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 4: Type 'number' is not assignable to type 'boolean'.
+      Line 7: Type 'undefined' is not assignable to type 'boolean'.
+      Line 10: Type 'number' is not assignable to type 'boolean'."
+    `)
+  })
+
+  it('handles scoping', () => {
+    const code = `for (let x: number = 0; x > 1; x = x + 1) {
+        display(x);
+      }
+      let x: string = '1';
+      for (x = '1'; x === '1'; x = x + '1') {
+        display(x);
+      }
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
+})

--- a/src/typeChecker/tsESTree.ts
+++ b/src/typeChecker/tsESTree.ts
@@ -558,6 +558,8 @@ export interface ArrayPattern extends BasePattern {
 export interface RestElement extends BasePattern {
   type: 'RestElement'
   argument: Pattern
+  // Added to support type syntax
+  typeAnnotation?: TSTypeAnnotation
 }
 
 export interface AssignmentPattern extends BasePattern {
@@ -735,7 +737,7 @@ export interface TSTypeAnnotation extends BaseTSNode {
 
 export interface TSFunctionType extends BaseTSNode {
   type: 'TSFunctionType'
-  parameters: Identifier[]
+  parameters: (Identifier | RestElement)[]
   typeAnnotation: TSTypeAnnotation
 }
 

--- a/src/typeChecker/tsESTree.ts
+++ b/src/typeChecker/tsESTree.ts
@@ -679,6 +679,8 @@ export type TSTypeAnnotationType =
   | 'TSUnionType'
   | 'TSIntersectionType'
   | 'TSLiteralType'
+  | 'TSArrayType'
+  | 'TSParenthesizedType'
 
 export type TSTypeKeyword =
   | 'TSAnyKeyword'
@@ -717,6 +719,8 @@ export type TSType =
   | TSIntersectionType
   | TSTypeReference
   | TSLiteralType
+  | TSArrayType
+  | TSParenthesizedType
 
 type BaseTSNode = BaseNode
 
@@ -748,6 +752,16 @@ export interface TSIntersectionType extends BaseTSNode {
 export interface TSLiteralType extends BaseTSNode {
   type: 'TSLiteralType'
   literal: Literal
+}
+
+export interface TSArrayType extends BaseTSNode {
+  type: 'TSArrayType'
+  elementType: TSType
+}
+
+export interface TSParenthesizedType extends BaseTSNode {
+  type: 'TSParenthesizedType'
+  typeAnnotation: TSType
 }
 
 export interface TSTypeAliasDeclaration extends BaseTSNode {

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -267,10 +267,11 @@ function typeCheckAndReturnType(node: tsEs.Node, context: Context, env: TypeEnvi
         throw new TypecheckError(node, 'Variable declaration must have value')
       }
       const init = node.declarations[0].init
-      // Look up declared type directly as type has already been added to environment
-      const expectedType =
-        lookupTypeAndRemoveForAllAndPredicateTypes(id.name, env) ??
-        getTypeAnnotationType(id.typeAnnotation, context, env)
+      // Look up declared type if current environment contains name
+      const expectedType = env[env.length - 1].typeMap.has(id.name)
+        ? lookupTypeAndRemoveForAllAndPredicateTypes(id.name, env) ??
+          getTypeAnnotationType(id.typeAnnotation, context, env)
+        : getTypeAnnotationType(id.typeAnnotation, context, env)
       const initType = typeCheckAndReturnType(init, context, env)
       checkForTypeMismatch(node, initType, expectedType, context)
 
@@ -541,6 +542,7 @@ function addTypeDeclarationsToEnvironment(
         }
         const id = node.declarations[0].id as tsEs.Identifier
         const expectedType = getTypeAnnotationType(id.typeAnnotation, context, env)
+        // Type is not checked here as it will be checked in typeCheckAndReturnType
 
         // Save variable type and decl kind in type env
         setType(id.name, expectedType, env)

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -365,6 +365,14 @@ function typeCheckAndReturnType(node: tsEs.Node, context: Context, env: TypeEnvi
         }
         return tAny
       }
+
+      // If any of the arguments is a spread element, skip type checking of arguments
+      // TODO: Add support for type checking of call expressions with spread elements
+      const hasVarArgs = args.reduce((prev, curr) => prev || curr.type === 'SpreadElement', false)
+      if (hasVarArgs) {
+        return calleeType.returnType
+      }
+
       // Check argument types before returning declared return type
       const expectedTypes = calleeType.parameterTypes
       if (args.length !== expectedTypes.length) {

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -24,6 +24,7 @@ import {
   Context,
   disallowedTypes,
   PrimitiveType,
+  SArray,
   TSAllowedTypes,
   TSBasicType,
   TSDisallowedTypes,
@@ -896,6 +897,15 @@ function hasTypeMismatchErrors(actualType: Type, expectedType: Type): boolean {
       }
       return hasTypeMismatchErrors(actualType.elementType, expectedType.elementType)
     case 'array':
+      if (actualType.kind === 'union') {
+        // Special case: number[] | string[] matches with (number | string)[]
+        const types = actualType.types.filter((type): type is SArray => type.kind === 'array')
+        if (types.length !== actualType.types.length) {
+          return true
+        }
+        const combinedType = types.map(type => type.elementType)
+        return hasTypeMismatchErrors(tUnion(...combinedType), expectedType.elementType)
+      }
       if (actualType.kind !== 'array') {
         return true
       }

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -366,6 +366,7 @@ export const temporaryStreamFuncs: [string, BindableType][] = [
 ]
 
 // Prelude function type overrides for Source Typed variant
+// No need to override predicate functions as they are automatically handled by type checker
 export const source1TypeOverrides: [string, BindableType][] = [
   // constants
   ['Infinity', tPrimitive('number', Infinity)],
@@ -398,7 +399,7 @@ export const source2TypeOverrides: [string, BindableType][] = [
   ['append', tFunc(tList(tAny), tList(tAny), tList(tAny))],
   ['build_list', tFunc(tFunc(tAny, tAny), tNumber, tList(tAny))],
   ['enum_list', tFunc(tNumber, tNumber, tList(tNumber))],
-  ['filter', tFunc(tFunc(tAny, tAny), tList(tAny), tList(tAny))],
+  ['filter', tFunc(tFunc(tAny, tBool), tList(tAny), tList(tAny))],
   ['for_each', tFunc(tFunc(tAny, tAny), tList(tAny), tBool)],
   ['length', tFunc(tList(tAny), tNumber)],
   ['list_ref', tFunc(tList(tAny), tNumber, tAny)],
@@ -413,6 +414,36 @@ export const source2TypeOverrides: [string, BindableType][] = [
   ['display_list', tForAll(tAny)],
   ['draw_data', tForAll(tAny)],
   ['equal', tFunc(tAny, tAny, tBool)]
+]
+
+export const source3TypeOverrides: [string, BindableType][] = [
+  // array functions
+  ['array_length', tFunc(tArray(tAny), tNumber)],
+  // mutating pair functions
+  ['set_head', tFunc(tPair(tAny, tAny), tAny, tUndef)],
+  ['set_tail', tFunc(tPair(tAny, tAny), tAny, tUndef)],
+  // stream library functions
+  ['build_stream', tFunc(tFunc(tAny, tAny), tNumber, tPair(tAny, tFunc(tAny)))],
+  ['enum_stream', tFunc(tNumber, tNumber, tPair(tNumber, tFunc(tAny)))],
+  ['eval_stream', tFunc(tPair(tAny, tFunc(tAny)), tNumber, tList(tAny))],
+  ['integers_from', tFunc(tNumber, tPair(tNumber, tFunc(tAny)))],
+  ['list_to_stream', tFunc(tList(tAny), tPair(tAny, tFunc(tAny)))],
+  ['stream', tAny],
+  [
+    'stream_append',
+    tFunc(tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))
+  ],
+  ['stream_filter', tFunc(tFunc(tAny, tBool), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_for_each', tFunc(tFunc(tAny, tAny), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_length', tFunc(tPair(tAny, tFunc(tAny)), tNumber)],
+  ['stream_map', tFunc(tFunc(tAny, tAny), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_member', tFunc(tAny, tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_ref', tFunc(tPair(tAny, tFunc(tAny)), tNumber, tAny)],
+  ['stream_remove', tFunc(tAny, tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_remove_all', tFunc(tAny, tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_reverse', tFunc(tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_tail', tFunc(tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
+  ['stream_to_list', tFunc(tPair(tAny, tFunc(tAny)), tList(tAny))]
 ]
 
 const predeclaredConstTypes: [string, Type][] = [
@@ -453,6 +484,9 @@ export function getTypeOverrides(chapter: Chapter): [string, BindableType][] {
   const typeOverrides = [...source1TypeOverrides]
   if (chapter >= 2) {
     typeOverrides.push(...source2TypeOverrides)
+  }
+  if (chapter >= 3) {
+    typeOverrides.push(...source3TypeOverrides)
   }
   return typeOverrides
 }

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -123,6 +123,11 @@ export function formatTypeString(type: Type, formatAsLiteral?: boolean): string 
       )}>`
     case 'list':
       return `List<${formatTypeString(type.elementType, formatAsLiteral)}>`
+    case 'array':
+      const elementTypeString = formatTypeString(type.elementType, formatAsLiteral)
+      return elementTypeString.includes('|') || elementTypeString.includes('=>')
+        ? `(${elementTypeString})[]`
+        : `${elementTypeString}[]`
     default:
       return type.kind
   }


### PR DESCRIPTION
Changes:
-
- Added support for array types to type error checker.
- Added support for array access, variable reassignment and loops to type error checker.
- Added type checking for Source 3 library functions.
- Added tests for Source 3 Typed.

How to test:
-
1. Without frontend: Run Source 3 Typed in the js-slang REPL.
```
$ js-slang -c 3 -v typed # if js-slang is added to PATH
$ node dist/repl/repl.js -c 3 -v typed # if js-slang is not added to PATH
```
2. With frontend: [Link local js-slang to local frontend](https://github.com/source-academy/js-slang#using-your-js-slang-in-your-local-source-academy) and checkout local frontend to source-academy/frontend#2299.
3. Check the existing unit tests in `src/typeChecker/__tests__/source3Typed.test.ts`.
```
$ yarn test src/typeChecker/__tests__/source3Typed.test.ts
```