### PR TITLE
Update file path to function name translation

### DIFF
--- a/src/errors/localImportErrors.ts
+++ b/src/errors/localImportErrors.ts
@@ -2,22 +2,38 @@ import { UNKNOWN_LOCATION } from '../constants'
 import { nonAlphanumericCharEncoding } from '../localImports/filePaths'
 import { ErrorSeverity, ErrorType, SourceError } from '../types'
 
-export class InvalidFilePathError implements SourceError {
+export abstract class InvalidFilePathError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
   public location = UNKNOWN_LOCATION
 
   constructor(public filePath: string) {}
 
+  abstract explain(): string
+
+  abstract elaborate(): string
+}
+
+export class IllegalCharInFilePathError extends InvalidFilePathError {
   public explain() {
     const validNonAlphanumericChars = Object.keys(nonAlphanumericCharEncoding)
       .map(char => `'${char}'`)
       .join(', ')
-    return `'${this.filePath}' must only contain alphanumeric chars or one of ${validNonAlphanumericChars}, and must not contain consecutive slashes '//'.`
+    return `File path '${this.filePath}' must only contain alphanumeric chars and/or ${validNonAlphanumericChars}.`
   }
 
   public elaborate() {
-    return 'Rename the offending file path to only use valid chars and remove consecutive slashes.'
+    return 'Rename the offending file path to only use valid chars.'
+  }
+}
+
+export class ConsecutiveSlashesInFilePathError extends InvalidFilePathError {
+  public explain() {
+    return `File path '${this.filePath}' cannot contain consecutive slashes '//'.`
+  }
+
+  public elaborate() {
+    return 'Remove consecutive slashes from the offending file path.'
   }
 }
 

--- a/src/errors/localImportErrors.ts
+++ b/src/errors/localImportErrors.ts
@@ -1,5 +1,5 @@
 import { UNKNOWN_LOCATION } from '../constants'
