### PR TITLE
Modify Source Typed to use success typing

### DIFF
--- a/docs/specs/source_1_typed_typing.tex
+++ b/docs/specs/source_1_typed_typing.tex
@@ -245,7 +245,7 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \item{If the expression on the right side is of type $\String$ or literal string type,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
 \item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
-  $\Number\ |\ \String$. The return type is $\Any$.}
+  $\Number\ |\ \String$. The return type is $\Number\ |\ \String$.}
 \end{itemize}
 
 \noindent
@@ -271,7 +271,7 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \wedge (\Number\ |\ \String) \neq \emptyset
-    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number\ |\ \String}
 \]
 \noindent
 

--- a/docs/specs/source_1_typed_typing.tex
+++ b/docs/specs/source_1_typed_typing.tex
@@ -155,45 +155,36 @@ $\Gamma_{-1}$
 & $[$ & \texttt{undefined} & $\leftarrow$  & $\Undefined$ & & & $]$ & $\Gamma_0$ \\
 & \end{tabular}
 
-\subsection{Subtyping}
+\subsection{Success Types}
 
-In order for type checks to be performed in Source \S 1 Typed, we introduce the notion of subtyping.
+In order for type checks to be performed in Source \S 1 Typed, we introduce the notion of success types.
 
+We first define the special $\Any$ type:
 \begin{definition}
-$t \subseteq t'$ is used to denote that type $t$ is a subtype of type $t'$.
+$\Any$ is the union of all possible types.
 \end{definition}
 
-Subtyping is illustrated using the following type rules:
+Success typing in Source Typed is defined as follows:
 
-\noindent
-\[
-\Rule{}{t \subseteq \Any}
-\qquad
-\Rule{t'\ \textit{is a basic type} \quad t\ \textit{is a basic type} \quad t' = t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t'\ \textit{is a literal type} \quad t\ \textit{is a basic type} \quad \texttt{typeof}\ t' = t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{(\forall 1 \leq i \leq n)(t_i \subseteq t'_i) \quad t' \subseteq t}{(t'_1, \ldots t'_n) \rightarrow t' \subseteq (t_1, \ldots t_n) \rightarrow t}
-\qquad
-\Rule{(\exists i)(t' \subseteq t_i)}{t'\ \subseteq\ t_1\ |\ \ldots\ |\ t_n}
-\]
-\noindent
+\begin{definition}
+Type $t'$ is a success type of type $t$ if $\exists x (x \in t \wedge x \in t')$.
+Alternatively: $t \wedge t' \neq \emptyset$.
+\end{definition}
+
+In Source Typed, type checks are performed by checking that the actual type is a success type of the expected type.
+This means that type errors will be thrown if and only if a definite clash in types at runtime is detected.
+Given that $\Any$ is the union of all possible types, this also means that the $\Any$ type is guaranteed not to produce any type errors.
 
 \subsection{Typing Relations}
 \label{typing-rules}
 
 To perform type checking on the program, typing relations are applied to every statement and expression in the program.
 
-Note that a name that is declared to be of type $t$ will always refer to values of a type $t'$ such that $t' \subseteq t$ at runtime.
-Names that do not have a type declared will be assumed to have the $any$ type; the $any$ type will not ever produce any type errors.
+Names that do not have a type declared will be assumed to have the $\Any$ type.
 
 \subsubsection{Typing Relations on Expressions}
 
-The derived type of primitive expressions is their literal type, which is always a subtype of its corresponding basic type.
+The derived type of primitive expressions is their literal type, which is an element of its corresponding basic type.
 
 \noindent
 \[
@@ -226,18 +217,18 @@ For function applications (including applications of binary and unary operators)
 \noindent
 \[
 \Rule{\Gamma \vdash E_0 : (t_1, \ldots, t_n) \rightarrow t \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq t_i \vee t'_i = \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
+  \quad (\forall 1 \leq i \leq n)(t'_i \wedge t_i \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+  \quad (\forall 1 \leq i \leq n)(t'_i \wedge \Any \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
 \]
 \noindent
 
 The type of the operator must be a function type with the right number of parameters,
-and the type of every argument must be a subtype of the corresponding parameter type of the function type.
-If all these conditions are met, the type of the function application is the same
+and the type of every argument must be a success type of the corresponding parameter type of the function type.
+If all of the conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
 If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
 
@@ -245,42 +236,42 @@ Applications of binary and unary operators are treated the same as function appl
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on the left side is a subtype of type $\Number$,
-  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If the expression on the left side is a subtype of type $\String$,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on the right side is a subtype of type $\Number$,
-  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If the expression on the right side is a subtype of type $\String$,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are subtypes of 
+\item{If the expression on the left side is of type $\Number$ or literal number type,
+  check that the other expression is a success type of $\Number$. The return type is $\Number$.}
+\item{If the expression on the left side is of type $\String$ or literal string type,
+  check that the other expression is a success type of $\String$. The return type is $\String$.}
+\item{If the expression on the right side is of type $\Number$ or literal number type,
+  check that the other expression is a success type of $\Number$. The return type is $\Number$.}
+\item{If the expression on the right side is of type $\String$ or literal string type,
+  check that the other expression is a success type of $\String$. The return type is $\String$.}
+\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
   $\Number\ |\ \String$. The return type is $\Any$.}
 \end{itemize}
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
-    \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+    \quad t_1 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
-    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+    \quad t_1 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
-    \quad t_0 \subseteq \Number \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+    \quad t_0 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
-    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+    \quad t_0 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\Number\ |\ \String) \vee t_0 = \Any
-    \quad t_1 \subseteq (\Number\ |\ \String) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \wedge (\Number\ |\ \String) \neq \emptyset
+    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Any}
 \]
 \noindent
 
@@ -291,26 +282,26 @@ The type of the lambda expression is then the function type with the declared ty
 
 \noindent
 \[
-  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash ( \Lp  x_1:\ t_1, \ldots, x_n:\ t_n \Rp :\ t\ \texttt{=>}\ \Lc\ S\ \Rc) : (t_1, \ldots, t_n) \rightarrow t}  
 \]
 \noindent
 
 The type of a conditional expression is the union of the type of its consequent expression and its alternate expression.
-The predicate expression of a conditional expression must be a subtype of a boolean.
+The predicate expression of a conditional expression must be a success type of a boolean.
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash E_{cons} : t_{cons} \quad \Gamma \vdash E_{alt} : t_{alt}
-    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
+    \quad t_{pred} \wedge \Bool \neq \emptyset}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
 \]
 \noindent
 
