### PR TITLE
Add Source 4 Typed variant; modify typechecking for + operator

### DIFF
--- a/docs/specs/source_1_typed_typing.tex
+++ b/docs/specs/source_1_typed_typing.tex
@@ -76,13 +76,13 @@ type environment $\Gamma_0$ as follows:
 && \hspace{2mm} [ \texttt{typeof} \leftarrow \Any \rightarrow \String]\Gamma_{-2}
 \end{eqnarray*}
 
-The overloaded binary primitives are handled as follows:
+The overloaded binary primitives (with the exception of \texttt{+}, the handling of which will be elaborated in \nameref{typing-rules})
+are handled as follows:
 
 \begin{eqnarray*}
  & &
       \Gamma_{-2}
-                 [ \texttt{+} \leftarrow (\String,\ \String) \rightarrow \String\ |\ (\Number,\ \Number) \rightarrow \Number] \\
-&& \hspace{6mm}  [ \texttt{===} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
+                 [ \texttt{===} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
 && \hspace{6mm}  [ \texttt{!==} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
 && \hspace{6mm}  [ \texttt{>} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
 && \hspace{6mm}  [ \texttt{>=} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
@@ -184,6 +184,7 @@ Subtyping is illustrated using the following type rules:
 \noindent
 
 \subsection{Typing Relations}
+\label{typing-rules}
 
 To perform type checking on the program, typing relations are applied to every statement and expression in the program.
 
@@ -239,6 +240,45 @@ and the type of every argument must be a subtype of the corresponding parameter 
 If all these conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
 If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+
+Applications of binary and unary operators are treated the same as function applications, with the exception of the \texttt{+} operator.
+For the \texttt{+} operator, the following rules are applied, in order of priority:
+
+\begin{itemize}
+\item{If the expression on either side is of type $\String$ or literal string type,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on either side is of type $\Number$ or literal number type,
+  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
+\item{If neither expression can be narrowed to either $\String$ or $\Number$, check that both sides are subtypes of 
+  $\String\ |\ \Number$. The return type is $\Any$.}
+\end{itemize}
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
+    \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
+    \quad t_0 \subseteq \Number \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\String\ |\ \Number) \vee t_0 = \Any
+    \quad t_1 \subseteq (\String\ |\ \Number) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+\]
+\noindent
 
 For lambda expressions, we extend $\Gamma$ with the declared types of all the function parameters,
 and check the type of the function body against the declared return type.

--- a/docs/specs/source_2_typed_typing.tex
+++ b/docs/specs/source_2_typed_typing.tex
@@ -77,13 +77,13 @@ type environment $\Gamma_0$ as follows:
 && \hspace{2mm} [ \texttt{typeof} \leftarrow \Any \rightarrow \String]\Gamma_{-2}
 \end{eqnarray*}
 
-The overloaded binary primitives are handled as follows:
+The overloaded binary primitives (with the exception of \texttt{+}, the handling of which will be elaborated in \nameref{typing-rules})
+are handled as follows:
 
 \begin{eqnarray*}
  & &
       \Gamma_{-2}
-                 [ \texttt{+} \leftarrow (\String,\ \String) \rightarrow \String\ |\ (\Number,\ \Number) \rightarrow \Number] \\
-&& \hspace{6mm}  [ \texttt{===} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
+                 [ \texttt{===} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
 && \hspace{6mm}  [ \texttt{!==} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool] \\
 && \hspace{6mm}  [ \texttt{>} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
 && \hspace{6mm}  [ \texttt{>=} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
@@ -215,6 +215,7 @@ Subtyping is illustrated using the following type rules:
 \noindent
 
 \subsection{Typing Relations}
+\label{typing-rules}
 
 To perform type checking on the program, typing relations are applied to every statement and expression in the program.
 
@@ -270,6 +271,45 @@ and the type of every argument must be a subtype of the corresponding parameter 
 If all these conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
 If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+
+Applications of binary and unary operators are treated the same as function applications, with the exception of the \texttt{+} operator.
+For the \texttt{+} operator, the following rules are applied, in order of priority:
+
+\begin{itemize}
+\item{If the expression on either side is of type $\String$ or literal string type,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on either side is of type $\Number$ or literal number type,
+  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
+\item{If neither expression can be narrowed to either $\String$ or $\Number$, check that both sides are subtypes of 
+  $\String\ |\ \Number$. The return type is $\Any$.}
+\end{itemize}
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
+    \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
+    \quad t_0 \subseteq \Number \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\String\ |\ \Number) \vee t_0 = \Any
+    \quad t_1 \subseteq (\String\ |\ \Number) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+\]
+\noindent
 
 For lambda expressions, we extend $\Gamma$ with the declared types of all the function parameters,
 and check the type of the function body against the declared return type.

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -77,13 +77,13 @@ type environment $\Gamma_0$ as follows:
 && \hspace{2mm} [ \texttt{typeof} \leftarrow \Any \rightarrow \String]\Gamma_{-2}
 \end{eqnarray*}
 
-The overloaded binary primitives are handled as follows:
+The overloaded binary primitives (with the exception of \texttt{+}, the handling of which will be elaborated in \nameref{typing-rules})
+are handled as follows:
 
 \begin{eqnarray*}
  & &
       \Gamma_{-2}
-                 [ \texttt{+} \leftarrow (\String,\ \String) \rightarrow \String\ |\ (\Number,\ \Number) \rightarrow \Number] \\
-&& \hspace{6mm}  [ \texttt{===} \leftarrow (\Any,\ \Any) \rightarrow \Bool] \\
+                 [ \texttt{===} \leftarrow (\Any,\ \Any) \rightarrow \Bool] \\
 && \hspace{6mm}  [ \texttt{!==} \leftarrow (\Any,\ \Any) \rightarrow \Bool] \\
 && \hspace{6mm}  [ \texttt{>} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
 && \hspace{6mm}  [ \texttt{>=} \leftarrow (\String,\ \String) \rightarrow \Bool\ |\ (\Number,\ \Number) \rightarrow \Bool]\\
@@ -223,6 +223,7 @@ Subtyping is illustrated using the following type rules:
 \noindent
 
 \subsection{Typing Relations}
+\label{typing-rules}
 
 To perform type checking on the program, typing relations are applied to every statement and expression in the program.
 
@@ -278,6 +279,45 @@ and the type of every argument must be a subtype of the corresponding parameter 
 If all these conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
 If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+
+Applications of binary and unary operators are treated the same as function applications, with the exception of the \texttt{+} operator.
+For the \texttt{+} operator, the following rules are applied, in order of priority:
+
+\begin{itemize}
+\item{If the expression on either side is of type $\String$ or literal string type,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on either side is of type $\Number$ or literal number type,
+  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
+\item{If neither expression can be narrowed to either $\String$ or $\Number$, check that both sides are subtypes of 
+  $\String\ |\ \Number$. The return type is $\Any$.}
+\end{itemize}
+
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
+    \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
+    \quad t_0 \subseteq \Number \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\String\ |\ \Number) \vee t_0 = \Any
+    \quad t_1 \subseteq (\String\ |\ \Number) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+\]
+\noindent
 
 For lambda expressions, we extend $\Gamma$ with the declared types of all the function parameters,
 and check the type of the function body against the declared return type.

--- a/src/typeChecker/__tests__/source1Typed.test.ts
+++ b/src/typeChecker/__tests__/source1Typed.test.ts
@@ -656,11 +656,11 @@ describe('binary operations', () => {
       const x12: number = x1 + x4; // no error, number + any, return type number
       const x13: string = x5 + x2; // no error, any + string, return type string
       const x14: string = x1 + x2; // error, number + string, return type string
-      const x15: string = x4 + x5; // error, any + any, return type number | string
-      const x16: number | string = x6 + x4; // no error, string | number + any, return type number | string
+      const x15: string = x4 + x5; // no error, any + any, return type any
+      const x16: number | string = x6 + x4; // no error, string | number + any, return type any
       const x17: number = x1 + x6; // error, number + string | number, return type number
       const x18: string = x6 + x2; // error, string | number + string, return type string
-      const x19: string | number = x5 + x7; // error, any + string | boolean, return type string | number
+      const x19: string | number = x5 + x7; // error, any + string | boolean, return type any
     `
 
     parse(code, context)
@@ -668,7 +668,6 @@ describe('binary operations', () => {
       "Line 10: Type 'boolean' is not assignable to type 'number'.
       Line 11: Type 'boolean' is not assignable to type 'string'.
       Line 14: Type 'string' is not assignable to type 'number'.
-      Line 15: Type 'number | string' is not assignable to type 'string'.
       Line 17: Type 'string | number' is not assignable to type 'number'.
       Line 18: Type 'string | number' is not assignable to type 'string'.
       Line 19: Type 'string | boolean' is not assignable to type 'number | string'."

--- a/src/typeChecker/__tests__/source4Typed.test.ts
+++ b/src/typeChecker/__tests__/source4Typed.test.ts
@@ -1,0 +1,23 @@
+import { parseError } from '../..'
+import { mockContext } from '../../mocks/context'
+import { parse } from '../../parser/parser'
+import { Chapter, Variant } from '../../types'
+
+let context = mockContext(Chapter.SOURCE_4, Variant.TYPED)
+
+beforeEach(() => {
+  context = mockContext(Chapter.SOURCE_4, Variant.TYPED)
+})
+
+describe('parse', () => {
+  it('takes in string', () => {
+    const code = `const x1 = parse('1;');
+      const x2 = parse(1);
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 2: Type 'number' is not assignable to type 'string'."`
+    )
+  })
+})

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -667,10 +667,10 @@ function typeCheckAndReturnBinaryExpressionType(
         return rightType
       }
 
-      // Return type is number | string if both left and right are neither number nor string
+      // Return type is any if both left and right are neither number nor string
       checkForTypeMismatch(node, leftType, tUnion(tNumber, tString), context)
       checkForTypeMismatch(node, rightType, tUnion(tNumber, tString), context)
-      return tUnion(tNumber, tString)
+      return tAny
     case '<':
     case '<=':
     case '>':

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -446,6 +446,13 @@ export const source3TypeOverrides: [string, BindableType][] = [
   ['stream_to_list', tFunc(tPair(tAny, tFunc(tAny)), tList(tAny))]
 ]
 
+export const source4TypeOverrides: [string, BindableType][] = [
+  ['apply_in_underlying_javascript', tFunc(tAny, tList(tAny), tAny)],
+  ['tokenize', tFunc(tString, tList(tString))],
+  // TODO: Define types for parse tree
+  ['parse', tFunc(tString, tAny)]
+]
+
 const predeclaredConstTypes: [string, Type][] = [
   ['Infinity', tLiteral(Infinity)],
   ['NaN', tLiteral(NaN)],
@@ -487,6 +494,9 @@ export function getTypeOverrides(chapter: Chapter): [string, BindableType][] {
   }
   if (chapter >= 3) {
     typeOverrides.push(...source3TypeOverrides)
+  }
+  if (chapter >= 4) {
+    typeOverrides.push(...source4TypeOverrides)
   }
   return typeOverrides
 }


### PR DESCRIPTION
Adds support for Source 4 predeclared functions to Source Typed. The `parse` function is typed loosely for now; a separate PR will be made down the line to add support for Source 4 parse tree types. Tests and documentation will also only be added once the parse tree types are added.

Also included in the PR is a modification to the behavior of the `+` operator. The new behavior is as follows:
- If the expression on either side is `string` primitive/literal type, check that the other expression is a subtype of `string`, then return type `string`.
- If the expression on either side is `number` primitive/literal type, check that the other expression is a subtype of `number`, then return type `number`.
- If neither expression can be narrowed to either `string` or `number`, check that both sides are subtypes of `string | number`, then return type `any`.

Specs for Source Typed 1-3 have also been updated accordingly.