-import { charEncoding } from '../localImports/filePaths'
+import { nonAlphanumericCharEncoding } from '../localImports/filePaths'
 import { ErrorSeverity, ErrorType, SourceError } from '../types'
 
 export class InvalidFilePathError implements SourceError {
@@ -10,7 +10,7 @@ export class InvalidFilePathError implements SourceError {
   constructor(public filePath: string) {}
 
   public explain() {
-    const validNonAlphanumericChars = Object.keys(charEncoding)
+    const validNonAlphanumericChars = Object.keys(nonAlphanumericCharEncoding)
       .map(char => `'${char}'`)
       .join(', ')
     return `'${this.filePath}' must only contain alphanumeric chars or one of ${validNonAlphanumericChars}.`

--- a/src/errors/localImportErrors.ts
+++ b/src/errors/localImportErrors.ts
@@ -13,11 +13,11 @@ export class InvalidFilePathError implements SourceError {
     const validNonAlphanumericChars = Object.keys(nonAlphanumericCharEncoding)
       .map(char => `'${char}'`)
       .join(', ')
-    return `'${this.filePath}' must only contain alphanumeric chars or one of ${validNonAlphanumericChars}.`
+    return `'${this.filePath}' must only contain alphanumeric chars or one of ${validNonAlphanumericChars}, and must not contain consecutive slashes '//'.`
   }
 
   public elaborate() {
-    return 'Rename the offending file path to only use valid chars.'
+    return 'Rename the offending file path to only use valid chars and remove consecutive slashes.'
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ import { compileToIns } from './vm/svml-compiler'
 export { SourceDocumentation } from './editors/ace/docTooltip'
 import * as es from 'estree'
 
-import { CannotFindModuleError, InvalidFilePathError } from './errors/localImportErrors'
-import { isFilePathValid } from './localImports/filePaths'
+import { CannotFindModuleError } from './errors/localImportErrors'
+import { validateFilePath } from './localImports/filePaths'
 import { getKeywords, getProgramNames, NameDeclaration } from './name-extractor'
 import {
   fullJSRunner,
@@ -310,8 +310,9 @@ export async function runFilesInContext(
   options: Partial<IOptions> = {}
 ): Promise<Result> {
   for (const filePath in files) {
-    if (!isFilePathValid(filePath)) {
-      context.errors.push(new InvalidFilePathError(filePath))
+    const filePathError = validateFilePath(filePath)
+    if (filePathError !== null) {
+      context.errors.push(filePathError)
       return resolvedErrorPromise
     }
   }

--- a/src/localImports/__tests__/preprocessor.ts
+++ b/src/localImports/__tests__/preprocessor.ts
@@ -173,7 +173,7 @@ describe('preprocessFileImports', () => {
     const expectedCode = `
       import { a, b, c } from "source-module";
 
-      function __$not$dash$source$dash$module$dot$js__() {
+      function __$not$$dash$$source$$dash$$module$$dot$$js__() {
         const x = 1;
         const y = 2;
         const z = 3;
@@ -184,12 +184,12 @@ describe('preprocessFileImports', () => {
         return pair(square, list(pair("x", x), pair("y", y), pair("z", z)));
       }
 
-      const ___$not$dash$source$dash$module$dot$js___ = __$not$dash$source$dash$module$dot$js__();
+      const ___$not$$dash$$source$$dash$$module$$dot$$js___ = __$not$$dash$$source$$dash$$module$$dot$$js__();
 
-      const w = ${accessExportFunctionName}(___$not$dash$source$dash$module$dot$js___, "${defaultExportLookupName}");
-      const x = ${accessExportFunctionName}(___$not$dash$source$dash$module$dot$js___, "x");
-      const y = ${accessExportFunctionName}(___$not$dash$source$dash$module$dot$js___, "y");
-      const z = ${accessExportFunctionName}(___$not$dash$source$dash$module$dot$js___, "z");
+      const w = ${accessExportFunctionName}(___$not$$dash$$source$$dash$$module$$dot$$js___, "${defaultExportLookupName}");
+      const x = ${accessExportFunctionName}(___$not$$dash$$source$$dash$$module$$dot$$js___, "x");
+      const y = ${accessExportFunctionName}(___$not$$dash$$source$$dash$$module$$dot$$js___, "y");
+      const z = ${accessExportFunctionName}(___$not$$dash$$source$$dash$$module$$dot$$js___, "z");
     `
     const actualProgram = preprocessFileImports(files, '/a.js', actualContext)
     assertASTsAreEquivalent(actualProgram, expectedCode)
@@ -222,24 +222,24 @@ describe('preprocessFileImports', () => {
       import { f, g } from "other-source-module";
       import { h } from "another-source-module";
 
-      function __$b$dot$js__(___$c$dot$js___) {
-        const square = ${accessExportFunctionName}(___$c$dot$js___, "square");
+      function __$b$$dot$$js__(___$c$$dot$$js___) {
+        const square = ${accessExportFunctionName}(___$c$$dot$$js___, "square");
 
         const b = square(5);
 
         return pair(null, list(pair("b", b)));
       }
 
-      function __$c$dot$js__() {
+      function __$c$$dot$$js__() {
         const square = x => x * x;
 
         return pair(null, list(pair("square", square)));
       }
 
-      const ___$c$dot$js___ = __$c$dot$js__();
-      const ___$b$dot$js___ = __$b$dot$js__(___$c$dot$js___);
+      const ___$c$$dot$$js___ = __$c$$dot$$js__();
+      const ___$b$$dot$$js___ = __$b$$dot$$js__(___$c$$dot$$js___);
 
-      const b = ${accessExportFunctionName}(___$b$dot$js___, "b");
+      const b = ${accessExportFunctionName}(___$b$$dot$$js___, "b");
 
       b;
     `
@@ -314,9 +314,9 @@ describe('preprocessFileImports', () => {
       `
     }
     const expectedCode = `
-      function __$b$dot$js__(___$c$dot$js___) {
-        const y = ${accessExportFunctionName}(___$c$dot$js___, "${defaultExportLookupName}");
-        const square = ${accessExportFunctionName}(___$c$dot$js___, "square");
+      function __$b$$dot$$js__(___$c$$dot$$js___) {
+        const y = ${accessExportFunctionName}(___$c$$dot$$js___, "${defaultExportLookupName}");
+        const square = ${accessExportFunctionName}(___$c$$dot$$js___, "square");
 
         const a = square(y);
         const b = 3;
@@ -324,8 +324,8 @@ describe('preprocessFileImports', () => {
         return pair(null, list(pair("a", a), pair("b", b)));
       }
 
-      function __$c$dot$js__(___$d$dot$js___) {
-        const mysteryFunction = ${accessExportFunctionName}(___$d$dot$js___, "mysteryFunction");
+      function __$c$$dot$$js__(___$d$$dot$$js___) {
+        const mysteryFunction = ${accessExportFunctionName}(___$d$$dot$$js___, "mysteryFunction");
 
         const x = mysteryFunction(5);
         function square(x) {
@@ -335,18 +335,18 @@ describe('preprocessFileImports', () => {
         return pair(x, list(pair("square", square)));
       }
 
-      function __$d$dot$js__() {
+      function __$d$$dot$$js__() {
         const addTwo = x => x + 2;
 
         return pair(null, list(pair("mysteryFunction", addTwo)));
       }
 
-      const ___$d$dot$js___ = __$d$dot$js__();
-      const ___$c$dot$js___ = __$c$dot$js__(___$d$dot$js___);
-      const ___$b$dot$js___ = __$b$dot$js__(___$c$dot$js___);
+      const ___$d$$dot$$js___ = __$d$$dot$$js__();
+      const ___$c$$dot$$js___ = __$c$$dot$$js__(___$d$$dot$$js___);
+      const ___$b$$dot$$js___ = __$b$$dot$$js__(___$c$$dot$$js___);
 
-      const x = ${accessExportFunctionName}(___$b$dot$js___, "a");
-      const y = ${accessExportFunctionName}(___$b$dot$js___, "b");
+      const x = ${accessExportFunctionName}(___$b$$dot$$js___, "a");
+      const y = ${accessExportFunctionName}(___$b$$dot$$js___, "b");
 
       x + y;
     `

--- a/src/localImports/__tests__/transformers/transformProgramToFunctionDeclaration.ts
+++ b/src/localImports/__tests__/transformers/transformProgramToFunctionDeclaration.ts
@@ -7,7 +7,7 @@ import { parseCodeError, stripLocationInfo } from '../utils'
 
 describe('transformImportedFile', () => {
   const currentFileName = '/dir/a.js'
-  const functionName = '__$dir$a$dot$js__'
+  const functionName = '__$dir$a$$dot$$js__'
   let actualContext = mockContext(Chapter.LIBRARY_PARSER)
   let expectedContext = mockContext(Chapter.LIBRARY_PARSER)
 
@@ -353,9 +353,9 @@ describe('transformImportedFile', () => {
       import { y } from "../dir2/c.js";
     `
     const expectedCode = `
-      function ${functionName}(___$dir$b$dot$js___, ___$dir2$c$dot$js___) {
-        const x = __access_export__(___$dir$b$dot$js___, "x");
-        const y = __access_export__(___$dir2$c$dot$js___, "y");
+      function ${functionName}(___$dir$b$$dot$$js___, ___$dir2$c$$dot$$js___) {
+        const x = __access_export__(___$dir$b$$dot$$js___, "x");
+        const y = __access_export__(___$dir2$c$$dot$$js___, "y");
 
         return pair(null, list());
       }
@@ -369,9 +369,9 @@ describe('transformImportedFile', () => {
       import y from "../dir2/c.js";
     `
     const expectedCode = `
-      function ${functionName}(___$dir$b$dot$js___, ___$dir2$c$dot$js___) {
-        const x = __access_export__(___$dir$b$dot$js___, "${defaultExportLookupName}");
-        const y = __access_export__(___$dir2$c$dot$js___, "${defaultExportLookupName}");
+      function ${functionName}(___$dir$b$$dot$$js___, ___$dir2$c$$dot$$js___) {
+        const x = __access_export__(___$dir$b$$dot$$js___, "${defaultExportLookupName}");
+        const y = __access_export__(___$dir2$c$$dot$$js___, "${defaultExportLookupName}");
 
         return pair(null, list());
       }
@@ -385,9 +385,9 @@ describe('transformImportedFile', () => {
       import { y } from "../../../../../dir2/c.js";
     `
     const expectedCode = `
-      function ${functionName}(___$dir$b$dot$js___, ___$dir2$c$dot$js___) {
-        const x = __access_export__(___$dir$b$dot$js___, "x");
-        const y = __access_export__(___$dir2$c$dot$js___, "y");
+      function ${functionName}(___$dir$b$$dot$$js___, ___$dir2$c$$dot$$js___) {
+        const x = __access_export__(___$dir$b$$dot$$js___, "x");
+        const y = __access_export__(___$dir2$c$$dot$$js___, "y");
 
         return pair(null, list());
       }
@@ -401,9 +401,9 @@ describe('transformImportedFile', () => {
       import { y } from "../dir/b.js";
     `
     const expectedCode = `
-      function ${functionName}(___$dir$b$dot$js___) {
-        const x = __access_export__(___$dir$b$dot$js___, "x");
-        const y = __access_export__(___$dir$b$dot$js___, "y");
+      function ${functionName}(___$dir$b$$dot$$js___) {
+        const x = __access_export__(___$dir$b$$dot$$js___, "x");
+        const y = __access_export__(___$dir$b$$dot$$js___, "y");
 
         return pair(null, list());
       }
@@ -420,10 +420,10 @@ describe('transformImportedFile', () => {
       export const a = x + y + z;
     `
     const expectedCode = `
-      function ${functionName}(___$dir$b$dot$js___) {
-        const x = __access_export__(___$dir$b$dot$js___, "x");
-        const y = __access_export__(___$dir$b$dot$js___, "y");
-        const z = __access_export__(___$dir$b$dot$js___, "z");
+      function ${functionName}(___$dir$b$$dot$$js___) {
+        const x = __access_export__(___$dir$b$$dot$$js___, "x");
+        const y = __access_export__(___$dir$b$$dot$$js___, "y");
+        const z = __access_export__(___$dir$b$$dot$$js___, "z");
 
         const a = x + y + z;
 

--- a/src/localImports/filePaths.ts
+++ b/src/localImports/filePaths.ts
@@ -1,8 +1,14 @@
 /**
- * Maps characters that are legal in file paths but illegal in
- * function names to strings which are legal in function names.
+ * Maps non-alphanumeric characters that are legal in file paths
+ * to strings which are legal in function names.
  */
-export const charEncoding: Record<string, string> = {
+export const nonAlphanumericCharEncoding: Record<string, string> = {
+  // While the underscore character is legal in both file paths
+  // and function names, it is the only character to be legal
+  // in both that is not an alphanumeric character. For simplicity,
+  // we handle it the same way as the other non-alphanumeric
+  // characters.
+  _: '_',
   '/': '$',
   '.': '$dot$',
   '-': '$dash$'
@@ -20,7 +26,7 @@ export const charEncoding: Record<string, string> = {
  * @param filePath The file path to transform.
  */
 export const transformFilePathToValidFunctionName = (filePath: string): string => {
-  const encodeChars = Object.entries(charEncoding).reduce(
+  const encodeChars = Object.entries(nonAlphanumericCharEncoding).reduce(
     (
       accumulatedFunction: (filePath: string) => string,
       [charToReplace, replacementString]: [string, string]
@@ -64,7 +70,7 @@ export const isFilePathValid = (filePath: string): boolean => {
     if (isAlphanumeric(char)) {
       continue
     }
-    if (char in charEncoding) {
+    if (char in nonAlphanumericCharEncoding) {
       continue
     }
     return false

--- a/src/localImports/filePaths.ts
+++ b/src/localImports/filePaths.ts
@@ -10,8 +10,15 @@ export const nonAlphanumericCharEncoding: Record<string, string> = {
   // characters.
   _: '_',
   '/': '$',
-  '.': '$dot$',
-  '-': '$dash$'
+  // The following encodings work because we disallow file paths
+  // with consecutive slash characters (//). Note that when using
+  // the 'replace' or 'replaceAll' functions, the dollar sign ($)
+  // takes on a special meaning. As such, to insert a dollar sign,
+  // we need to write '$$'. See
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
+  // for more information.
+  '.': '$$$$dot$$$$', // '$$dot$$'
+  '-': '$$$$dash$$$$' // '$$dash$$'
 }
 
 /**
@@ -61,11 +68,15 @@ const isAlphanumeric = (char: string): boolean => {
 /**
  * Returns whether the given file path is valid. A file path is
  * valid if it only contains alphanumeric characters and the
- * characters defined in `charEncoding`.
+ * characters defined in `charEncoding`, and does not contain
+ * consecutive slash characters (//).
  *
  * @param filePath The file path to check.
  */
 export const isFilePathValid = (filePath: string): boolean => {
+  if (filePath.includes('//')) {
+    return false
+  }
   for (const char of filePath) {
     if (isAlphanumeric(char)) {
       continue

--- a/src/localImports/filePaths.ts
+++ b/src/localImports/filePaths.ts
@@ -1,3 +1,9 @@
+import {
+  ConsecutiveSlashesInFilePathError,
+  IllegalCharInFilePathError,
+  InvalidFilePathError
+} from '../errors/localImportErrors'
+
 /**
  * Maps non-alphanumeric characters that are legal in file paths
  * to strings which are legal in function names.
@@ -66,16 +72,17 @@ const isAlphanumeric = (char: string): boolean => {
 }
 
 /**
- * Returns whether the given file path is valid. A file path is
- * valid if it only contains alphanumeric characters and the
- * characters defined in `charEncoding`, and does not contain
- * consecutive slash characters (//).
+ * Validates the given file path, returning an `InvalidFilePathError`
+ * if the file path is invalid & `null` otherwise. A file path is
+ * valid if it only contains alphanumeric characters and the characters
+ * defined in `charEncoding`, and does not contain consecutive slash
+ * characters (//).
  *
  * @param filePath The file path to check.
  */
-export const isFilePathValid = (filePath: string): boolean => {
+export const validateFilePath = (filePath: string): InvalidFilePathError | null => {
   if (filePath.includes('//')) {
-    return false
+    return new ConsecutiveSlashesInFilePathError(filePath)
   }
   for (const char of filePath) {
     if (isAlphanumeric(char)) {
@@ -84,9 +91,9 @@ export const isFilePathValid = (filePath: string): boolean => {
     if (char in nonAlphanumericCharEncoding) {
       continue
     }
-    return false
+    return new IllegalCharInFilePathError(filePath)
   }
-  return true
+  return null
 }
 
 /**

--- a/src/runner/__tests__/files.ts
+++ b/src/runner/__tests__/files.ts
@@ -9,50 +9,50 @@ describe('runFilesInContext', () => {
     context = mockContext(Chapter.SOURCE_4)
   })
 
-  it('returns InvalidFilePathError if any file path contains invalid characters', () => {
+  it('returns IllegalCharInFilePathError if any file path contains invalid characters', () => {
     const files: Record<string, string> = {
       '/a.js': '1 + 2;',
       '/+-.js': '"hello world";'
     }
     runFilesInContext(files, '/a.js', context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"'/+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'."`
+      `"File path '/+-.js' must only contain alphanumeric chars and/or '_', '/', '.', '-'."`
     )
   })
 
-  it('returns InvalidFilePathError if any file path contains invalid characters - verbose', () => {
+  it('returns IllegalCharInFilePathError if any file path contains invalid characters - verbose', () => {
     const files: Record<string, string> = {
       '/a.js': '1 + 2;',
       '/+-.js': '"hello world";'
     }
     runFilesInContext(files, '/a.js', context)
     expect(parseError(context.errors, true)).toMatchInlineSnapshot(`
-      "'/+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.
-      Rename the offending file path to only use valid chars and remove consecutive slashes.
+      "File path '/+-.js' must only contain alphanumeric chars and/or '_', '/', '.', '-'.
+      Rename the offending file path to only use valid chars.
       "
     `)
   })
 
-  it('returns InvalidFilePathError if any file path contains consecutive slash characters', () => {
+  it('returns ConsecutiveSlashesInFilePathError if any file path contains consecutive slash characters', () => {
     const files: Record<string, string> = {
       '/a.js': '1 + 2;',
       '/dir//dir2/b.js': '"hello world";'
     }
     runFilesInContext(files, '/a.js', context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"'/dir//dir2/b.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'."`
+      `"File path '/dir//dir2/b.js' cannot contain consecutive slashes '//'."`
     )
   })
 
-  it('returns InvalidFilePathError if any file path contains consecutive slash characters - verbose', () => {
+  it('returns ConsecutiveSlashesInFilePathError if any file path contains consecutive slash characters - verbose', () => {
     const files: Record<string, string> = {
       '/a.js': '1 + 2;',
       '/dir//dir2/b.js': '"hello world";'
     }
     runFilesInContext(files, '/a.js', context)
     expect(parseError(context.errors, true)).toMatchInlineSnapshot(`
-      "'/dir//dir2/b.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.
-      Rename the offending file path to only use valid chars and remove consecutive slashes.
+      "File path '/dir//dir2/b.js' cannot contain consecutive slashes '//'.
+      Remove consecutive slashes from the offending file path.
       "
     `)
   })

--- a/src/runner/__tests__/files.ts
+++ b/src/runner/__tests__/files.ts
@@ -16,7 +16,7 @@ describe('runFilesInContext', () => {
     }
     runFilesInContext(files, 'a.js', context)
     expect(parseError(context.errors)).toEqual(
-      `'+-.js' must only contain alphanumeric chars or one of '/', '.', '-'.`
+      `'+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-'.`
     )
   })
 

--- a/src/runner/__tests__/files.ts
+++ b/src/runner/__tests__/files.ts
@@ -15,9 +15,22 @@ describe('runFilesInContext', () => {
       '/+-.js': '"hello world";'
     }
     runFilesInContext(files, '/a.js', context)
-    expect(parseError(context.errors)).toEqual(
-      `'/+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.`
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"'/+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'."`
     )
+  })
+
+  it('returns InvalidFilePathError if any file path contains invalid characters - verbose', () => {
+    const files: Record<string, string> = {
+      '/a.js': '1 + 2;',
+      '/+-.js': '"hello world";'
+    }
+    runFilesInContext(files, '/a.js', context)
+    expect(parseError(context.errors, true)).toMatchInlineSnapshot(`
+      "'/+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.
+      Rename the offending file path to only use valid chars and remove consecutive slashes.
+      "
+    `)
   })
 
   it('returns InvalidFilePathError if any file path contains consecutive slash characters', () => {
@@ -26,14 +39,37 @@ describe('runFilesInContext', () => {
       '/dir//dir2/b.js': '"hello world";'
     }
     runFilesInContext(files, '/a.js', context)
-    expect(parseError(context.errors)).toEqual(
-      `'/dir//dir2/b.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.`
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"'/dir//dir2/b.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'."`
     )
+  })
+
+  it('returns InvalidFilePathError if any file path contains consecutive slash characters - verbose', () => {
+    const files: Record<string, string> = {
+      '/a.js': '1 + 2;',
+      '/dir//dir2/b.js': '"hello world";'
+    }
+    runFilesInContext(files, '/a.js', context)
+    expect(parseError(context.errors, true)).toMatchInlineSnapshot(`
+      "'/dir//dir2/b.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.
+      Rename the offending file path to only use valid chars and remove consecutive slashes.
+      "
+    `)
   })
 
   it('returns CannotFindModuleError if entrypoint file does not exist', () => {
     const files: Record<string, string> = {}
-    runFilesInContext(files, 'a.js', context)
-    expect(parseError(context.errors)).toEqual(`Cannot find module 'a.js'.`)
+    runFilesInContext(files, '/a.js', context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`"Cannot find module '/a.js'."`)
+  })
+
+  it('returns CannotFindModuleError if entrypoint file does not exist - verbose', () => {
+    const files: Record<string, string> = {}
+    runFilesInContext(files, '/a.js', context)
+    expect(parseError(context.errors, true)).toMatchInlineSnapshot(`
+      "Cannot find module '/a.js'.
+      Check that the module file path resolves to an existing file.
+      "
+    `)
   })
 })

--- a/src/runner/__tests__/files.ts
+++ b/src/runner/__tests__/files.ts
@@ -9,14 +9,25 @@ describe('runFilesInContext', () => {
     context = mockContext(Chapter.SOURCE_4)
   })
 
-  it('returns InvalidFilePathError if file paths are invalid', () => {
+  it('returns InvalidFilePathError if any file path contains invalid characters', () => {
     const files: Record<string, string> = {
-      'a.js': '1 + 2;',
-      '+-.js': '"hello world";'
+      '/a.js': '1 + 2;',
+      '/+-.js': '"hello world";'
     }
-    runFilesInContext(files, 'a.js', context)
+    runFilesInContext(files, '/a.js', context)
     expect(parseError(context.errors)).toEqual(
-      `'+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-'.`
+      `'/+-.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.`
+    )
+  })
+
+  it('returns InvalidFilePathError if any file path contains consecutive slash characters', () => {
+    const files: Record<string, string> = {
+      '/a.js': '1 + 2;',
+      '/dir//dir2/b.js': '"hello world";'
+    }
+    runFilesInContext(files, '/a.js', context)
+    expect(parseError(context.errors)).toEqual(
+      `'/dir//dir2/b.js' must only contain alphanumeric chars or one of '_', '/', '.', '-', and must not contain consecutive slashes '//'.`
     )
   })
 


### PR DESCRIPTION
Prof @martin-henz observed that with the current file path to function name translation, we would still have name collisions. For example, both `/a.js` and `/a/dot/js` would be translated into `__$a$dot$js__`.

To work around this, we impose an additional constraint on the file paths such that file paths should not contain consecutive slashes (`//`). This means that we can update the encoding of `.` to `$$dot$$` and `-` to `$$dash$$`, both of which cannot be obtained from file paths that do not themselves contain `.` or `-`.

On top of that, the underscore character (`_`) is now allowed in file paths, and is translated to function names as itself.

Part of https://github.com/source-academy/frontend/issues/2176. Related to #1332.