-For as expressions, the type to cast the expression to must be a subtype of the type of the expression.
+For as expressions, the type to cast the expression to must be a success type of the type of the expression.
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E : t' \quad t \subseteq t'}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
+  \Rule{\Gamma \vdash E : t' \quad t \wedge t' \neq \emptyset}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
 \]
 \noindent
 
@@ -318,12 +309,12 @@ For as expressions, the type to cast the expression to must be a subtype of the 
 
 For constant declarations, the declared type of $x$, $t$, is added to the type environment.
 As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
-The derived type of the expression $E$ must be a subtype of the type declared for name $x$.
+The derived type of the expression $E$ must be a success type of the type declared for name $x$.
 The type of the constant declaration statement itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
 \]
 \noindent
@@ -384,12 +375,12 @@ The type of a block outside of function bodies is the type of the last value-pro
 \noindent
 
 The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
-The predicate expression of a conditional statement must be a subtype of a boolean.
+The predicate expression of a conditional statement must be a success type of a boolean.
 
 \noindent
 \[
   \Rule{\Gamma \vdash S_{pred} : t_{pred} \quad \Gamma \vdash S_{cons} : t_{cons} \quad \Gamma \vdash S_{alt} : t_{alt}
-    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
+    \quad t_{pred} \wedge \Bool \neq \emptyset}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
     \texttt{else}\ \{\ S_{alt}\ \}) : t_{cons}\ |\ t_{alt}}
 \]
 \noindent

--- a/docs/specs/source_1_typed_typing.tex
+++ b/docs/specs/source_1_typed_typing.tex
@@ -363,17 +363,6 @@ If the block does not contain any return statements, the type is $\Undefined$.
 \]
 \noindent
 
-The type of a block outside of function bodies is the type of the last value-producing statement in the block.
-
-\noindent
-\[
-  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
-    \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is the last value-producing statement}}{
-    \Gamma \vdash \{ (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
-    S_1, \ldots, S_n\} : t'_n}
-\]
-\noindent
-
 The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
 The predicate expression of a conditional statement must be a success type of a boolean.
 

--- a/docs/specs/source_2_typed_typing.tex
+++ b/docs/specs/source_2_typed_typing.tex
@@ -372,17 +372,6 @@ If the block does not contain any return statements, the type is $\Undefined$.
 \]
 \noindent
 
-The type of a block outside of function bodies is the type of the last value-producing statement in the block.
-
-\noindent
-\[
-  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
-    \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is the last value-producing statement}}{
-    \Gamma \vdash \{ (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
-    S_1, \ldots, S_n\} : t'_n}
-\]
-\noindent
-
 The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
 The predicate expression of a conditional statement must be a success type of a boolean.
 

--- a/docs/specs/source_2_typed_typing.tex
+++ b/docs/specs/source_2_typed_typing.tex
@@ -254,7 +254,7 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \item{If the expression on the right side is of type $\String$ or literal string type,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
 \item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
-  $\Number\ |\ \String$. The return type is $\Any$.}
+  $\Number\ |\ \String$. The return type is $\Number\ |\ \String$.}
 \end{itemize}
 
 \noindent
@@ -280,7 +280,7 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \wedge (\Number\ |\ \String) \neq \emptyset
-    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number\ |\ \String}
 \]
 \noindent
 

