### PR TITLE
Add documentation and specs for Source 3 Typed

### DIFF
--- a/docs/md/README_3_TYPED.md
+++ b/docs/md/README_3_TYPED.md
@@ -1,8 +1,8 @@
-Source §2 Typed is a small programming language, designed for the first chapter
+Source §3 Typed is a small programming language, designed for the first chapter
 of the textbook
 <a href="https://sourceacademy.org/sicpjs">Structure and Interpretation
 of Computer Programs, JavaScript Adaptation</a> (SICP JS).
-Source §2 Typed introduces <EM>type syntax</EM> and <EM>type checking</EM>.
+Source §3 Typed introduces <EM>type syntax</EM> and <EM>type checking</EM>.
 
 ## What is static type checking?
 
@@ -12,18 +12,16 @@ while statically typed languages check types before the code is run (at compile 
 Though Source is a dynamically typed language, we can still introduce type checks
 that check the code for errors at compile time.
 
-## What can you do in Source §2 Typed?
+## What can you do in Source §3 Typed?
 
 You can use all features of
-<a href="../source_1_typed/">Source §1 Typed</a> and <a href="../source_2/">Source §2</a>, but with the following additional types:
+<a href="../source_2_typed/">Source §2 Typed</a> and <a href="../source_3/">Source §3</a>, but with the following additional types:
 
-- `null` types
-- Pair type (`Pair<headType, tailType>`): takes in two type parameters, head type and tail type
-- List type (`List<elemType>`): takes in one type parameter, element type
+- Array types, e.g. `number[]`, `(string | number)[]`
 
 ## You want the definitive specs?
 
 For our development team, we are maintaining a definitive description
 of the language, called the
-<a href="../source_2_typed.pdf">Specification of Source §2 Typed</a>.
+<a href="../source_3_typed.pdf">Specification of Source §3 Typed</a>.
 Feel free to take a peek!

--- a/docs/md/README_top.md
+++ b/docs/md/README_top.md
@@ -39,6 +39,8 @@ the members of our learning community.
 
 #### <a href="source_3_concurrent/">Source §3 Concurrent</a>
 
+#### <a href="source_3_typed/">Source §3 Typed</a>
+
 #### <a href="source_4_gpu/">Source §4 GPU</a>
 
 ### Specifications
@@ -67,6 +69,8 @@ the Source Academy.
 #### <a href="source_3_nondet.pdf">Specification of Source §3 Non-Det</a>
 
 #### <a href="source_3_concurrent.pdf">Specification of Source §3 Concurrent</a>
+
+#### <a href="source_3_typed.pdf">Specification of Source §3 Typed</a>
 
 #### <a href="source_4_gpu.pdf">Specification of Source §4 GPU</a>
 

--- a/docs/specs/Makefile
+++ b/docs/specs/Makefile
@@ -1,6 +1,6 @@
 PDFLATEX = latexmk -pdf
 
-SPECSNUMS = 1 1_lazy 1_wasm 1_type_inference 1_infinite_loop_detection 1_typed 2 2_lazy 2_typed 3_type_inference 3 3_nondet 3_concurrent 4 4_gpu styleguide 2_stepper studio_2
+SPECSNUMS = 1 1_lazy 1_wasm 1_type_inference 1_infinite_loop_detection 1_typed 2 2_lazy 2_typed 3_type_inference 3 3_nondet 3_concurrent 3_typed 4 4_gpu styleguide 2_stepper studio_2
 
 SPECS = $(SPECSNUMS:%=source_%)
 

--- a/docs/specs/source_3_typed.tex
+++ b/docs/specs/source_3_typed.tex
@@ -1,0 +1,64 @@
+\input source_header.tex
+
+\begin{document}
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+	\docheader{2022}{Source}{\S 3 Typed}{Martin Henz, Jingjing Zhao}
+	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\input source_intro.tex
+
+Source \S 3 Typed is a variant of Source \S 3 that introduces type syntax and type checking.
+
+\input source_bnf.tex
+
+\input source_3_typed_bnf.tex
+
+\input source_return
+
+\input source_import
+
+\input source_boolean_operators
+
+\input source_loops
+
+\input source_names_lang
+
+\input source_numbers
+
+\input source_strings
+
+\input source_arrays
+
+\input source_comments
+
+\input source_3_typed_typing.tex
+
+\input source_typing_3
+
+\section{Standard Libraries}
+
+The following libraries are always available in this language.
+
+\input source_misc
+
+\input source_math
+
+\input source_lists
+
+\input source_pair_mutators
+
+\input source_array_support
+
+\input source_streams
+
+\input source_js_differences
+
+\newpage
+
+\input source_list_library
+
+\newpage
+
+\input source_stream_library
+
+\end{document}

--- a/docs/specs/source_3_typed_bnf.tex
+++ b/docs/specs/source_3_typed_bnf.tex
@@ -1,0 +1,149 @@
+\addtolength{\jot}{-0.5mm}
+\begin{alignat*}{9}
+&& \textit{program}    &&\quad ::= &\quad && \textit{import-directive} ... \ \textit{statement} ...
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/3.1.1\#p6}{program}} \\[1mm]
+&& \textit{import-directive}    &&\quad ::= &\quad && \textbf{\texttt{import}}\ \textbf{\texttt{\{}}\ \textit{import-names} \ \textbf{\texttt{\}}}\ \textbf{\texttt{from}}\  \textit{string} \ \textbf{\texttt{;}}
+                                                           && \textrm{import directive} \\[1mm]
+&& \textit{import-names}   && ::= &\quad &&  \epsilon\ | \  \textit{import-name} \ 
+                                                   (\ \textbf{\texttt{,}} \ \textit{import-name}\ ) ...
+                                                            && \textrm{import name list}   \\[1mm]
+&& \textit{import-name}   && ::= &\quad &&  \textit{name}\ | \  \textit{name} \ \textbf{\texttt{as}}\ \textit{name} 
+                                                            && \textrm{import name}   \\[1mm]
+&& \textit{statement}    &&\quad ::= &\quad && \textbf{\texttt{const}}\  \textit{name}[\texttt{:}\ \textit{type}] \ 
+                                                            \textbf{\texttt{=}}\  \textit{expression} \ \textbf{\texttt{;}}
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.2\#p2}{constant declaration}} \\
+&&                       && |   &\quad && \textit{let} \ \textbf{\texttt{;}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/3.1.1\#p3}{variable declaration}} \\
+&&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
+                                                    \textbf{\texttt{(}}\  \textit{rest-names} \ \textbf{\texttt{)}}[\texttt{:}\ \textit{type}]\ \textit{block} \quad
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{function declaration}}\\
+&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name} \ 
+                                                           \textbf{\texttt{=}}\  \textit{type} \ \textbf{\texttt{;}} && \textrm{type alias declaration}\\
+&&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{return statement}}\\
+&&                       && |   &\quad && \textit{if-statement} \quad
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.3.2\#p13}{conditional statement}}\\
+&&                       && |   &\quad && \textbf{\texttt{while}}\  
+                                   \textbf{\texttt{(}}\  \textit{expression} \ \textbf{\texttt{)}} \
+                                   \textit{block}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/4.1.2\#ex_4.7}{while loop}}\\
+&&                       && |   &\quad && \textbf{\texttt{for}}\ \textbf{\texttt{(}} \ 
+                                          (\ \textit{\href{https://sourceacademy.org/sicpjs/4.1.2\#ex_4.8}{expression}}_1 \ | \  \textit{\href{https://sourceacademy.org/sicpjs/4.1.2\#ex_4.9}{let}}\ ) \textbf{\texttt{;}} \\
+&&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{expression}_2 \ \textbf{\texttt{;}} \\
+&&                       &&     &\quad && \ \ \ \ \ \ \ \ \ \ \textit{expression}_3 \ \textbf{\texttt{)}} \ 
+                                            \textit{block}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/4.1.2\#ex_4.8}{for loop}}\\
+&&                       && |   &\quad && \textbf{\texttt{break}}\ \textbf{\texttt{;}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/4.1.2\#ex_4.7}{break statement}}\\
+&&                       && |   &\quad && \textbf{\texttt{continue}}\ \textbf{\texttt{;}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/4.1.2\#ex_4.7}{continue statement}}\\
+&&                       && |   &\quad &&  \textit{block} 
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.8\#p14}{block statement}}\\
+&&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{;}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p3}{expression statement}} \\
+&&                       && |   &\quad &&  \textbf{\texttt{debugger}} \ \textbf{\texttt{;}}
+                                                           && \textrm{breakpoint} \\[1mm]
+&& \textit{names}   && ::= &\quad &&  \epsilon\ | \  \textit{name}[\texttt{:}\ \textit{type}] \ 
+                                                   (\ \textbf{\texttt{,}} \ \textit{name}[\texttt{:}\ \textit{type}]\ ) ...
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{name list}}   \\[1mm]
+&& \textit{rest-names}   && ::= &\quad &&  \epsilon\ | \  \texttt{...} \textit{name} \ |  \ \textit{names}\ [\texttt{, ...}\textit{name}]
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{name list} (\href{https://sourceacademy.org/sicpjs/3.4.2\#p17}{rest})} \\[1mm]
+&& \textit{if-statement} && ::= &\quad &&  \textbf{\texttt{if}}\
+                                   \textbf{\texttt{(}}\ \textit{expression} \ \textbf{\texttt{)}}\ 
+                                   \textit{block} \\
+&&                       &&     &      && [ \ \textbf{\texttt{else}}\
+                                          (\ \textit{block}
+                                          \ | \
+                                          \textit{\href{https://sourceacademy.org/sicpjs/1.3.3\#footnote-1}{if-statement}} \ )\ ]
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.3.2\#p12}{conditional statement}} \\[1mm]
+&& \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement} ... \ \textbf{\texttt{\}}} \quad
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.8\#p14}{block statement}} \\[1mm]
+\end{alignat*}
+
+\begin{alignat*}{9}
+&& \textit{let}          && ::= &\quad &&  \textbf{\texttt{let}}\  \textit{name}[\texttt{:}\ \textit{type}] \ 
+                                           \textbf{\texttt{=}}\  \textit{expression} 
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/3.1.1\#p3}{variable declaration}} \\[1mm]
+&& \textit{assignment}   && ::= &\quad &&  \textit{name} \ 
+                                           \textbf{\texttt{=}}\  \textit{expression} 
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/3.1.1\#p4}{variable assignment}} \\
+&&                       && |   &\quad && \textit{expression} \textbf{\texttt{[}}
+                                          \textit{expression} \textbf{\texttt{]}} \ 
+                                           \textbf{\texttt{=}}\  \textit{expression} 
+                                                           && \textrm{array assignment} \\[1mm]
+&& \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p3}{primitive number expression}}\\
+&&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p1}{primitive boolean expression}}\\
+&&                       && |   &\quad &&  \textit{string}   && \textrm{\href{https://sourceacademy.org/sicpjs/2.3.1}{primitive string expression}} \\
+&&                       && |   &\quad && \textbf{\texttt{null}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/2.2.1\#p1}{primitive list expression}} \\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.2}{name expression}} \\
+&&                       && |   &\quad &&  \textit{expression} \  \textit{binary-operator} \ 
+                                            \textit{expression} \qquad
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p5}{binary operator combination}} \\
+&&                       && |   &\quad &&   \textit{unary-operator} \ 
+                                            \textit{expression}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p4}{unary operator combination}}\\
+&&                       && |   &\quad &&  \textit{expression} \  \textit{binary-logical} \ 
+                                            \textit{expression} \qquad
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p5}{logical composition}}\\
+&&                       && |   &\quad &&   \textit{expression} \ 
+                                            \textbf{\texttt{(}}\ \textit{spread-expressions}\
+                                            \textbf{\texttt{)}}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p5}{function application}} \\
+&&                       && |   &\quad &&   (\ \textit{rest-names}\ )\
+                                            \texttt{\textbf{=>}}\ \textit{expression}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.3.2}{lambda expression (expr. body)}} \\
+&&                       && |   &\quad &&   (\ \textit{rest-names}\ )\ 
+                                            \texttt{\textbf{=>}}\ \textit{block}
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/2.2.4\#footnote-3}{lambda expression (block body)}} \\
+&&                       && |   &\quad &&   \textit{expression} \ \textbf{\texttt{?}}\ 
+                                            \textit{expression}
+                                            \ \textbf{\texttt{:}}\
+                                            \textit{expression}\
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p1}{conditional expression}} \\
+&&                       && |   &\quad && \textit{assignment} 
+                                                           && \textrm{assignment} \\
+&&                       && |   &\quad && \textit{expression} \textbf{\texttt{[}}
+                                          \textit{expression} \textbf{\texttt{]}}
+                                                           && \textrm{array access} \\
+&&                       && |   &\quad &&   \textbf{\texttt{[}}\ 
+                                            \textit{expressions}\
+                                            \textbf{\texttt{]}}
+                                                           && \textrm{literal array expression}\\
+&&                       && |   &\quad &&  \textbf{\texttt{(}}\  \textit{expression} \ 
+                                            \textbf{\texttt{)}} && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p6}{parenthesised expression}}\\
+&&                       && |   &\quad &&  \textit{expression} \ \textbf{\texttt{as}}\ \textit{type} && \textrm{as expression}\\[1mm]
+&& \textit{binary-operator}    \ 
+                        && ::= &\quad && \textbf{\texttt{+}}\ |\ \textbf{\texttt{-}}\ |\ \textbf{\texttt{*}}\ |\ \textbf{\texttt{/}}\ |\ \textbf{\texttt{\%}}\ |\ 
+                                   \textbf{\texttt{===}}\ |\ \textbf{\texttt{!==}}\ \\
+&&                       && |  &\quad &&  \texttt{\textbf{>}}\ |\ \texttt{\textbf{<}}\ |\ \texttt{\textbf{>=}}\ |\ \texttt{\textbf{<=}}
+                                          && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p4}{binary operator}}\\[1mm]
+&& \textit{unary-operator}    
+                        && ::= &\quad && \textbf{\texttt{!}}\ |\ \textbf{\texttt{-}}
+                        && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p4}{unary operator}}\\[1mm]          
+&& \textit{binary-logical}   && ::=  &\quad &&  \textbf{\texttt{\&\&}}\ |\ \texttt{\textbf{||}}
+                                          && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p5}{logical composition symbol}}\\[1mm]
+&& \textit{expressions}  && ::= &\quad && \epsilon\ | \ \textit{expression}\ (
+                                                               \ \textbf{\texttt{,}} \
+                                                                 \textit{expression} \ 
+                                                                      ) ...
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p5}{element expressions}}\\[1mm]
+&& \textit{spread-expressions}  && ::= &\quad && \epsilon\ | \ \textit{spread-expression}\ (
+                                                               \ \textbf{\texttt{,}} \
+                                                                 \textit{spread-expression} \ 
+                                                                      ) ...\quad
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p5}{argument expressions}}\\[1mm]
+&& \textit{spread-expression}  && ::= &\quad && \textit{expression} \ |\ 
+                                               \texttt{...}\ \textit{expression}
+                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p5}{argument expression} (\href{https://sourceacademy.org/sicpjs/3.4.2\#p17}{spread})}\\[1mm]
+&& \textit{type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
+&&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{null}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
+&&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{type reference}\\
+&&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{type} && \textrm{function type}\\
+&&                       && |   &\quad &&   \textit{type}\ \texttt{\textbf{|}}\ \textit{type} && \textrm{union type}\\
+&&                       && |   &\quad &&   \textit{Pair<type, type>} && \textrm{pair type}\\
+&&                       && |   &\quad &&   \textit{List<type>} && \textrm{list type}\\
+&&                       && |   &\quad &&   \textit{type[]} && \textrm{array type}\\
+\end{alignat*}

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -1,0 +1,457 @@
+\newcommand{\Rule}[2]{\genfrac{}{}{0.7pt}{}{{\setlength{\fboxrule}{0pt}\setlength{\fboxsep}{3mm}\fbox{$#1$}}}{{\setlength{\fboxrule}{0pt}\setlength{\fboxsep}{3mm}\fbox{$#2$}}}}
+
+\newcommand{\TruE}{\textbf{\texttt{true}}}
+\newcommand{\FalsE}{\textbf{\texttt{false}}}
+\newcommand{\AndOp}{\texttt{\&\&}}
+\newcommand{\OrOp}{\texttt{||}}
+\newcommand{\ThenOp}{\texttt{?}}
+\newcommand{\ElseOp}{\texttt{:}}
+\newcommand{\Rc}{\texttt{\}}}
+\newcommand{\Lc}{\texttt{\{}}
+\newcommand{\Rp}{\texttt{)}}
+\newcommand{\Lp}{\texttt{(}}
+\newcommand{\Fun}{\textbf{\texttt{function}}}
+\newcommand{\Let}{\textbf{\texttt{let}}}
+\newcommand{\Return}{\textbf{\texttt{return}}}
+\newcommand{\Const}{\textbf{\texttt{const}}}
+\newcommand{\If}{\textbf{\texttt{if}}}
+\newcommand{\Else}{\textbf{\texttt{else}}}
+\newcommand{\Bool}{\texttt{boolean}}
+\newcommand{\Number}{\texttt{number}}
+\newcommand{\String}{\texttt{string}}
+\newcommand{\Undefined}{\texttt{undefined}}
+\newcommand{\Null}{\texttt{null}}
+\newcommand{\Any}{\texttt{any}}
+\newcommand{\Void}{\texttt{void}}
+\newcommand{\Pred}{\textit{Pred}}
+\newcommand{\type}{\textit{type}}
+\newcommand{\polytype}{\textit{polytype}}
+\newcommand{\predtype}{\textit{predtype}}
+\newcommand{\ExtractPos}{\ensuremath{\textit{Extract}^+}}
+\newcommand{\ExtractNeg}{\ensuremath{\textit{Extract}^-}}
+
+\newtheorem{definition}{Definition}[section]
+
+\section{Type System}  
+
+In Source \S 3 Typed, the Source \S 3 syntax is expanded to include type syntax such as type annotations and type aliases.
+This allows names to be explicitly typed, and for type checks to be performed.
+
+Support for \texttt{typeof} operations is also added to Source \S 3 Typed.
+
+\subsection{Type Environment}
+
+In order to keep track of the type of names in a program, we define a
+\emph{type environment}, denoted by $\Gamma$. More
+formally,
+the partial function $\Gamma$ from names to types expresses a 
+context, in which a name $x$ is associated with type $\Gamma(x)$. 
+
+We define a relation $\Gamma[x \leftarrow t]\Gamma'$ on type environments 
+$\Gamma$, names $x$, types $t$, and type environments $\Gamma'$,
+which constructs a type environment that behaves like the 
+given one, except that the type of $x$ is $t$. More formally, 
+if $\Gamma[x \leftarrow t]\Gamma'$, then $\Gamma'(y)$ is $t$, 
+if $y=x$ and $\Gamma(y)$ 
+otherwise. Obviously, this uniquely identifies $\Gamma'$ for
+a given $\Gamma$, $x$, and $t$, and thus the type environment extension
+relation is functional in its first three arguments.
+
+The set of names, on which a type environment
+$\Gamma$ is defined, is called the domain of $\Gamma$, 
+denoted by $\textit{dom}(\Gamma)$.
+
+For each non-overloaded primitive operator, we add a binding to our initial
+type environment $\Gamma_0$ as follows:
+
+\begin{eqnarray*}
+& &
+       \emptyset[ -_2 \leftarrow  (\Number, \Number) \rightarrow \Number]\\
+&& \hspace{2mm} [ * \leftarrow  (\Number, \Number) \rightarrow \Number]\\
+&& \hspace{2mm} [ / \leftarrow  (\Number, \Number) \rightarrow \Number]\\
+&& \hspace{2mm} [ \% \leftarrow (\Number, \Number) \rightarrow \Number]\\
+&& \hspace{2mm} [ \&\& \leftarrow (\Bool, \texttt{T}) \rightarrow \Bool\ |\ \texttt{T}]\\
+&& \hspace{2mm} [ || \leftarrow   (\Bool, \texttt{T}) \rightarrow \Bool\ |\ \texttt{T}]\\
+&& \hspace{2mm} [ ! \leftarrow \Bool \rightarrow \Bool]\\
+&& \hspace{2mm} [ -_1 \leftarrow \Number \rightarrow \Number]\\
+&& \hspace{2mm} [ \texttt{typeof} \leftarrow \Any \rightarrow \String]\Gamma_{-2}
+\end{eqnarray*}
+
+The overloaded binary primitives are handled as follows:
+
+\begin{eqnarray*}
+ & &
+      \Gamma_{-2}
+                 [ \texttt{+} \leftarrow (\String,\ \String) \rightarrow \String\ |\ (\Number,\ \Number) \rightarrow \Number] \\
+&& \hspace{6mm}  [ \texttt{===} \leftarrow (\Any,\ \Any) \rightarrow \Bool] \\
+&& \hspace{6mm}  [ \texttt{!==} \leftarrow (\Any,\ \Any) \rightarrow \Bool] \\
+&& \hspace{6mm}  [ \texttt{>} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
+&& \hspace{6mm}  [ \texttt{>=} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
+&& \hspace{6mm}  [ \texttt{<} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
+&& \hspace{6mm}  [ \texttt{<=} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\Gamma_{-1}
+\end{eqnarray*}
+
+The Source \S 3 standard library functions and constants have their types defined as follows:
+
+\begin{tabular}[fragile]{lllllllll}
+$\Gamma_{-1}$
+& $[$ & \texttt{display}      & $\leftarrow$  & $\Any$ & & & $]$ \\
+& $[$ & \texttt{error}      & $\leftarrow$  & $\Any$ & & & $]$ \\
+& $[$ & \texttt{Infinity}      & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{is\_boolean}   & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{is\_function}  & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{is\_number}    & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{is\_string}    & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{is\_undefined} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{math\_abs} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_acos} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_acosh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_asin} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_asinh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_atan} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_atan2} & $\leftarrow$  & $(\Number, \Number)$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_atanh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_cbrt} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_ceil} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_clz32} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_cos} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_cosh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_exp} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_expm1} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_floor} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_fround} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_hypot} & $\leftarrow$  & $\Any$ & & & $]$ \\
+& $[$ & \texttt{math\_imul} & $\leftarrow$  & $(\Number, \Number)$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_LN2} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_LN10} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_log} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_log1p} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_log2} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_LOG2E} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_log10} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_LOG10E} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_max} & $\leftarrow$  & $\Any$ & & & $]$ \\
+& $[$ & \texttt{math\_min} & $\leftarrow$  & $\Any$ & & & $]$ \\
+& $[$ & \texttt{math\_PI} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_pow} & $\leftarrow$  & $(\Number, \Number)$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_random} & $\leftarrow$  & $()$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_round} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& \end{tabular}
+
+\begin{tabular}[fragile]{lllllllll}
+& $[$ & \texttt{math\_sign} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_sin} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_sinh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_sqrt} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_SQRT1\_2} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_SQRT2} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{math\_tan} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_tanh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{math\_trunc} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{NaN} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& $[$ & \texttt{parse\_int} & $\leftarrow$  & $(\String, \Number)$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{prompt} & $\leftarrow$  & $\String$ & $\rightarrow$ & $\String$ & $]$ \\
+& $[$ & \texttt{get\_time} & $\leftarrow$  & $()$ & $\rightarrow$ & $\Number$ & $]$ \\
+& $[$ & \texttt{stringify} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\String$ & $]$ \\
+& $[$ & \texttt{undefined} & $\leftarrow$  & $\Undefined$ & & & $]$ \\
+& $[$ & \texttt{null}      & $\leftarrow$  & $\Null$ & & & $]$ \\
+& $[$ & \texttt{pair} & $\leftarrow$  & $(T_1,\ T_2)$ & $\rightarrow$ & \textit{Pair<} $T_1,\ T_2$ \textit{>} & $]$ \\
+& $[$ & \texttt{head} & $\leftarrow$  & \textit{Pair<} $T_1,\ T_2$ \textit{>} & $\rightarrow$ & $T_1$ & $]$ \\
+& $[$ & \texttt{tail} & $\leftarrow$  & \textit{Pair<} $T_1,\ T_2$ \textit{>} & $\rightarrow$ & $T_2$ & $]$ \\
+& $[$ & \texttt{list} & $\leftarrow$  & $(T_1, \ldots, T_n)$ & $\rightarrow$ & \textit{List<} $T_1\ |\ \ldots\ |\ T_n$ \textit{>} & $]$ \\
+& $[$ & \texttt{is\_pair} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{is\_null} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{is\_list} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{set\_head} & $\leftarrow$  & \textit{Pair<} $T_1,\ T_2$ \textit{>} & $\rightarrow$ & $\Undefined$ & $]$ \\
+& $[$ & \texttt{set\_tail} & $\leftarrow$  & \textit{Pair<} $T_1,\ T_2$ \textit{>} & $\rightarrow$ & $\Undefined$ & $]$ \\
+& $[$ & \texttt{is\_array} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
+& $[$ & \texttt{array\_length} & $\leftarrow$  & $\Any$[] & $\rightarrow$ & $\Number$ & $]$ $\Gamma_0$ \\
+& \end{tabular}
+
+\subsection{Subtyping}
+
+In order for type checks to be performed in Source \S 3 Typed, we introduce the notion of subtyping.
+
+\begin{definition}
+$t \subseteq t'$ is used to denote that type $t$ is a subtype of type $t'$.
+\end{definition}
+
+Subtyping is illustrated using the following type rules:
+
+\noindent
+\[
+\Rule{}{t \subseteq \Any}
+\qquad
+\Rule{t'\ \textit{is a basic type} \quad t\ \textit{is a basic type} \quad t' = t}{t' \subseteq t}
+\]
+\noindent
+\[
+\Rule{t'\ \textit{is a literal type} \quad t\ \textit{is a basic type} \quad \texttt{typeof}\ t' = t}{t' \subseteq t}
+\]
+\noindent
+\[
+\Rule{(\forall 1 \leq i \leq n)(t_i \subseteq t'_i) \quad t' \subseteq t}{(t'_1, \ldots t'_n) \rightarrow t' \subseteq (t_1, \ldots t_n) \rightarrow t}
+\qquad
+\Rule{(\exists i)(t' \subseteq t_i)}{t'\ \subseteq\ t_1\ |\ \ldots\ |\ t_n}
+\]
+\noindent
+\[
+\Rule{t' = \textit{Pair<}\ t'_{head}, t'_{tail}\ \textit{>} \quad t = \textit{Pair<}\ t_{head}, t_{tail}\ \textit{>}
+  \quad t'_{head} \subseteq t_{head} \quad t'_{tail} \subseteq t_{tail}}{t' \subseteq t}
+\]
+\noindent
+\[
+\Rule{t' = \textit{List<}\ t'_{elem}\ \textit{>} \quad t = \textit{List<}\ t_{elem}\ \textit{>}
+  \quad t'_{elem} \subseteq t_{elem}}{t' \subseteq t}
+\qquad
+\Rule{t' = \Null \quad t = \textit{List<}\ t_{elem}\ \textit{>}}{t' \subseteq t}
+\]
+\noindent
+\[
+\Rule{t' = \textit{Pair<}\ t'_{head}, t'_{tail}\ \textit{>} \quad t = \textit{List<}\ t_{elem}\ \textit{>}
+  \quad t'_{head} \subseteq t_{elem} \quad t'_{tail} \subseteq t}{t' \subseteq t}
+\]
+\noindent
+\[
+\Rule{t' = \textit{List<}\ t'_{elem}\ \textit{>} \quad t = \textit{Pair<}\ t_{head}, t_{tail}\ \textit{>}
+  \quad t'_{elem} \subseteq t_{head} \quad t' \subseteq t_{tail}}{t' \subseteq t}
+\]
+\noindent
+\[
+\Rule{t' = t'_{elem}[] \quad t = t_{elem}[] \quad t'_{elem} \subseteq t_{elem}}{t' \subseteq t}
+\]
+\noindent
+
+\subsection{Typing Relations}
+
+To perform type checking on the program, typing relations are applied to every statement and expression in the program.
+
+Note that a name that is declared to be of type $t$ will always refer to values of a type $t'$ such that $t' \subseteq t$ at runtime.
+Names that do not have a type declared will be assumed to have the $any$ type; the $any$ type will not ever produce any type errors.
+
+\subsubsection{Typing Relations on Expressions}
+
+The derived type of primitive expressions is their literal type, which is always a subtype of its corresponding basic type.
+
+\noindent
+\[
+  \Rule{}{\Gamma \vdash n : \textit{literal type}\ n}
+  \quad
+  \Rule{}{\Gamma \vdash s : \textit{literal type}\ s}
+\]
+\noindent
+
+where $n$ denotes any literal number and $s$ denotes any literal string.
+
+\noindent
+\[
+  \Rule{}{\Gamma \vdash \TruE : \textit{literal type}\ \TruE}
+  \quad
+  \Rule{}{\Gamma \vdash \FalsE : \textit{literal type}\ \FalsE}
+\]
+\noindent
+
+For names, the type must be derived from the type environment.
+
+\noindent
+\[
+  \Rule{}{\Gamma \vdash x : \Gamma(x)}
+\]
+\noindent
+
+For function applications (including applications of binary and unary operators), the following two type rules are used, depending on the type of $E_0$.
+
+\noindent
+\[
+\Rule{\Gamma \vdash E_0 : (t_1, \ldots, t_n) \rightarrow t \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
+  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq t_i \vee t'_i = \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
+  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+\]
+\noindent
+
+The type of the operator must be a function type with the right number of parameters,
+and the type of every argument must be a subtype of the corresponding parameter type of the function type.
+If all these conditions are met, the type of the function application is the same
+as the return type of the function type that is the type of the operator.
+If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+
+For lambda expressions, we extend $\Gamma$ with the declared types of all the function parameters,
+and check the type of the function body against the declared return type.
+As type syntax is optional, if type annotations are absent for any of the arguments or the return type, the type is assumed to be $\Any$.
+The type of the lambda expression is then the function type with the declared types of the parameters and the return type. 
+
+\noindent
+\[
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \subseteq t \vee t' = \Any}{
+    \Gamma \vdash ( \Lp  x_1:\ t_1, \ldots, x_n:\ t_n \Rp :\ t\ \texttt{=>}\ \Lc\ S\ \Rc) : (t_1, \ldots, t_n) \rightarrow t}  
+\]
+\noindent
+
+The type of a conditional expression is the union of the type of its consequent expression and its alternate expression.
+The predicate expression of a conditional expression must be a subtype of a boolean.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash E_{cons} : t_{cons} \quad \Gamma \vdash E_{alt} : t_{alt}
+    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
+\]
+\noindent
+
+The type of a literal array expression is the union of the types of all of the array's members.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_1 : t_1, \ldots, \Gamma \vdash E_n : t_n}{
+    \Gamma \vdash [E_1, \ldots, E_n] : (t_1\ |\ \ldots\ |\ t_n)[]}
+\]
+\noindent
+
+The type of an array access expression is the member type of the array. The array index must be a number.
+If the type of the array being accessed is $\Any$, the type of the array access expression is $\Any$.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0[] \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number \vee t_1 = \Any}{
+    \Gamma \vdash E_0[E_1] : t_0}
+  \quad
+  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number \vee t_1 = \Any}{
+    \Gamma \vdash E_0[E_1] : \Any}
+\]
+\noindent
+
+For as expressions, the type to cast the expression to must be a subtype of the type of the expression.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E : t' \quad t \subseteq t'}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
+\]
+\noindent
+
+\subsubsection{Typing Relations on Assignments}
+
+For assignments, the type of the right expression must be a subtype of the type of the left expression.
+The type of the assignment itself is $\Undefined$.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq t_0 \vee t_1 = \Any}{
+    \Gamma \vdash (E_0 = E_1) : \Undefined}
+\]
+\noindent
+
+\subsubsection{Typing Relations on Statements}
+
+For constant or variable declarations, the declared type of $x$, $t$, is added to the type environment.
+As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
+The derived type of the expression $E$ must be a subtype of the type declared for name $x$.
+The type of the constant declaration statement itself is $\Undefined$.
+
+\noindent
+\[
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \subseteq t \vee t' = \Any}{
+    \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+  \qquad
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \subseteq t \vee t' = \Any}{
+    \Gamma \vdash (\texttt{let}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+\]
+\noindent
+
+For type alias declarations, the declared type of $x$, $t$, is added to the type environment.
+The type of the type alias declaration itself is $\Undefined$.
+
+\noindent
+\[
+  \Rule{\Gamma [x \leftarrow t] \Gamma'}{\Gamma \vdash (\texttt{type}\ x = t\texttt{;}) : \Undefined}
+\]
+\noindent
+
+The type of return statements and expression statements is the type of the expression in the statement.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E : t}{\Gamma \vdash (\texttt{return}\ E\texttt{;}) : t}
+  \quad
+  \Rule{\Gamma \vdash E : t}{\Gamma \vdash (E\texttt{;}) : t}
+\]
+\noindent
+
+The type of break and continue statements is $\Undefined$.
+
+\noindent
+\[
+  \Rule{}{\Gamma \vdash (\texttt{break} \texttt{;}) : \Undefined}
+  \quad
+  \Rule{}{\Gamma \vdash (\texttt{continue} \texttt{;}) : \Undefined}
+\]
+\noindent
+
+For blocks, $\Gamma$ is first extended to include the types of names declared in the block.
+Then, the component statements are checked against the extended type environment.
+
+We assume that whenever there is a return statement or a conditional statement with a return statement within a
+block, it is the last statement in the block. (One could consider a ``dead code'' error otherwise.)
+
+The type of a function body block is the type of the return statement in the block.
+If the block does not contain any return statements, the type is $\Undefined$.
+
+\noindent
+\[
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
+    \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is a return statement}}{
+    \Gamma \vdash \{ (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
+    S_1, \ldots, S_n\} : t'_n}
+\]
+\noindent
+\[
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
+    \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is not a return statement}}{
+    \Gamma \vdash \{ (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1 \texttt{;}) \ldots (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
+    S_1, \ldots, S_n\} : \Undefined}
+\]
+\noindent
+
+The type of a block outside of function bodies is the type of the last value-producing statement in the block.
+
+\noindent
+\[
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
+    \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is the last value-producing statement}}{
+    \Gamma \vdash \{ (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
+    S_1, \ldots, S_n\} : t'_n}
+\]
+\noindent
+
+The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
+The predicate expression of a conditional statement must be a subtype of a boolean.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash S_{pred} : t_{pred} \quad \Gamma \vdash S_{cons} : t_{cons} \quad \Gamma \vdash S_{alt} : t_{alt}
+    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
+    \texttt{else}\ \{\ S_{alt}\ \}) : t_{cons}\ |\ t_{alt}}
+\]
+\noindent
+
+For \texttt{while} statements, the predicate expression must be a subtype of $\Bool$. The rest of the statement is treated as a block.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash S : t \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any }{
+    \Gamma \vdash (\texttt{while}\ (\ E_{pred}\ )\ \{\ S\ \}) : t}
+\]
+\noindent
+
+For \texttt{for} statements, the typing is the same as that of a \texttt{while} statement,
+except with additional type checks for the initialization and assignment expressions.
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_{init} : t_{init} \quad \Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash E_{assign} : t_{assign} \quad
+    \Gamma \vdash S : t \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any }{
+    \Gamma \vdash (\texttt{for}\ (\ E_{init} \texttt{;} E_{pred} \texttt{;} E_{assign}\ )\ \{\ S\ \}) : t}
+\]
+\noindent

--- a/scripts/jsdoc.sh
+++ b/scripts/jsdoc.sh
@@ -137,6 +137,18 @@ run() {
 	     ${LIB}/pairmutator.js \
 		 ${LIB}/non-det.js
     
+	# Source §3 Typed
+    
+    ${JSDOC} -r -t ${TMPL} \
+	     -c docs/jsdoc/conf.json \
+	     -R ${MD}/README_3_TYPED.md \
+	     -d ${DST}/"source_3_typed"/ \
+	     ${LIB}/misc.js \
+	     ${LIB}/math.js \
+         ${LIB}/list.js \
+	     ${LIB}/stream.js \
+	     ${LIB}/array.js \
+	     ${LIB}/pairmutator.js
     
     # Source §4
     


### PR DESCRIPTION
Adds pages on Source 3 Typed to the SA docs website, including the detailed specifications.

To be merged after #1327.

How to test: Follow the instructions on [building the documentation](https://github.com/source-academy/js-slang#documentation), then check the PDF specs and docs website generated. The specs and docs can be checked against #1327 to ensure that the behavior is consistent in both documentation and implementation.