### PR TITLE
Prepend underscore to unused arguments

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -417,8 +417,7 @@ const defaultBuiltIns: CustomBuiltIns = {
   prompt: misc.rawDisplay,
   // See issue #11
   alert: misc.rawDisplay,
-  // TODO: 'v' is defined but never used
-  visualiseList: (v: Value) => {
+  visualiseList: (_v: Value) => {
     throw new Error('List visualizer is not enabled')
   }
 }

--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -38,7 +38,7 @@ export function HighlightRulesSelector(
   )[] = []
 ) {
   // @ts-ignore
-  function _SourceHighlightRules(acequire, exports, module) {
+  function _SourceHighlightRules(acequire, exports, _module) {
     'use strict'
 
     const oop = acequire('../lib/oop')
@@ -756,7 +756,7 @@ export function ModeSelector(
   const name = id.toString() + variant + external
 
   // @ts-ignore
-  function _Mode(acequire, exports, module) {
+  function _Mode(acequire, exports, _module) {
     'use strict'
 
     const oop = acequire('../lib/oop')

--- a/src/editors/ace/theme/source.ts
+++ b/src/editors/ace/theme/source.ts
@@ -9,7 +9,7 @@
  */
 
 // @ts-ignore
-function theme(acequire, exports, module) {
+function theme(acequire, exports, _module) {
   exports.isDark = true
   exports.cssClass = 'ace-source'
   exports.cssText =

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -85,12 +85,12 @@ export function findDeclarationNode(program: Node, identifier: Identifier): Node
           }
         }
       },
-      VariableDeclarator(node: VariableDeclarator, state: any, callback: WalkerCallback<any>) {
+      VariableDeclarator(node: VariableDeclarator, _state: any, _callback: WalkerCallback<any>) {
         if ((node.id as Identifier).name === identifier.name) {
           declarations.push(node.id)
         }
       },
-      ImportSpecifier(node: ImportSpecifier, state: any, callback: WalkerCallback<any>) {
+      ImportSpecifier(node: ImportSpecifier, _state: any, _callback: WalkerCallback<any>) {
         if ((node.imported as Identifier).name === identifier.name) {
           declarations.push(node.imported)
         }

--- a/src/gpu/__tests__/runtimeOk.ts
+++ b/src/gpu/__tests__/runtimeOk.ts
@@ -8,7 +8,7 @@ test('__createKernel with 1 loop returns correct result', () => {
     return 1
   }
   const arr: number[] = []
-  const f2 = function (i: any) {
+  const f2 = function (_i: any) {
     return 1
   }
   __createKernel(bounds, extern, f1, arr, f2)

--- a/src/infiniteLoops/__tests__/instrument.ts
+++ b/src/infiniteLoops/__tests__/instrument.ts
@@ -14,7 +14,7 @@ function mockFunctionsAndState() {
   const theState = undefined
   const functions = {}
   const returnFirst = (...args: any[]) => args[0]
-  const nothing = (...args: any[]) => {}
+  const nothing = (..._args: any[]) => {}
   functions[functionNames.nothingFunction] = nothing
   functions[functionNames.concretize] = returnFirst
   functions[functionNames.hybridize] = returnFirst

--- a/src/infiniteLoops/instrument.ts
+++ b/src/infiniteLoops/instrument.ts
@@ -124,7 +124,7 @@ function unshadowVariables(program: es.Node, predefined = {}) {
     },
     ArrowFunctionExpression: unshadowFunctionInner,
     FunctionExpression: unshadowFunctionInner,
-    Identifier(node: es.Identifier, s: undefined, callback: WalkerCallback<undefined>) {
+    Identifier(node: es.Identifier, _s: undefined, _callback: WalkerCallback<undefined>) {
       if (env[0][node.name]) {
         node.name = env[0][node.name]
       } else {
@@ -254,7 +254,7 @@ function hybridizeBinaryUnaryOperations(program: es.Node) {
 
 function hybridizeVariablesAndLiterals(program: es.Node) {
   recursive(program, true, {
-    Identifier(node: es.Identifier, state: boolean, callback: WalkerCallback<boolean>) {
+    Identifier(node: es.Identifier, state: boolean, _callback: WalkerCallback<boolean>) {
       if (state) {
         create.mutateToCallExpression(node, callFunction(FunctionNames.hybridize), [
           create.identifier(node.name),
@@ -263,7 +263,7 @@ function hybridizeVariablesAndLiterals(program: es.Node) {
         ])
       }
     },
-    Literal(node: es.Literal, state: boolean, callback: WalkerCallback<boolean>) {
+    Literal(node: es.Literal, state: boolean, _callback: WalkerCallback<boolean>) {
       if (state && (typeof node.value === 'boolean' || typeof node.value === 'number')) {
         create.mutateToCallExpression(node, callFunction(FunctionNames.dummify), [
           create.literal(node.value)
@@ -544,8 +544,8 @@ function trackLocations(program: es.Program) {
   const stateExpr = create.identifier(globalIds.stateId)
   const doLoops = (
     node: es.ForStatement | es.WhileStatement,
-    state: undefined,
-    callback: WalkerCallback<undefined>
+    _state: undefined,
+    _callback: WalkerCallback<undefined>
   ) => {
     inPlaceEnclose(
       node.body,
@@ -555,7 +555,11 @@ function trackLocations(program: es.Program) {
     )
   }
   recursive(program, undefined, {
-    CallExpression(node: es.CallExpression, state: undefined, callback: WalkerCallback<undefined>) {
+    CallExpression(
+      node: es.CallExpression,
+      _state: undefined,
+      _callback: WalkerCallback<undefined>
+    ) {
       if (node.callee.type === 'MemberExpression') return
       const copy: es.CallExpression = { ...node }
       const lazyCall = create.arrowFunctionExpression([], copy)

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -269,7 +269,7 @@ function prepareBuiltins(oldBuiltins: Map<string, any>) {
   return newBuiltins
 }
 
-function nothingFunction(...args: any[]) {
+function nothingFunction(..._args: any[]) {
   return nothingFunction
 }
 

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -337,7 +337,7 @@ function* evaluateConditional(node: es.IfStatement | es.ConditionalExpression, c
 // prettier-ignore
 export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   /** Simple Values */
-  Literal: function*(node: es.Literal, context: Context) {
+  Literal: function*(node: es.Literal, _context: Context) {
     yield node.value
   },
 
@@ -496,11 +496,11 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return yield* evaluate(node.expression, context)
   },
 
-  ContinueStatement: function*(node: es.ContinueStatement, context: Context) {
+  ContinueStatement: function*(_node: es.ContinueStatement, _context: Context) {
     yield new ContinueValue()
   },
 
-  BreakStatement: function*(node: es.BreakStatement, context: Context) {
+  BreakStatement: function*(_node: es.BreakStatement, _context: Context) {
     yield new BreakValue()
   },
 

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -340,7 +340,7 @@ function* evaluateBlockStatement(context: Context, node: es.BlockStatement) {
 // prettier-ignore
 export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   /** Simple Values */
-  Literal: function*(node: es.Literal, context: Context) {
+  Literal: function*(node: es.Literal, _context: Context) {
     return node.value
   },
 
@@ -443,11 +443,11 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
     return undefined
   },
 
-  ContinueStatement: function*(node: es.ContinueStatement, context: Context) {
+  ContinueStatement: function*(_node: es.ContinueStatement, _context: Context) {
     return new ContinueValue()
   },
 
-  BreakStatement: function*(node: es.BreakStatement, context: Context) {
+  BreakStatement: function*(_node: es.BreakStatement, _context: Context) {
     return new BreakValue()
   },
 

--- a/src/name-extractor/index.ts
+++ b/src/name-extractor/index.ts
@@ -105,7 +105,7 @@ export function getKeywords(
   function addAllowedKeywords(keywords: { [key: string]: NameDeclaration[] }) {
     Object.entries(keywords)
       .filter(([nodeType]) => context.chapter >= syntaxBlacklist[nodeType])
-      .forEach(([nodeType, decl]) => keywordSuggestions.push(...decl))
+      .forEach(([_nodeType, decl]) => keywordSuggestions.push(...decl))
   }
 
   // The rest of the keywords are only valid at the beginning of a statement

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -246,7 +246,7 @@ function createWalkers(
   const syntaxPairs = Object.entries(allowedSyntaxes)
   syntaxPairs.map(pair => {
     const syntax = pair[0]
-    newWalkers.set(syntax, (node: es.Node, context: Context, ancestors: [es.Node]) => {
+    newWalkers.set(syntax, (node: es.Node, context: Context, _ancestors: [es.Node]) => {
       if (!visitedNodes.has(node)) {
         visitedNodes.add(node)
 

--- a/src/parser/rules/bracesAroundFor.ts
+++ b/src/parser/rules/bracesAroundFor.ts
@@ -32,7 +32,7 @@ const bracesAroundFor: Rule<es.ForStatement> = {
   name: 'braces-around-for',
 
   checkers: {
-    ForStatement(node: es.ForStatement, ancestors: [es.Node]) {
+    ForStatement(node: es.ForStatement, _ancestors: [es.Node]) {
       if (node.body.type !== 'BlockStatement') {
         return [new BracesAroundForError(node)]
       } else {

--- a/src/parser/rules/bracesAroundIfElse.ts
+++ b/src/parser/rules/bracesAroundIfElse.ts
@@ -72,7 +72,7 @@ const bracesAroundIfElse: Rule<es.IfStatement> = {
   name: 'braces-around-if-else',
 
   checkers: {
-    IfStatement(node: es.IfStatement, ancestors: [es.Node]) {
+    IfStatement(node: es.IfStatement, _ancestors: [es.Node]) {
       const errors: SourceError[] = []
       if (node.consequent && node.consequent.type !== 'BlockStatement') {
         errors.push(new BracesAroundIfElseError(node, 'consequent'))

--- a/src/parser/rules/bracesAroundWhile.ts
+++ b/src/parser/rules/bracesAroundWhile.ts
@@ -29,7 +29,7 @@ const bracesAroundWhile: Rule<es.WhileStatement> = {
   name: 'braces-around-while',
 
   checkers: {
-    WhileStatement(node: es.WhileStatement, ancestors: [es.Node]) {
+    WhileStatement(node: es.WhileStatement, _ancestors: [es.Node]) {
       if (node.body.type !== 'BlockStatement') {
         return [new BracesAroundWhileError(node)]
       } else {

--- a/src/parser/rules/noDeclareMutable.ts
+++ b/src/parser/rules/noDeclareMutable.ts
@@ -34,7 +34,7 @@ const noDeclareMutable: Rule<es.VariableDeclaration> = {
   disableFromChapter: Chapter.SOURCE_3,
 
   checkers: {
-    VariableDeclaration(node: es.VariableDeclaration, ancestors: [es.Node]) {
+    VariableDeclaration(node: es.VariableDeclaration, _ancestors: [es.Node]) {
       if (mutableDeclarators.includes(node.kind)) {
         return [new NoDeclareMutableError(node)]
       } else {

--- a/src/parser/rules/noDotAbbreviation.ts
+++ b/src/parser/rules/noDotAbbreviation.ts
@@ -28,7 +28,7 @@ const noDotAbbreviation: Rule<es.MemberExpression> = {
   disableFromChapter: Chapter.LIBRARY_PARSER,
 
   checkers: {
-    MemberExpression(node: es.MemberExpression, ancestors: [es.Node]) {
+    MemberExpression(node: es.MemberExpression, _ancestors: [es.Node]) {
       if (!node.computed) {
         return [new NoDotAbbreviationError(node)]
       } else {

--- a/src/parser/rules/noEval.ts
+++ b/src/parser/rules/noEval.ts
@@ -25,7 +25,7 @@ const noEval: Rule<es.Identifier> = {
   name: 'no-eval',
 
   checkers: {
-    Identifier(node: es.Identifier, ancestors: [es.Node]) {
+    Identifier(node: es.Identifier, _ancestors: [es.Node]) {
       if (node.name === 'eval') {
         return [new NoEval(node)]
       } else {

--- a/src/parser/rules/noIfWithoutElse.ts
+++ b/src/parser/rules/noIfWithoutElse.ts
@@ -33,7 +33,7 @@ const noIfWithoutElse: Rule<es.IfStatement> = {
   name: 'no-if-without-else',
   disableFromChapter: Chapter.SOURCE_3,
   checkers: {
-    IfStatement(node: es.IfStatement, ancestors: [es.Node]) {
+    IfStatement(node: es.IfStatement, _ancestors: [es.Node]) {
       if (!node.alternate) {
         return [new NoIfWithoutElseError(node)]
       } else {

--- a/src/parser/rules/noImplicitDeclareUndefined.ts
+++ b/src/parser/rules/noImplicitDeclareUndefined.ts
@@ -33,7 +33,7 @@ const noImplicitDeclareUndefined: Rule<es.VariableDeclaration> = {
   name: 'no-implicit-declare-undefined',
 
   checkers: {
-    VariableDeclaration(node: es.VariableDeclaration, ancestors: [es.Node]) {
+    VariableDeclaration(node: es.VariableDeclaration, _ancestors: [es.Node]) {
       const errors: SourceError[] = []
       for (const decl of node.declarations) {
         if (!decl.init) {

--- a/src/parser/rules/noImplicitReturnUndefined.ts
+++ b/src/parser/rules/noImplicitReturnUndefined.ts
@@ -31,7 +31,7 @@ const noImplicitReturnUndefined: Rule<es.ReturnStatement> = {
   name: 'no-implicit-return-undefined',
 
   checkers: {
-    ReturnStatement(node: es.ReturnStatement, ancestors: [es.Node]) {
+    ReturnStatement(node: es.ReturnStatement, _ancestors: [es.Node]) {
       if (!node.argument) {
         return [new NoImplicitReturnUndefinedError(node)]
       } else {

--- a/src/parser/rules/noNull.ts
+++ b/src/parser/rules/noNull.ts
@@ -25,7 +25,7 @@ const noNull: Rule<es.Literal> = {
   name: 'no-null',
   disableFromChapter: Chapter.SOURCE_2,
   checkers: {
-    Literal(node: es.Literal, ancestors: [es.Node]) {
+    Literal(node: es.Literal, _ancestors: [es.Node]) {
       if (node.value === null) {
         return [new NoNullError(node)]
       } else {

--- a/src/parser/rules/noTemplateExpression.ts
+++ b/src/parser/rules/noTemplateExpression.ts
@@ -25,7 +25,7 @@ const noTemplateExpression: Rule<es.TemplateLiteral> = {
   name: 'no-template-expression',
 
   checkers: {
-    TemplateLiteral(node: es.TemplateLiteral, ancestors: [es.Node]) {
+    TemplateLiteral(node: es.TemplateLiteral, _ancestors: [es.Node]) {
       if (node.expressions.length > 0) {
         return [new NoTemplateExpressionError(node)]
       } else {

--- a/src/parser/rules/noUnspecifiedLiteral.ts
+++ b/src/parser/rules/noUnspecifiedLiteral.ts
@@ -31,7 +31,7 @@ export class NoUnspecifiedLiteral implements SourceError {
 const noUnspecifiedLiteral: Rule<es.Literal> = {
   name: 'no-unspecified-literal',
   checkers: {
-    Literal(node: es.Literal, ancestors: [es.Node]) {
+    Literal(node: es.Literal, _ancestors: [es.Node]) {
       if (node.value !== null && !specifiedLiterals.includes(typeof node.value)) {
         return [new NoUnspecifiedLiteral(node)]
       } else {

--- a/src/parser/rules/noUnspecifiedOperator.ts
+++ b/src/parser/rules/noUnspecifiedOperator.ts
@@ -28,7 +28,7 @@ const noUnspecifiedOperator: Rule<es.BinaryExpression | es.UnaryExpression> = {
   name: 'no-unspecified-operator',
 
   checkers: {
-    BinaryExpression(node: es.BinaryExpression, ancestors: [es.Node]) {
+    BinaryExpression(node: es.BinaryExpression, _ancestors: [es.Node]) {
       const permittedOperators = [
         '+',
         '-',

--- a/src/parser/rules/noUpdateAssignment.ts
+++ b/src/parser/rules/noUpdateAssignment.ts
@@ -36,7 +36,7 @@ const noUpdateAssignment: Rule<es.AssignmentExpression> = {
   name: 'no-update-assignment',
 
   checkers: {
-    AssignmentExpression(node: es.AssignmentExpression, ancestors: [es.Node]) {
+    AssignmentExpression(node: es.AssignmentExpression, _ancestors: [es.Node]) {
       if (node.operator !== '=') {
         return [new NoUpdateAssignment(node)]
       } else {

--- a/src/parser/rules/noVar.ts
+++ b/src/parser/rules/noVar.ts
@@ -29,7 +29,7 @@ const noVar: Rule<es.VariableDeclaration> = {
   name: 'no-var',
 
   checkers: {
-    VariableDeclaration(node: es.VariableDeclaration, ancestors: [es.Node]) {
+    VariableDeclaration(node: es.VariableDeclaration, _ancestors: [es.Node]) {
       if (node.kind === 'var') {
         return [new NoVarError(node)]
       } else {

--- a/src/parser/rules/singleVariableDeclaration.ts
+++ b/src/parser/rules/singleVariableDeclaration.ts
@@ -35,7 +35,7 @@ const singleVariableDeclaration: Rule<es.VariableDeclaration> = {
   name: 'single-variable-declaration',
 
   checkers: {
-    VariableDeclaration(node: es.VariableDeclaration, ancestors: [es.Node]) {
+    VariableDeclaration(node: es.VariableDeclaration, _ancestors: [es.Node]) {
       if (node.declarations.length > 1) {
         return [new MultipleDeclarationsError(node)]
       } else {

--- a/src/parser/rules/strictEquality.ts
+++ b/src/parser/rules/strictEquality.ts
@@ -29,7 +29,7 @@ const strictEquality: Rule<es.BinaryExpression> = {
   name: 'strict-equality',
 
   checkers: {
-    BinaryExpression(node: es.BinaryExpression, ancestors: [es.Node]) {
+    BinaryExpression(node: es.BinaryExpression, _ancestors: [es.Node]) {
       if (node.operator === '==' || node.operator === '!=') {
         return [new StrictEqualityError(node)]
       } else {

--- a/src/schedulers.ts
+++ b/src/schedulers.ts
@@ -5,7 +5,7 @@ import { Context, Result, Scheduler, Value } from './types'
 
 export class AsyncScheduler implements Scheduler {
   public run(it: IterableIterator<Value>, context: Context): Promise<Result> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       context.runtime.isRunning = true
       let itValue = it.next()
       try {
@@ -37,7 +37,7 @@ export class AsyncScheduler implements Scheduler {
 
 export class NonDetScheduler implements Scheduler {
   public run(it: IterableIterator<Value>, context: Context): Promise<Result> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       try {
         const itValue = it.next()
         if (itValue.done) {
@@ -65,7 +65,7 @@ export class PreemptiveScheduler implements Scheduler {
   constructor(public steps: number) {}
 
   public run(it: IterableIterator<Value>, context: Context): Promise<Result> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       context.runtime.isRunning = true
       // This is used in the evaluation of the REPL during a paused state.
       // The debugger is turned off while the code evaluates just above the debugger statement.

--- a/src/stdlib/misc.ts
+++ b/src/stdlib/misc.ts
@@ -9,7 +9,7 @@ import { stringify } from '../utils/stringify'
  * @param externalContext a property of Context that can hold
  *   any information required for external use (optional).
  */
-export function rawDisplay(value: Value, str: string, externalContext: any) {
+export function rawDisplay(value: Value, str: string, _externalContext: any) {
   // tslint:disable-next-line:no-console
   console.log((str === undefined ? '' : str + ' ') + value.toString())
   return value

--- a/src/stdlib/parser.ts
+++ b/src/stdlib/parser.ts
@@ -270,14 +270,14 @@ const transformers: ASTTransformers = new Map([
 
   [
     'BreakStatement',
-    (node: es.BreakStatement) => {
+    (_node: es.BreakStatement) => {
       return vector_to_list(['break_statement'])
     }
   ],
 
   [
     'ContinueStatement',
-    (node: es.ContinueStatement) => {
+    (_node: es.ContinueStatement) => {
       return vector_to_list(['continue_statement'])
     }
   ],
@@ -425,14 +425,14 @@ const transformers: ASTTransformers = new Map([
 
   [
     'ThisExpression',
-    (node: es.ThisExpression) => {
+    (_node: es.ThisExpression) => {
       return vector_to_list(['this_expression'])
     }
   ],
 
   [
     'Super',
-    (node: es.Super) => {
+    (_node: es.Super) => {
       return vector_to_list(['super_expression'])
     }
   ],

--- a/src/transpiler/__tests__/modules.ts
+++ b/src/transpiler/__tests__/modules.ts
@@ -19,7 +19,7 @@ test('Transform import declarations into variable declarations', () => {
   `
   const context = mockContext(Chapter.SOURCE_4)
   const program = parse(code, context)!
-  const [_, importNodes] = transformImportDeclarations(program, new Set<string>())
+  const [, importNodes] = transformImportDeclarations(program, new Set<string>())
 
   expect(importNodes[0].type).toBe('VariableDeclaration')
   expect((importNodes[0].declarations[0].id as Identifier).name).toEqual('foo')
@@ -38,7 +38,7 @@ test('Transpiler accounts for user variable names when transforming import state
   `
   const context = mockContext(4)
   const program = parse(code, context)!
-  const [_, importNodes, [varDecl0, varDecl1]] = transformImportDeclarations(
+  const [, importNodes, [varDecl0, varDecl1]] = transformImportDeclarations(
     program,
     new Set<string>(['__MODULE_0__', '__MODULE_2__'])
   )

--- a/src/typeChecker/typeChecker.ts
+++ b/src/typeChecker/typeChecker.ts
@@ -513,7 +513,7 @@ function cannotBeResolvedIfAddable(LHS: Variable, RHS: Type): boolean {
   )
 }
 
-function downgradePredicateToFunction(type: PredicateType): FunctionType {
+function downgradePredicateToFunction(_type: PredicateType): FunctionType {
   return {
     kind: 'function',
     parameterTypes: [freshTypeVar(tVar('T'))],

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -66,15 +66,15 @@ export function createTestContext({
   } else {
     const testContext: TestContext = {
       ...createContext(chapter, variant, [], undefined, {
-        rawDisplay: (str1, str2, externalContext) => {
+        rawDisplay: (str1, str2, _externalContext) => {
           testContext.displayResult.push((str2 === undefined ? '' : str2 + ' ') + str1)
           return str1
         },
-        prompt: (str, externalContext) => {
+        prompt: (str, _externalContext) => {
           testContext.promptResult.push(str)
           return null
         },
-        alert: (str, externalContext) => {
+        alert: (str, _externalContext) => {
           testContext.alertResult.push(str)
         },
         visualiseList: value => {

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -51,7 +51,7 @@ export function validateAndAnnotate(
     BlockStatement: processBlock,
     FunctionDeclaration: processFunction,
     ArrowFunctionExpression: processFunction,
-    ForStatement(forStatement: es.ForStatement, ancestors: es.Node[]) {
+    ForStatement(forStatement: es.ForStatement, _ancestors: es.Node[]) {
       const init = forStatement.init!
       if (init.type === 'VariableDeclaration') {
         accessedBeforeDeclarationMap.set(

--- a/src/vm/svml-compiler.ts
+++ b/src/vm/svml-compiler.ts
@@ -311,7 +311,7 @@ function renameVariables(
   }
 
   recursive(baseNode, new Set<string>(), {
-    VariablePattern(node: es.Identifier, inactive, c) {
+    VariablePattern(node: es.Identifier, inactive, _c) {
       // for declarations
       const name = node.name
       if (inactive.has(name)) {
@@ -321,7 +321,7 @@ function renameVariables(
         node.name = namesToRename.get(name)!
       }
     },
-    Identifier(node: es.Identifier, inactive, c) {
+    Identifier(node: es.Identifier, inactive, _c) {
       // for lone references
       const name = node.name
       if (inactive.has(name)) {
@@ -566,7 +566,7 @@ const compilers = {
   },
 
   // handled by insertFlag in compile function
-  ReturnStatement(node: es.Node, indexTable: Map<string, EnvEntry>[], insertFlag: boolean) {
+  ReturnStatement(node: es.Node, indexTable: Map<string, EnvEntry>[], _insertFlag: boolean) {
     node = node as es.ReturnStatement
     if (loopTracker.length > 0) {
       throw Error('return not allowed in loops')
@@ -846,7 +846,7 @@ const compilers = {
     throw Error('Invalid Assignment')
   },
 
-  ForStatement(node: es.Node, indexTable: Map<string, EnvEntry>[], insertFlag: boolean) {
+  ForStatement(_node: es.Node, _indexTable: Map<string, EnvEntry>[], _insertFlag: boolean) {
     throw Error('Unsupported operation')
   },
 
@@ -904,7 +904,7 @@ const compilers = {
     return { maxStackSize: 0, insertFlag }
   },
 
-  ObjectExpression(node: es.Node, indexTable: Map<string, EnvEntry>[], insertFlag: boolean) {
+  ObjectExpression(_node: es.Node, _indexTable: Map<string, EnvEntry>[], _insertFlag: boolean) {
     throw Error('Unsupported operation')
   },
 
@@ -920,11 +920,11 @@ const compilers = {
     throw Error('Unsupported operation')
   },
 
-  Property(node: es.Node, indexTable: Map<string, EnvEntry>[], insertFlag: boolean) {
+  Property(_node: es.Node, _indexTable: Map<string, EnvEntry>[], _insertFlag: boolean) {
     throw Error('Unsupported operation')
   },
 
-  DebuggerStatement(node: es.Node, indexTable: Map<string, EnvEntry>[], insertFlag: boolean) {
+  DebuggerStatement(_node: es.Node, _indexTable: Map<string, EnvEntry>[], _insertFlag: boolean) {
     throw Error('Unsupported operation')
   }
 }


### PR DESCRIPTION
Fix ESLint warnings relating to unused arguments. Typically, instances of unused arguments are due to needing to conform to some API despite not making use of the arguments. To indicate that these arguments are intentionally unused, we prepend an underscore to them. ESLint has been previously configured to ignore unused arguments that start with `_`.

This brings down the number of ESLint warnings from 117 to ~~41~~ 39 (after adding @shenyih0ng's fixes). Eventually, the goal should be that ESLint does not throw up any warnings at all so that we can enforce it as a requirement for PRs to pass the CI pipeline.

Related to #1321.