--- a/docs/specs/source_2_typed_typing.tex
+++ b/docs/specs/source_2_typed_typing.tex
@@ -164,67 +164,36 @@ $\Gamma_{-1}$
 & $[$ & \texttt{is\_list} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ $\Gamma_0$ \\
 & \end{tabular}
 
-\subsection{Subtyping}
+\subsection{Success Types}
 
-In order for type checks to be performed in Source \S 2 Typed, we introduce the notion of subtyping.
+In order for type checks to be performed in Source \S 3 Typed, we introduce the notion of success types.
 
+We first define the special $\Any$ type:
 \begin{definition}
-$t \subseteq t'$ is used to denote that type $t$ is a subtype of type $t'$.
+$\Any$ is the union of all possible types.
 \end{definition}
 
-Subtyping is illustrated using the following type rules:
+Success typing in Source Typed is defined as follows:
 
-\noindent
-\[
-\Rule{}{t \subseteq \Any}
-\qquad
-\Rule{t'\ \textit{is a basic type} \quad t\ \textit{is a basic type} \quad t' = t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t'\ \textit{is a literal type} \quad t\ \textit{is a basic type} \quad \texttt{typeof}\ t' = t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{(\forall 1 \leq i \leq n)(t_i \subseteq t'_i) \quad t' \subseteq t}{(t'_1, \ldots t'_n) \rightarrow t' \subseteq (t_1, \ldots t_n) \rightarrow t}
-\qquad
-\Rule{(\exists i)(t' \subseteq t_i)}{t'\ \subseteq\ t_1\ |\ \ldots\ |\ t_n}
-\]
-\noindent
-\[
-\Rule{t' = \textit{Pair<}\ t'_{head}, t'_{tail}\ \textit{>} \quad t = \textit{Pair<}\ t_{head}, t_{tail}\ \textit{>}
-  \quad t'_{head} \subseteq t_{head} \quad t'_{tail} \subseteq t_{tail}}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = \textit{List<}\ t'_{elem}\ \textit{>} \quad t = \textit{List<}\ t_{elem}\ \textit{>}
-  \quad t'_{elem} \subseteq t_{elem}}{t' \subseteq t}
-\qquad
-\Rule{t' = \Null \quad t = \textit{List<}\ t_{elem}\ \textit{>}}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = \textit{Pair<}\ t'_{head}, t'_{tail}\ \textit{>} \quad t = \textit{List<}\ t_{elem}\ \textit{>}
-  \quad t'_{head} \subseteq t_{elem} \quad t'_{tail} \subseteq t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = \textit{List<}\ t'_{elem}\ \textit{>} \quad t = \textit{Pair<}\ t_{head}, t_{tail}\ \textit{>}
-  \quad t'_{elem} \subseteq t_{head} \quad t' \subseteq t_{tail}}{t' \subseteq t}
-\]
-\noindent
+\begin{definition}
+Type $t'$ is a success type of type $t$ if $\exists x (x \in t \wedge x \in t')$.
+Alternatively: $t \wedge t' \neq \emptyset$.
+\end{definition}
+
+In Source Typed, type checks are performed by checking that the actual type is a success type of the expected type.
+This means that type errors will be thrown if and only if a definite clash in types at runtime is detected.
+Given that $\Any$ is the union of all possible types, this also means that the $\Any$ type is guaranteed not to produce any type errors.
 
 \subsection{Typing Relations}
 \label{typing-rules}
 
 To perform type checking on the program, typing relations are applied to every statement and expression in the program.
 
-Note that a name that is declared to be of type $t$ will always refer to values of a type $t'$ such that $t' \subseteq t$ at runtime.
-Names that do not have a type declared will be assumed to have the $any$ type; the $any$ type will not ever produce any type errors.
+Names that do not have a type declared will be assumed to have the $\Any$ type.
 
 \subsubsection{Typing Relations on Expressions}
 
-The derived type of primitive expressions is their literal type, which is always a subtype of its corresponding basic type.
+The derived type of primitive expressions is their literal type, which is an element of its corresponding basic type.
 
 \noindent
 \[
@@ -257,18 +226,18 @@ For function applications (including applications of binary and unary operators)
 \noindent
 \[
 \Rule{\Gamma \vdash E_0 : (t_1, \ldots, t_n) \rightarrow t \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq t_i \vee t'_i = \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
+  \quad (\forall 1 \leq i \leq n)(t'_i \wedge t_i \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+  \quad (\forall 1 \leq i \leq n)(t'_i \wedge \Any \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
 \]
 \noindent
 
 The type of the operator must be a function type with the right number of parameters,
-and the type of every argument must be a subtype of the corresponding parameter type of the function type.
-If all these conditions are met, the type of the function application is the same
+and the type of every argument must be a success type of the corresponding parameter type of the function type.
+If all of the conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
 If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
 
@@ -276,42 +245,42 @@ Applications of binary and unary operators are treated the same as function appl
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on the left side is a subtype of type $\Number$,
-  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If the expression on the left side is a subtype of type $\String$,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on the right side is a subtype of type $\Number$,
-  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If the expression on the right side is a subtype of type $\String$,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are subtypes of 
+\item{If the expression on the left side is of type $\Number$ or literal number type,
+  check that the other expression is a success type of $\Number$. The return type is $\Number$.}
+\item{If the expression on the left side is of type $\String$ or literal string type,
+  check that the other expression is a success type of $\String$. The return type is $\String$.}
+\item{If the expression on the right side is of type $\Number$ or literal number type,
+  check that the other expression is a success type of $\Number$. The return type is $\Number$.}
+\item{If the expression on the right side is of type $\String$ or literal string type,
+  check that the other expression is a success type of $\String$. The return type is $\String$.}
+\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
   $\Number\ |\ \String$. The return type is $\Any$.}
 \end{itemize}
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
-    \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+    \quad t_1 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
-    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+    \quad t_1 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
-    \quad t_0 \subseteq \Number \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+    \quad t_0 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
-    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+    \quad t_0 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\Number\ |\ \String) \vee t_0 = \Any
-    \quad t_1 \subseteq (\Number\ |\ \String) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \wedge (\Number\ |\ \String) \neq \emptyset
+    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Any}
 \]
 \noindent
 
@@ -322,26 +291,26 @@ The type of the lambda expression is then the function type with the declared ty
 
 \noindent
 \[
-  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash ( \Lp  x_1:\ t_1, \ldots, x_n:\ t_n \Rp :\ t\ \texttt{=>}\ \Lc\ S\ \Rc) : (t_1, \ldots, t_n) \rightarrow t}  
 \]
 \noindent
 
 The type of a conditional expression is the union of the type of its consequent expression and its alternate expression.
-The predicate expression of a conditional expression must be a subtype of a boolean.
+The predicate expression of a conditional expression must be a success type of a boolean.
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash E_{cons} : t_{cons} \quad \Gamma \vdash E_{alt} : t_{alt}
-    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
+    \quad t_{pred} \wedge \Bool \neq \emptyset}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
 \]
 \noindent
 
-For as expressions, the type to cast the expression to must be a subtype of the type of the expression.
+For as expressions, the type to cast the expression to must be a success type of the type of the expression.
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E : t' \quad t \subseteq t'}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
+  \Rule{\Gamma \vdash E : t' \quad t \wedge t' \neq \emptyset}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
 \]
 \noindent
 
@@ -349,12 +318,12 @@ For as expressions, the type to cast the expression to must be a subtype of the 
 
 For constant declarations, the declared type of $x$, $t$, is added to the type environment.
 As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
-The derived type of the expression $E$ must be a subtype of the type declared for name $x$.
+The derived type of the expression $E$ must be a success type of the type declared for name $x$.
 The type of the constant declaration statement itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
 \]
 \noindent
@@ -415,12 +384,12 @@ The type of a block outside of function bodies is the type of the last value-pro
 \noindent
 
 The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
