### PR TITLE
Modify + operator to prioritise left type in Source Typed

### DIFF
--- a/docs/specs/source_1_typed_typing.tex
+++ b/docs/specs/source_1_typed_typing.tex
@@ -245,28 +245,27 @@ Applications of binary and unary operators are treated the same as function appl
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on either side is of type $\String$ or literal string type,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on either side is of type $\Number$ or literal number type,
+\item{If the expression on the left side is a subtype of type $\Number$,
   check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If neither expression can be narrowed to either $\String$ or $\Number$, check that both sides are subtypes of 
-  $\String\ |\ \Number$. The return type is $\Any$.}
+\item{If the expression on the left side is a subtype of type $\String$,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on the right side is a subtype of type $\Number$,
+  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
+\item{If the expression on the right side is a subtype of type $\String$,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are subtypes of 
+  $\Number\ |\ \String$. The return type is $\Any$.}
 \end{itemize}
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
-    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
-\]
-\noindent
-\[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
-    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
-\]
-\noindent
-\[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
     \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
@@ -275,8 +274,13 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\String\ |\ \Number) \vee t_0 = \Any
-    \quad t_1 \subseteq (\String\ |\ \Number) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\Number\ |\ \String) \vee t_0 = \Any
+    \quad t_1 \subseteq (\Number\ |\ \String) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
 \]
 \noindent
 

--- a/docs/specs/source_2_typed_typing.tex
+++ b/docs/specs/source_2_typed_typing.tex
@@ -276,28 +276,27 @@ Applications of binary and unary operators are treated the same as function appl
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on either side is of type $\String$ or literal string type,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on either side is of type $\Number$ or literal number type,
+\item{If the expression on the left side is a subtype of type $\Number$,
   check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If neither expression can be narrowed to either $\String$ or $\Number$, check that both sides are subtypes of 
-  $\String\ |\ \Number$. The return type is $\Any$.}
+\item{If the expression on the left side is a subtype of type $\String$,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on the right side is a subtype of type $\Number$,
+  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
+\item{If the expression on the right side is a subtype of type $\String$,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are subtypes of 
+  $\Number\ |\ \String$. The return type is $\Any$.}
 \end{itemize}
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
-    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
-\]
-\noindent
-\[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
-    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
-\]
-\noindent
-\[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
     \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
@@ -306,8 +305,13 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\String\ |\ \Number) \vee t_0 = \Any
-    \quad t_1 \subseteq (\String\ |\ \Number) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\Number\ |\ \String) \vee t_0 = \Any
+    \quad t_1 \subseteq (\Number\ |\ \String) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
 \]
 \noindent
 

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -284,28 +284,27 @@ Applications of binary and unary operators are treated the same as function appl
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on either side is of type $\String$ or literal string type,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on either side is of type $\Number$ or literal number type,
+\item{If the expression on the left side is a subtype of type $\Number$,
   check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If neither expression can be narrowed to either $\String$ or $\Number$, check that both sides are subtypes of 
-  $\String\ |\ \Number$. The return type is $\Any$.}
+\item{If the expression on the left side is a subtype of type $\String$,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on the right side is a subtype of type $\Number$,
+  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
+\item{If the expression on the right side is a subtype of type $\String$,
+  check that the other expression is a subtype of $\String$. The return type is $\String$.}
+\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are subtypes of 
+  $\Number\ |\ \String$. The return type is $\Any$.}
 \end{itemize}
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
-    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
-\]
-\noindent
-\[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
-    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
-\]
-\noindent
-\[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
     \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
@@ -314,8 +313,13 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\String\ |\ \Number) \vee t_0 = \Any
-    \quad t_1 \subseteq (\String\ |\ \Number) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+\]
+\noindent
+\[
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\Number\ |\ \String) \vee t_0 = \Any
+    \quad t_1 \subseteq (\Number\ |\ \String) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
 \]
 \noindent
 

--- a/src/typeChecker/__tests__/source1Typed.test.ts
+++ b/src/typeChecker/__tests__/source1Typed.test.ts
@@ -655,7 +655,7 @@ describe('binary operations', () => {
       const x11: string = x3 + x2; // error, boolean + string, return type string
       const x12: number = x1 + x4; // no error, number + any, return type number
       const x13: string = x5 + x2; // no error, any + string, return type string
-      const x14: string = x1 + x2; // error, number + string, return type string
+      const x14: number = x1 + x2; // error, number + string, return type number (follows left side)
       const x15: string = x4 + x5; // no error, any + any, return type any
       const x16: number | string = x6 + x4; // no error, string | number + any, return type any
       const x17: number = x1 + x6; // error, number + string | number, return type number
@@ -977,7 +977,7 @@ describe('scoping', () => {
       f(x); // error
       const z: string = x + y; // no error
     }
-    const z: string = x + y; // error
+    const z: number = x + y; // error
     `
 
     parse(code, context)

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -650,20 +650,12 @@ function typeCheckAndReturnBinaryExpressionType(
       // However, the case where one side is string and other side is number is not allowed
       if (leftTypeString === 'number' || leftTypeString === 'string') {
         checkForTypeMismatch(node, rightType, leftType, context)
-        // Return type will be either number or string depending on the left/right type
-        // However, if one side is of type string and other side is of type number, return type will be string
-        if (leftTypeString === 'string' || rightTypeString === 'string') {
-          return tString
-        }
+        // If left type is number or string, return left type
         return leftType
       }
       if (rightTypeString === 'number' || rightTypeString === 'string') {
         checkForTypeMismatch(node, leftType, rightType, context)
-        // Return type will be either number or string depending on the left/right type
-        // However, if one side is of type string and other side is of type number, return type will be string
-        if (leftTypeString === 'string' || rightTypeString === 'string') {
-          return tString
-        }
+        // If left type is not number or string but right type is number or string, return right type
         return rightType
       }
 
@@ -697,7 +689,7 @@ function typeCheckAndReturnBinaryExpressionType(
       checkForTypeMismatch(node, rightType, tUnion(tNumber, tString), context)
       return tBool
     default:
-      return tAny
+      throw new TypecheckError(node, 'Unknown operator')
   }
 }
 


### PR DESCRIPTION
Currently, in both Source Typed and Source, the `+` operator checks the right type against the left type if the left type is `string` or `number`. Therefore, it is expected for the type of the result to also prioritise left type over right type. However, the actual behaviour prioritises `string` over `number`. This PR corrects this inconsistency.