### PR TITLE
Fix verbose error messages without line numbers not being verbose

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export function parseError(errors: SourceError[], verbose: boolean = verboseErro
       // way to display it.
       const elaboration = error.elaborate()
       return line < 1
-        ? explanation
+        ? `${explanation}\n${elaboration}\n`
         : `Line ${line}, Column ${column}: ${explanation}\n${elaboration}\n`
     } else {
       return line < 1 ? explanation : `Line ${line}: ${explanation}`


### PR DESCRIPTION
If an error does not have a location (i.e., line number) associated with it, its message is not verbose even when verbosity is enabled.