-The predicate expression of a conditional statement must be a subtype of a boolean.
+The predicate expression of a conditional statement must be a success type of a boolean.
 
 \noindent
 \[
   \Rule{\Gamma \vdash S_{pred} : t_{pred} \quad \Gamma \vdash S_{cons} : t_{cons} \quad \Gamma \vdash S_{alt} : t_{alt}
-    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
+    \quad t_{pred} \wedge \Bool \neq \emptyset}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
     \texttt{else}\ \{\ S_{alt}\ \}) : t_{cons}\ |\ t_{alt}}
 \]
 \noindent

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -401,17 +401,6 @@ If the block does not contain any return statements, the type is $\Undefined$.
 \]
 \noindent
 
-The type of a block outside of function bodies is the type of the last value-producing statement in the block.
-
-\noindent
-\[
-  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
-    \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is the last value-producing statement}}{
-    \Gamma \vdash \{ (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
-    S_1, \ldots, S_n\} : t'_n}
-\]
-\noindent
-
 The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
 The predicate expression of a conditional statement must be a success type of a boolean.
 

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -258,7 +258,7 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \item{If the expression on the right side is of type $\String$ or literal string type,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
 \item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
-  $\Number\ |\ \String$. The return type is $\Any$.}
+  $\Number\ |\ \String$. The return type is $\Number\ |\ \String$.}
 \end{itemize}
 
 \noindent
@@ -284,7 +284,7 @@ For the \texttt{+} operator, the following rules are applied, in order of priori
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \wedge (\Number\ |\ \String) \neq \emptyset
-    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number\ |\ \String}
 \]
 \noindent
 

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -321,12 +321,12 @@ For as expressions, the type to cast the expression to must be a success type of
 \subsubsection{Typing Relations on Assignments}
 
 For assignments, the type of the right expression must be a success type of the type of the left expression.
-The type of the assignment itself is $\Undefined$.
+The type of the assignment itself is the type of the right expression.
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \wedge t_0 \neq \emptyset}{
-    \Gamma \vdash (E_0 = E_1) : \Undefined}
+    \Gamma \vdash (E_0 = E_1) : t_1}
 \]
 \noindent
 

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -168,71 +168,36 @@ $\Gamma_{-1}$
 & $[$ & \texttt{array\_length} & $\leftarrow$  & $\Any$[] & $\rightarrow$ & $\Number$ & $]$ $\Gamma_0$ \\
 & \end{tabular}
 
-\subsection{Subtyping}
+\subsection{Success Types}
 
-In order for type checks to be performed in Source \S 3 Typed, we introduce the notion of subtyping.
+In order for type checks to be performed in Source \S 3 Typed, we introduce the notion of success types.
 
+We first define the special $\Any$ type:
 \begin{definition}
-$t \subseteq t'$ is used to denote that type $t$ is a subtype of type $t'$.
+$\Any$ is the union of all possible types.
 \end{definition}
 
-Subtyping is illustrated using the following type rules:
+Success typing in Source Typed is defined as follows:
 
-\noindent
-\[
-\Rule{}{t \subseteq \Any}
-\qquad
-\Rule{t'\ \textit{is a basic type} \quad t\ \textit{is a basic type} \quad t' = t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t'\ \textit{is a literal type} \quad t\ \textit{is a basic type} \quad \texttt{typeof}\ t' = t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{(\forall 1 \leq i \leq n)(t_i \subseteq t'_i) \quad t' \subseteq t}{(t'_1, \ldots t'_n) \rightarrow t' \subseteq (t_1, \ldots t_n) \rightarrow t}
-\qquad
-\Rule{(\exists i)(t' \subseteq t_i)}{t'\ \subseteq\ t_1\ |\ \ldots\ |\ t_n}
-\]
-\noindent
-\[
-\Rule{t' = \textit{Pair<}\ t'_{head}, t'_{tail}\ \textit{>} \quad t = \textit{Pair<}\ t_{head}, t_{tail}\ \textit{>}
-  \quad t'_{head} \subseteq t_{head} \quad t'_{tail} \subseteq t_{tail}}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = \textit{List<}\ t'_{elem}\ \textit{>} \quad t = \textit{List<}\ t_{elem}\ \textit{>}
-  \quad t'_{elem} \subseteq t_{elem}}{t' \subseteq t}
-\qquad
-\Rule{t' = \Null \quad t = \textit{List<}\ t_{elem}\ \textit{>}}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = \textit{Pair<}\ t'_{head}, t'_{tail}\ \textit{>} \quad t = \textit{List<}\ t_{elem}\ \textit{>}
-  \quad t'_{head} \subseteq t_{elem} \quad t'_{tail} \subseteq t}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = \textit{List<}\ t'_{elem}\ \textit{>} \quad t = \textit{Pair<}\ t_{head}, t_{tail}\ \textit{>}
-  \quad t'_{elem} \subseteq t_{head} \quad t' \subseteq t_{tail}}{t' \subseteq t}
-\]
-\noindent
-\[
-\Rule{t' = t'_{elem}[] \quad t = t_{elem}[] \quad t'_{elem} \subseteq t_{elem}}{t' \subseteq t}
-\]
-\noindent
+\begin{definition}
+Type $t'$ is a success type of type $t$ if $\exists x (x \in t \wedge x \in t')$.
+Alternatively: $t \wedge t' \neq \emptyset$.
+\end{definition}
+
+In Source Typed, type checks are performed by checking that the actual type is a success type of the expected type.
+This means that type errors will be thrown if and only if a definite clash in types at runtime is detected.
+Given that $\Any$ is the union of all possible types, this also means that the $\Any$ type is guaranteed not to produce any type errors.
 
 \subsection{Typing Relations}
 \label{typing-rules}
 
 To perform type checking on the program, typing relations are applied to every statement and expression in the program.
 
-Note that a name that is declared to be of type $t$ will always refer to values of a type $t'$ such that $t' \subseteq t$ at runtime.
-Names that do not have a type declared will be assumed to have the $any$ type; the $any$ type will not ever produce any type errors.
+Names that do not have a type declared will be assumed to have the $\Any$ type.
 
 \subsubsection{Typing Relations on Expressions}
 
-The derived type of primitive expressions is their literal type, which is always a subtype of its corresponding basic type.
+The derived type of primitive expressions is their literal type, which is an element of its corresponding basic type.
 
 \noindent
 \[
@@ -265,18 +230,18 @@ For function applications (including applications of binary and unary operators)
 \noindent
 \[
 \Rule{\Gamma \vdash E_0 : (t_1, \ldots, t_n) \rightarrow t \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq t_i \vee t'_i = \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
+  \quad (\forall 1 \leq i \leq n)(t'_i \wedge t_i \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : t}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \subseteq \Any)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+  \quad (\forall 1 \leq i \leq n)(t'_i \wedge \Any \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
 \]
 \noindent
 
 The type of the operator must be a function type with the right number of parameters,
-and the type of every argument must be a subtype of the corresponding parameter type of the function type.
-If all these conditions are met, the type of the function application is the same
+and the type of every argument must be a success type of the corresponding parameter type of the function type.
+If all of the conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
 If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
 
@@ -284,42 +249,42 @@ Applications of binary and unary operators are treated the same as function appl
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on the left side is a subtype of type $\Number$,
-  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If the expression on the left side is a subtype of type $\String$,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on the right side is a subtype of type $\Number$,
-  check that the other expression is a subtype of $\Number$. The return type is $\Number$.}
-\item{If the expression on the right side is a subtype of type $\String$,
-  check that the other expression is a subtype of $\String$. The return type is $\String$.}
-\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are subtypes of 
+\item{If the expression on the left side is of type $\Number$ or literal number type,
+  check that the other expression is a success type of $\Number$. The return type is $\Number$.}
+\item{If the expression on the left side is of type $\String$ or literal string type,
+  check that the other expression is a success type of $\String$. The return type is $\String$.}
+\item{If the expression on the right side is of type $\Number$ or literal number type,
+  check that the other expression is a success type of $\Number$. The return type is $\Number$.}
+\item{If the expression on the right side is of type $\String$ or literal string type,
+  check that the other expression is a success type of $\String$. The return type is $\String$.}
+\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
   $\Number\ |\ \String$. The return type is $\Any$.}
 \end{itemize}
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
-    \quad t_1 \subseteq \Number \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+    \quad t_1 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
-    \quad t_1 \subseteq \String \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+    \quad t_1 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
-    \quad t_0 \subseteq \Number \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Number}
+    \quad t_0 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
   \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
-    \quad t_0 \subseteq \String \vee t_0 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \String}
+    \quad t_0 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq (\Number\ |\ \String) \vee t_0 = \Any
-    \quad t_1 \subseteq (\Number\ |\ \String) \vee t_1 = \Any}{\Gamma \vdash E_0\ + \ E_1 : \Any}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \wedge (\Number\ |\ \String) \neq \emptyset
+    \quad t_1 \wedge (\Number\ |\ \String) \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Any}
 \]
 \noindent
 
@@ -330,76 +295,54 @@ The type of the lambda expression is then the function type with the declared ty
 
 \noindent
 \[
-  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad \Gamma' \vdash S : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash ( \Lp  x_1:\ t_1, \ldots, x_n:\ t_n \Rp :\ t\ \texttt{=>}\ \Lc\ S\ \Rc) : (t_1, \ldots, t_n) \rightarrow t}  
 \]
 \noindent
 
 The type of a conditional expression is the union of the type of its consequent expression and its alternate expression.
-The predicate expression of a conditional expression must be a subtype of a boolean.
+The predicate expression of a conditional expression must be a success type of a boolean.
 
 \noindent
 \[
   \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash E_{cons} : t_{cons} \quad \Gamma \vdash E_{alt} : t_{alt}
-    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
+    \quad t_{pred} \wedge \Bool \neq \emptyset}{\Gamma \vdash (E_{pred}\ \texttt{?}\ E_{cons} : E_{alt}) : t_{cons}\ |\ t_{alt}}
 \]
 \noindent
 
-The type of a literal array expression is the union of the types of all of the array's members.
+For as expressions, the type to cast the expression to must be a success type of the type of the expression.
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_1 : t_1, \ldots, \Gamma \vdash E_n : t_n}{
-    \Gamma \vdash [E_1, \ldots, E_n] : (t_1\ |\ \ldots\ |\ t_n)[]}
-\]
-\noindent
-
-The type of an array access expression is the member type of the array. The array index must be a number.
-If the type of the array being accessed is $\Any$, the type of the array access expression is $\Any$.
-
-\noindent
-\[
-  \Rule{\Gamma \vdash E_0 : t_0[] \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number \vee t_1 = \Any}{
-    \Gamma \vdash E_0[E_1] : t_0}
-  \quad
-  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number \vee t_1 = \Any}{
-    \Gamma \vdash E_0[E_1] : \Any}
-\]
-\noindent
-
-For as expressions, the type to cast the expression to must be a subtype of the type of the expression.
-
-\noindent
-\[
-  \Rule{\Gamma \vdash E : t' \quad t \subseteq t'}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
+  \Rule{\Gamma \vdash E : t' \quad t \wedge t' \neq \emptyset}{\Gamma \vdash (E\ \texttt{as}\ t) : t}  
 \]
 \noindent
 
 \subsubsection{Typing Relations on Assignments}
 
-For assignments, the type of the right expression must be a subtype of the type of the left expression.
+For assignments, the type of the right expression must be a success type of the type of the left expression.
 The type of the assignment itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq t_0 \vee t_1 = \Any}{
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \wedge t_0 \neq \emptyset}{
     \Gamma \vdash (E_0 = E_1) : \Undefined}
 \]
 \noindent
 
 \subsubsection{Typing Relations on Statements}
 
-For constant or variable declarations, the declared type of $x$, $t$, is added to the type environment.
+For constant declarations, the declared type of $x$, $t$, is added to the type environment.
 As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
-The derived type of the expression $E$ must be a subtype of the type declared for name $x$.
+The derived type of the expression $E$ must be a success type of the type declared for name $x$.
 The type of the constant declaration statement itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
   \qquad
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \subseteq t \vee t' = \Any}{
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
     \Gamma \vdash (\texttt{let}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
 \]
 \noindent
@@ -446,14 +389,14 @@ If the block does not contain any return statements, the type is $\Undefined$.
 \[
   \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
     \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is a return statement}}{
-    \Gamma \vdash \{ (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
+    \Gamma \vdash \{ (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
     S_1, \ldots, S_n\} : t'_n}
 \]
 \noindent
 \[
   \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
     \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is not a return statement}}{
-    \Gamma \vdash \{ (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1 \texttt{;}) \ldots (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
+    \Gamma \vdash \{ (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
     S_1, \ldots, S_n\} : \Undefined}
 \]
 \noindent
@@ -464,27 +407,27 @@ The type of a block outside of function bodies is the type of the last value-pro
 \[
   \Rule{\Gamma [x_1 \leftarrow t_1] \cdots [x_n \leftarrow t_n] \Gamma' \quad
     \Gamma' \vdash S_1 : t'_1, \ldots, \Gamma' \vdash S_n : t'_n \quad S_n\ \textit{is the last value-producing statement}}{
-    \Gamma \vdash \{ (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{decl}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
+    \Gamma \vdash \{ (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;}) \ldots (\texttt{const}\ x_1 \texttt{:}\ t_1 = E_1\texttt{;})\
     S_1, \ldots, S_n\} : t'_n}
 \]
 \noindent
 
 The type of a conditional statement or if statement is the union of the type of its consequent statement and its alternate statement.
-The predicate expression of a conditional statement must be a subtype of a boolean.
+The predicate expression of a conditional statement must be a success type of a boolean.
 
 \noindent
 \[
   \Rule{\Gamma \vdash S_{pred} : t_{pred} \quad \Gamma \vdash S_{cons} : t_{cons} \quad \Gamma \vdash S_{alt} : t_{alt}
-    \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
+    \quad t_{pred} \wedge \Bool \neq \emptyset}{\Gamma \vdash (\texttt{if}\ (S_{pred})\ \{\ S_{cons}\ \}\
     \texttt{else}\ \{\ S_{alt}\ \}) : t_{cons}\ |\ t_{alt}}
 \]
 \noindent
 
-For \texttt{while} statements, the predicate expression must be a subtype of $\Bool$. The rest of the statement is treated as a block.
+For \texttt{while} statements, the predicate expression must be a success type of $\Bool$. The rest of the statement is treated as a block.
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash S : t \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any }{
+  \Rule{\Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash S : t \quad t_{pred} \wedge \Bool \neq \emptyset}{
     \Gamma \vdash (\texttt{while}\ (\ E_{pred}\ )\ \{\ S\ \}) : t}
 \]
 \noindent
@@ -495,7 +438,7 @@ except with additional type checks for the initialization and assignment express
 \noindent
 \[
   \Rule{\Gamma \vdash E_{init} : t_{init} \quad \Gamma \vdash E_{pred} : t_{pred} \quad \Gamma \vdash E_{assign} : t_{assign} \quad
-    \Gamma \vdash S : t \quad t_{pred} \subseteq \Bool \vee t_{pred} = \Any }{
+    \Gamma \vdash S : t \quad t_{pred} \wedge \Bool \neq \emptyset}{
     \Gamma \vdash (\texttt{for}\ (\ E_{init} \texttt{;} E_{pred} \texttt{;} E_{assign}\ )\ \{\ S\ \}) : t}
 \]
 \noindent

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -482,25 +482,6 @@ export class TypeNotCallableError implements SourceError {
   }
 }
 
-export class NoExplicitAnyError implements SourceError {
-  public type = ErrorType.TYPE
-  public severity = ErrorSeverity.ERROR
-
-  constructor(public node: tsEs.TSAsExpression) {}
-
-  get location() {
-    return this.node.loc!
-  }
-
-  public explain() {
-    return "Typecasting to 'any' is not allowed."
-  }
-
-  public elaborate() {
-    return this.explain()
-  }
-}
-
 export class TypecastError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
@@ -516,7 +497,7 @@ export class TypecastError implements SourceError {
   }
 
   public explain() {
-    return `Type '${this.originalType}' cannot be casted to type '${this.typeToCastTo}' as '${this.originalType}' is not a superset of '${this.typeToCastTo}'.`
+    return `Type '${this.originalType}' cannot be casted to type '${this.typeToCastTo}' as the two types do not intersect.`
   }
 
   public elaborate() {

--- a/src/typeChecker/__tests__/source1Typed.test.ts
+++ b/src/typeChecker/__tests__/source1Typed.test.ts
@@ -651,18 +651,19 @@ describe('binary operations', () => {
       const x12: number = x1 + x4; // no error, number + any, return type number
       const x13: string = x5 + x2; // no error, any + string, return type string
       const x14: number = x1 + x2; // error, number + string, return type number (follows left side)
-      const x15: string = x4 + x5; // no error, any + any, return type any
-      const x16: number | string = x6 + x4; // no error, string | number + any, return type any
+      const x15: string = x4 + x5; // no error, any + any, return type string | number
+      const x16: boolean = x6 + x4; // error, string | number + any, return type number | string
       const x17: number = x1 + x6; // no error, number + string | number, return type number
       const x18: string = x6 + x2; // no error, string | number + string, return type string
-      const x19: string | number = x5 + x7; // no error, any + string | boolean, return type any
+      const x19: string | number = x5 + x7; // no error, any + string | boolean, return type number | string
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
       "Line 10: Type 'boolean' is not assignable to type 'number'.
       Line 11: Type 'boolean' is not assignable to type 'string'.
-      Line 14: Type 'string' is not assignable to type 'number'."
+      Line 14: Type 'string' is not assignable to type 'number'.
+      Line 16: Type 'number | string' is not assignable to type 'boolean'."
     `)
   })
 

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -86,18 +86,19 @@ describe('list', () => {
       const x2: List<number> = list(); // no error
       const x3: List<number> = list('1'); // error
       const x4: List<number> = 1; // error
-      const x5: List<number> = list(1, '2'); // error
-      const x6: List<number | string> = list(1, '2'); // no error
-      const x7: List<number, string> = list(1, '2'); // error
-      const x8: List<null> = list(null, null); // no error
+      const x5: List<number> = list(1, '2'); // no error
+      const x6: List<boolean> = list(1, '2'); // error
+      const x7: List<number | string> = list(1, '2'); // no error
+      const x8: List<number, string> = list(1, '2'); // error
+      const x9: List<null> = list(null, null); // no error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 7: Generic type 'List' requires 1 type argument(s).
+      "Line 8: Generic type 'List' requires 1 type argument(s).
       Line 3: Type 'List<string>' is not assignable to type 'List<number>'.
       Line 4: Type 'number' is not assignable to type 'List<number>'.
-      Line 5: Type 'List<number | string>' is not assignable to type 'List<number>'."
+      Line 6: Type 'List<number | string>' is not assignable to type 'List<boolean>'."
     `)
   })
 
@@ -135,36 +136,36 @@ describe('head', () => {
     )
   })
 
-  it('return type is type of first element in pair', () => {
+  it('return type for pair is type of first element in pair', () => {
     const code = `const x1: Pair<number, number> = pair(1, 2);
     const x2: Pair<string, number> = pair('1', 2);
     const x3: Pair<string | number, number> = pair('1', 2);
     const x4: number = head(x1); // no error
     const x5: string = head(x2); // no error
     const x6: string = head(pair('1', 2)); // no error
-    const x7: string = head(x3); // error
+    const x7: boolean = head(x3); // error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"Line 7: Type 'string | number' is not assignable to type 'string'."`
+      `"Line 7: Type 'string | number' is not assignable to type 'boolean'."`
     )
   })
 
-  it('return type is element type in list', () => {
+  it('return type for list is element type in list', () => {
     const code = `const x1: List<number> = list(1, 2);
     const x2: List<string> = list('1', '2');
     const x3: List<string | number> = list('1', 2);
     const x4: number = head(x1); // no error
     const x5: string = head(x2); // no error
-    const x6: string = head(list('1', 2)); // error
-    const x7: string = head(x3); // error
+    const x6: boolean = head(list('1', 2)); // error
+    const x7: boolean = head(x3); // error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 6: Type 'string | number' is not assignable to type 'string'.
-      Line 7: Type 'string | number' is not assignable to type 'string'."
+      "Line 6: Type 'string | number' is not assignable to type 'boolean'.
+      Line 7: Type 'string | number' is not assignable to type 'boolean'."
     `)
   })
 })
@@ -183,19 +184,19 @@ describe('tail', () => {
     )
   })
 
-  it('return type is type of second element in pair', () => {
+  it('return type for pair is type of second element in pair', () => {
     const code = `const x1: Pair<number, number> = pair(1, 2);
     const x2: Pair<number, string> = pair(1, '2');
     const x3: Pair<number, string | number> = pair(1, '2');
     const x4: number = tail(x1); // no error
     const x5: string = tail(x2); // no error
     const x6: string = tail(pair(1, '2')); // no error
-    const x7: string = tail(x3); // error
+    const x7: boolean = tail(x3); // error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"Line 7: Type 'string | number' is not assignable to type 'string'."`
+      `"Line 7: Type 'string | number' is not assignable to type 'boolean'."`
     )
   })
 
@@ -206,12 +207,12 @@ describe('tail', () => {
     const x4: List<number> = tail(x1); // no error
     const x5: List<string> = tail(x2); // no error
     const x6: List<number> = tail(list('1', 2)); // no error
-    const x7: List<string> = tail(x3); // error
+    const x7: List<boolean> = tail(x3); // error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"Line 7: Type 'List<string | number>' is not assignable to type 'List<string>'."`
+      `"Line 7: Type 'List<string | number>' is not assignable to type 'List<boolean>'."`
     )
   })
 })

--- a/src/typeChecker/__tests__/source3Typed.test.ts
+++ b/src/typeChecker/__tests__/source3Typed.test.ts
@@ -157,7 +157,7 @@ describe('while loops', () => {
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
       "Line 6: Type 'number' is not assignable to type 'boolean'.
-      Line 9: Type 'undefined' is not assignable to type 'boolean'.
+      Line 9: Type 'number' is not assignable to type 'boolean'.
       Line 12: Type 'number' is not assignable to type 'boolean'."
     `)
   })
@@ -185,7 +185,7 @@ describe('for loops', () => {
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
       "Line 4: Type 'number' is not assignable to type 'boolean'.
-      Line 7: Type 'undefined' is not assignable to type 'boolean'.
+      Line 7: Type 'number' is not assignable to type 'boolean'.
       Line 10: Type 'number' is not assignable to type 'boolean'."
     `)
   })

--- a/src/typeChecker/__tests__/source3Typed.test.ts
+++ b/src/typeChecker/__tests__/source3Typed.test.ts
@@ -11,54 +11,63 @@ beforeEach(() => {
 
 describe('array type', () => {
   it('handles type mismatches correctly', () => {
-    const code = `const arr1: number[] = [1, 2, 3];
-      const arr2: string[] = ['1', '2', '3'];
-      const arr3: number[] = [1, '2', 3];
-      const arr4: string[] = [1, '2', 3];
-      const arr5: (number | string)[] = [1, '2', 3];
-      const arr6: number[] = [];
+    const code = `const arr1: number[] = [1, 2, 3]; // no error
+      const arr2: string[] = ['1', '2', '3']; // no error
+      const arr3: number[] = [1, '2', 3]; // no error
+      const arr4: boolean[] = [1, '2', 3]; // error
+      const arr5: (number | string)[] = [1, '2', 3]; // no error
+      const arr6: number[] = []; // no error
     `
 
     parse(code, context)
-    expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 3: Type '(number | string)[]' is not assignable to type 'number[]'.
-      Line 4: Type '(number | string)[]' is not assignable to type 'string[]'."
-    `)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 4: Type '(number | string)[]' is not assignable to type 'boolean[]'."`
+    )
   })
 
   it('handles nested array types', () => {
-    const code = `const arr1: number[][] = [[1], [2], [3]];
-      const arr2: string[][] = [['1'], ['2'], ['3']];
-      const arr3: number[][] = [[1], ['2'], [3]];
-      const arr4: string[][] = [[1], ['2'], [3]];
-      const arr5: (number | string)[][] = [[1], ['2'], [3]];
-      const arr6: number[][] = [];
+    const code = `const arr1: number[][] = [[1], [2], [3]]; // no error
+      const arr2: string[][] = [['1'], ['2'], ['3']]; // no error
+      const arr3: number[][] = [[1], ['2'], [3]]; // no error
+      const arr4: boolean[][] = [[1], ['2'], [3]]; // error
+      const arr5: (number | string)[][] = [[1], ['2'], [3]]; // no error
+      const arr6: number[][] = []; // no error
+      const arr7: number[][] = [1, 2, 3]; // error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 3: Type '(number[] | string[])[]' is not assignable to type 'number[][]'.
-      Line 4: Type '(number[] | string[])[]' is not assignable to type 'string[][]'."
+      "Line 4: Type '(number[] | string[])[]' is not assignable to type 'boolean[][]'.
+      Line 7: Type 'number[]' is not assignable to type 'number[][]'."
     `)
   })
 })
 
 describe('array access', () => {
-  it('index must be number', () => {
+  it('index must be success type of number', () => {
     const code = `const arr: number[] = [1, 2, 3];
-      arr[0];
-      arr['1'];
-      arr[true];
-      arr[undefined];
-      arr[null];
+      const x1: number = 0;
+      const x2: string = '1';
+      const x3: boolean = true;
+      const x4: string | number = '1';
+      const x5: string | boolean = '1';
+      arr[0]; // no error
+      arr['1']; // error
+      arr[true]; // error
+      arr[x1]; // no error
+      arr[x2]; // error
+      arr[x3]; // error
+      arr[x4]; // no error
+      arr[x5]; // error
     `
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 3: Type '\\"1\\"' cannot be used as an index type.
-      Line 4: Type 'true' cannot be used as an index type.
-      Line 5: Type 'undefined' cannot be used as an index type.
-      Line 6: Type 'null' cannot be used as an index type."
+      "Line 8: Type '\\"1\\"' cannot be used as an index type.
+      Line 9: Type 'true' cannot be used as an index type.
+      Line 11: Type 'string' cannot be used as an index type.
+      Line 12: Type 'boolean' cannot be used as an index type.
+      Line 14: Type 'string | boolean' cannot be used as an index type."
     `)
   })
 
@@ -125,7 +134,7 @@ describe('variable assignment', () => {
 })
 
 describe('while loops', () => {
-  it('predicate must be boolean', () => {
+  it('predicate must be success type of boolean', () => {
     const code = `let x: number = 0;
       let y: boolean = true;
       while (x < 1) { // no error
@@ -155,7 +164,7 @@ describe('while loops', () => {
 })
 
 describe('for loops', () => {
-  it('predicate must be boolean', () => {
+  it('predicate must be success type of boolean', () => {
     const code = `for (let x: number = 0; x < 1; x = x + 1) { // no error
         display(x);
       }
@@ -189,6 +198,34 @@ describe('for loops', () => {
       for (x = '1'; x === '1'; x = x + '1') {
         display(x);
       }
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
+})
+
+describe('binary operations', () => {
+  it('=== and !== allows any type on both sides', () => {
+    const code = `const x1: number = 1;
+      const x2: string = '1';
+      const x3: boolean = true;
+      const x4: any = true;
+      const x5 = undefined;
+      const x6: string | number = 1;
+      const x7: string | boolean = '1';
+      const x8: boolean = x1 === 1; // number + number
+      const x9: boolean = x2 !== '1'; // string + string
+      const x10: boolean = x1 === x3; // number + boolean
+      const x11: boolean = x3 !== x2; // boolean + string
+      const x12: boolean = x1 === x4; // number + any
+      const x13: boolean = x5 !== x2; // any + string
+      const x14: boolean = x1 === x2; // number + string
+      const x15: boolean = x4 !== x5; // any + any
+      const x16: boolean = x6 === x4; // string | number + any
+      const x17: boolean = x1 !== x6; // number + string | number
+      const x18: boolean = x6 === x2; // string | number + string
+      const x19: boolean = x5 !== x7; // any + string | boolean
     `
 
     parse(code, context)

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -402,7 +402,7 @@ function typeCheckAndReturnType(node: tsEs.Node, context: Context, env: TypeEnvi
         context.errors.push(new ConstNotAssignableTypeError(node, node.left.name))
       }
       checkForTypeMismatch(node, actualType, expectedType, context)
-      return tUndef
+      return actualType
     case 'ArrayExpression':
       // Casting is safe here as Source disallows use of spread elements and holes in arrays
       const elements = node.elements.filter(

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -655,10 +655,10 @@ function typeCheckAndReturnBinaryExpressionType(
         return rightType
       }
 
-      // Return type is any if both left and right are neither number nor string
+      // Return type is number | string if both left and right are neither number nor string
       checkForTypeMismatch(node, leftType, tUnion(tNumber, tString), context)
       checkForTypeMismatch(node, rightType, tUnion(tNumber, tString), context)
-      return tAny
+      return tUnion(tNumber, tString)
     case '<':
     case '<=':
     case '>':


### PR DESCRIPTION
Modifies the Source Typed variant such type errors are thrown only when the intersection of the expected and actual type is the empty set.