### PR TITLE
Refactor Source runner to operate on an AST instead of code

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -153,7 +153,7 @@ export const createEmptyContext = <T>(
     moduleContexts: {},
     unTypecheckedCode: [],
     typeEnvironment: createTypeEnvironment(chapter),
-    previousCode: [],
+    previousPrograms: [],
     shouldIncreaseEvaluationTimeout: false
   }
 }

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -153,7 +153,8 @@ export const createEmptyContext = <T>(
     moduleContexts: {},
     unTypecheckedCode: [],
     typeEnvironment: createTypeEnvironment(chapter),
-    previousCode: []
+    previousCode: [],
+    shouldIncreaseEvaluationTimeout: false
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,7 +324,11 @@ export async function runFilesInContext(
   }
 
   if (context.chapter === Chapter.FULL_JS) {
-    return fullJSRunner(code, context, options)
+    const program = parse(code, context)
+    if (program === undefined) {
+      return resolvedErrorPromise
+    }
+    return fullJSRunner(program, context, options)
   }
 
   if (context.chapter === Chapter.HTML) {

--- a/src/infiniteLoops/__tests__/errors.ts
+++ b/src/infiniteLoops/__tests__/errors.ts
@@ -1,3 +1,5 @@
+import * as es from 'estree'
+
 import { ExceptionError } from '../../errors/errors'
 import { RuntimeSourceError } from '../../errors/runtimeSourceError'
 import { TimeoutError } from '../../errors/timeoutErrors'
@@ -13,6 +15,11 @@ import {
 
 const noBaseCaseError = new InfiniteLoopError('f', false, 'test', InfiniteLoopErrorType.NoBaseCase)
 const fakePos = { start: { line: 0, column: 0 }, end: { line: 0, column: 0 } }
+const emptyProgram: es.Program = {
+  type: 'Program',
+  sourceType: 'module',
+  body: []
+}
 
 test('timeout errors are potential infinite loops', () => {
   const error = new TimeoutError()
@@ -38,12 +45,13 @@ test('other errors are not potential infinite loops', () => {
 test('getInfiniteLoopData works when error is directly reported', () => {
   const context = mockContext(Chapter.SOURCE_4)
   context.errors.push(noBaseCaseError)
-  context.previousCode.push('test')
+
+  context.previousPrograms.push(emptyProgram)
   const result = getInfiniteLoopData(context)
   expect(result).toBeDefined()
   expect(result?.[0]).toBe(InfiniteLoopErrorType.NoBaseCase)
   expect(result?.[3].length).toBe(1)
-  expect(result?.[3]).toContain('test')
+  expect(result?.[3]).toContain(emptyProgram)
 })
 
 test('getInfiniteLoopData works when error hidden in timeout', () => {
@@ -51,12 +59,12 @@ test('getInfiniteLoopData works when error hidden in timeout', () => {
   error.infiniteLoopError = noBaseCaseError
   const context = mockContext(Chapter.SOURCE_4)
   context.errors.push(error)
-  context.previousCode.push('test')
+  context.previousPrograms.push(emptyProgram)
   const result = getInfiniteLoopData(context)
   expect(result).toBeDefined()
   expect(result?.[0]).toBe(InfiniteLoopErrorType.NoBaseCase)
   expect(result?.[3].length).toBe(1)
-  expect(result?.[3]).toContain('test')
+  expect(result?.[3]).toContain(emptyProgram)
 })
 
 test('getInfiniteLoopData works when error hidden in exceptionError', () => {
@@ -64,10 +72,10 @@ test('getInfiniteLoopData works when error hidden in exceptionError', () => {
   innerError.infiniteLoopError = noBaseCaseError
   const context = mockContext(Chapter.SOURCE_4)
   context.errors.push(new ExceptionError(innerError, fakePos))
-  context.previousCode.push('test')
+  context.previousPrograms.push(emptyProgram)
   const result = getInfiniteLoopData(context)
   expect(result).toBeDefined()
   expect(result?.[0]).toBe(InfiniteLoopErrorType.NoBaseCase)
   expect(result?.[3].length).toBe(1)
-  expect(result?.[3]).toContain('test')
+  expect(result?.[3]).toContain(emptyProgram)
 })

--- a/src/infiniteLoops/__tests__/runtime.ts
+++ b/src/infiniteLoops/__tests__/runtime.ts
@@ -72,7 +72,7 @@ const testForInfiniteLoopWithCode = (code: string, previousPrograms: es.Program[
   const context = createContext(Chapter.SOURCE_4, Variant.DEFAULT)
   const program = parse(code, context)
   if (program === undefined) {
-    return
+    throw new Error('Unable to parse code.')
   }
   return testForInfiniteLoop(program, previousPrograms)
 }

--- a/src/infiniteLoops/__tests__/runtime.ts
+++ b/src/infiniteLoops/__tests__/runtime.ts
@@ -1,7 +1,11 @@
+import * as es from 'estree'
+
 import { runInContext } from '../..'
+import createContext from '../../createContext'
 import { mockContext } from '../../mocks/context'
 import * as moduleLoader from '../../modules/moduleLoader'
-import { Chapter } from '../../types'
+import { parse } from '../../parser/parser'
+import { Chapter, Variant } from '../../types'
 import { stripIndent } from '../../utils/formatters'
 import { getInfiniteLoopData, InfiniteLoopError, InfiniteLoopErrorType } from '../errors'
 import { testForInfiniteLoop } from '../runtime'
@@ -64,13 +68,22 @@ test('works in runInContext when throwInfiniteLoops is false', async () => {
   expect(result?.[1]).toBe(false)
 })
 
+const testForInfiniteLoopWithCode = (code: string, previousPrograms: es.Program[]) => {
+  const context = createContext(Chapter.SOURCE_4, Variant.DEFAULT)
+  const program = parse(code, context)
+  if (program === undefined) {
+    return
+  }
+  return testForInfiniteLoop(program, previousPrograms)
+}
+
 test('non-infinite recursion not detected', () => {
   const code = `function fib(x) {
         return x<=1?x:fib(x-1) + fib(x-2);
     }
     fib(100000);
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result).toBeUndefined()
 })
 
@@ -79,7 +92,7 @@ test('non-infinite loop not detected', () => {
     let j = 0;
     while(j<2000) {j=j+1;}
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result).toBeUndefined()
 })
 
@@ -89,7 +102,7 @@ test('no base case function detected', () => {
     }
     fib(100000);
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.NoBaseCase)
   expect(result?.streamMode).toBe(false)
 })
@@ -97,7 +110,7 @@ test('no base case function detected', () => {
 test('no base case loop detected', () => {
   const code = `for(let i = 0;true;i=i+1){i+1;}
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.NoBaseCase)
   expect(result?.streamMode).toBe(false)
 })
@@ -109,7 +122,7 @@ test('no variables changing function detected', () => {
     }
     f();
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
   expect(result?.streamMode).toBe(false)
   expect(result?.explain()).toContain('None of the variables are being updated.')
@@ -122,7 +135,7 @@ test('no state change function detected', () => {
     }
     f();
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
   expect(result?.streamMode).toBe(false)
   expect(result?.explain()).toContain('None of the variables are being updated.')
@@ -134,7 +147,7 @@ test('infinite cycle detected', () => {
     }
     f([2,3,4]);
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
   expect(result?.streamMode).toBe(false)
   expect(result?.explain()).toContain('cycle')
@@ -149,7 +162,7 @@ test('infinite data structures detected', () => {
     set_tail(tail(tail(circ)), circ);
     f(circ);
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
   expect(result?.streamMode).toBe(false)
   expect(result?.explain()).toContain('cycle')
@@ -162,14 +175,14 @@ test('functions using SMT work', () => {
     }
     f(1);
     `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.FromSmt)
   expect(result?.streamMode).toBe(false)
 })
 
 test('detect forcing infinite streams', () => {
   const code = `stream_to_list(integers_from(0));`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.NoBaseCase)
   expect(result?.streamMode).toBe(true)
 })
@@ -182,7 +195,7 @@ test('detect mutual recursion', () => {
         return x===1?0:1-e(x-1);
     }
     e(9);`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.FromSmt)
   expect(result?.streamMode).toBe(false)
 })
@@ -194,7 +207,7 @@ test('functions passed as arguments not checked', () => {
   const add = x => x + 1;
   
   (thrice)(twice(twice))(twice(add))(0);`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result).toBeUndefined()
 })
 
@@ -217,7 +230,7 @@ test('detect complicated cycle example', () => {
    
    remove_duplicate(list(list(1,2,3), list(1,2,3)));
    `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
   expect(result?.streamMode).toBe(false)
 })
@@ -233,7 +246,7 @@ test('detect complicated cycle example 2', () => {
 }
 make_big_int_from_number(1234);
    `
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
   expect(result?.streamMode).toBe(false)
 })
@@ -248,7 +261,7 @@ test('detect complicated fromSMT example 2', () => {
 
   }
   fast_power(2,3);`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.FromSmt)
   expect(result?.streamMode).toBe(false)
 })
@@ -260,7 +273,7 @@ test('detect complicated stream example', () => {
             : pair(a, () => stream_reverse(up(a + 1, b)));
   }
   eval_stream(up(1,1), 22);`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result).toBeDefined()
   expect(result?.streamMode).toBe(true)
 })
@@ -271,7 +284,7 @@ test('math functions are disabled in smt solver', () => {
     return x===0? x: f(math_floor(x+1));
   }
   f(1);`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result).toBeUndefined()
 })
 
@@ -281,7 +294,7 @@ test('cycle detection ignores non deterministic functions', () => {
     return x===0?0:f(math_floor(math_random()/2) + 1);
   }
   f(1);`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result).toBeUndefined()
 })
 
@@ -289,6 +302,6 @@ test('handle imports properly', () => {
   const code = `import {thrice} from "repeat";
   function f(x) { return is_number(x) ? f(x) : 42; }
   display(f(thrice(x=>x+1)(0)));`
-  const result = testForInfiniteLoop(code, [])
+  const result = testForInfiniteLoopWithCode(code, [])
   expect(result?.infiniteLoopType).toBe(InfiniteLoopErrorType.Cycle)
 })

--- a/src/infiniteLoops/errors.ts
+++ b/src/infiniteLoops/errors.ts
@@ -1,3 +1,5 @@
+import * as es from 'estree'
+
 import { Context } from '..'
 import { ExceptionError } from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
@@ -69,12 +71,12 @@ export class InfiniteLoopError extends RuntimeSourceError {
  *  *
  * @param {Context} - The context being used.
  *
- * @returns [error type, is stream, error message, previous code] if the error was an infinite loop
+ * @returns [error type, is stream, error message, previous programs] if the error was an infinite loop
  * @returns {undefined} otherwise
  */
 export function getInfiniteLoopData(
   context: Context
-): undefined | [InfiniteLoopErrorType, boolean, string, string[]] {
+): undefined | [InfiniteLoopErrorType, boolean, string, es.Program[]] {
   // return error type/string, prevCodeStack
   // cast as any to access infiniteLoopError property later
   const errors = context.errors
@@ -93,7 +95,7 @@ export function getInfiniteLoopData(
       infiniteLoopError.infiniteLoopType,
       infiniteLoopError.streamMode,
       infiniteLoopError.explain(),
-      context.previousCode
+      context.previousPrograms
     ]
   } else {
     return undefined

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -299,18 +299,15 @@ functions[FunctionNames.evalU] = sym.evaluateHybridUnary
 
 /**
  * Tests the given program for infinite loops.
- * @param code Program to test.
+ * @param program Program to test.
  * @param previousProgramsStack Any code previously entered in the REPL & parsed into AST.
  * @returns SourceError if an infinite loop was detected, undefined otherwise.
  */
-export function testForInfiniteLoop(code: string, previousProgramsStack: es.Program[]) {
+export function testForInfiniteLoop(program: es.Program, previousProgramsStack: es.Program[]) {
   const context = createContext(Chapter.SOURCE_4, Variant.DEFAULT, undefined, undefined)
   const prelude = parse(context.prelude as string, context) as es.Program
-  const previous: es.Program[] = [...previousProgramsStack]
   context.prelude = null
-  previous.push(prelude)
-  const program = parse(code, context)
-  if (program === undefined) return
+  const previous: es.Program[] = [...previousProgramsStack, prelude]
   const newBuiltins = prepareBuiltins(context.nativeStorage.builtins)
   const { builtinsId, functionsId, stateId } = InfiniteLoopRuntimeObjectNames
 

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -300,18 +300,14 @@ functions[FunctionNames.evalU] = sym.evaluateHybridUnary
 /**
  * Tests the given program for infinite loops.
  * @param code Program to test.
- * @param previousCodeStack Any code previously entered in the REPL.
+ * @param previousProgramsStack Any code previously entered in the REPL & parsed into AST.
  * @returns SourceError if an infinite loop was detected, undefined otherwise.
  */
-export function testForInfiniteLoop(code: string, previousCodeStack: string[]) {
+export function testForInfiniteLoop(code: string, previousProgramsStack: es.Program[]) {
   const context = createContext(Chapter.SOURCE_4, Variant.DEFAULT, undefined, undefined)
   const prelude = parse(context.prelude as string, context) as es.Program
-  const previous: es.Program[] = []
+  const previous: es.Program[] = [...previousProgramsStack]
   context.prelude = null
-  for (const code of previousCodeStack) {
-    const ast = parse(code, context)
-    if (ast !== undefined) previous.push(ast)
-  }
   previous.push(prelude)
   const program = parse(code, context)
   if (program === undefined) return

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -336,6 +336,10 @@ export function testForInfiniteLoop(code: string, previousProgramsStack: es.Prog
       }
       return error
     }
+    // Programs that exceed the maximum call stack size are okay as long as they terminate.
+    if (error instanceof RangeError && error.message === 'Maximum call stack size exceeded') {
+      return undefined
+    }
     throw error
   }
   return undefined

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -336,6 +336,7 @@ export function testForInfiniteLoop(code: string, previousProgramsStack: es.Prog
       }
       return error
     }
+    throw error
   }
   return undefined
 }

--- a/src/runner/fullJSRunner.ts
+++ b/src/runner/fullJSRunner.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Options, parse } from 'acorn'
 import { generate } from 'astring'
 import * as es from 'estree'
 import { RawSourceMap } from 'source-map'
@@ -8,44 +7,12 @@ import { IOptions, Result } from '..'
 import { NATIVE_STORAGE_ID } from '../constants'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { hoistAndMergeImports } from '../localImports/transformers/hoistAndMergeImports'
-import { FatalSyntaxError } from '../parser/parser'
+import { parse } from '../parser/parser'
 import { evallerReplacer, getBuiltins, transpile } from '../transpiler/transpiler'
 import type { Context } from '../types'
 import * as create from '../utils/astCreator'
 import { toSourceError } from './errors'
 import { appendModulesToContext, resolvedErrorPromise } from './utils'
-
-const FULL_JS_PARSER_OPTIONS: Options = {
-  sourceType: 'module',
-  ecmaVersion: 'latest',
-  locations: true
-}
-
-/**
- * Parse code string into AST
- * - any errors in the process of parsing will be added to the context
- *
- * @param code
- * @param context
- * @returns AST of code if there are no syntax errors, otherwise undefined
- */
-function parseFullJS(code: string, context: Context): es.Program | undefined {
-  let program: es.Program | undefined
-  try {
-    program = parse(code, FULL_JS_PARSER_OPTIONS) as unknown as es.Program
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      const loc = (error as any).loc
-      const location = {
-        start: { line: loc.line, column: loc.column },
-        end: { line: loc.line, column: loc.column + 1 }
-      }
-      context.errors.push(new FatalSyntaxError(location, error.toString()))
-    }
-  }
-
-  return program
-}
 
 function fullJSEval(code: string, { nativeStorage, ...ctx }: Context): any {
   if (nativeStorage.evaller) {
@@ -55,13 +22,16 @@ function fullJSEval(code: string, { nativeStorage, ...ctx }: Context): any {
   }
 }
 
-function preparePrelude(context: Context): es.Statement[] {
+function preparePrelude(context: Context): es.Statement[] | undefined {
   if (context.prelude === null) {
     return []
   }
   const prelude = context.prelude
   context.prelude = null
-  const program: es.Program = parseFullJS(prelude, context)!
+  const program = parse(prelude, context)
+  if (program === undefined) {
+    return undefined
+  }
 
   return program.body as es.Statement[]
 }
@@ -71,21 +41,19 @@ function containsPrevEval(context: Context): boolean {
 }
 
 export async function fullJSRunner(
-  code: string,
+  program: es.Program,
   context: Context,
   options: Partial<IOptions> = {}
 ): Promise<Result> {
-  // parse + check for syntax errors
-  const program: es.Program | undefined = parseFullJS(code, context)
-  if (!program) {
-    return resolvedErrorPromise
-  }
-
   // prelude & builtins
   // only process builtins and preludes if it is a fresh eval context
+  const prelude = preparePrelude(context)
+  if (prelude === undefined) {
+    return resolvedErrorPromise
+  }
   const preludeAndBuiltins: es.Statement[] = containsPrevEval(context)
     ? []
-    : [...getBuiltins(context.nativeStorage), ...preparePrelude(context)]
+    : [...getBuiltins(context.nativeStorage), ...prelude]
 
   // modules
   hoistAndMergeImports(program)

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -280,8 +280,10 @@ export async function sourceFilesRunner(
 
   context.variant = determineVariant(context, options)
   // FIXME: The type checker does not support the typing of multiple files, so
-  //        we only push the code in the entrypoint file. Either way, the type
-  //        checker is currently not used at all.
+  //        we only push the code in the entrypoint file. Ideally, all files
+  //        involved in the program evaluation should be type-checked. Either way,
+  //        the type checker is currently not used at all so this is not very
+  //        urgent.
   context.unTypecheckedCode.push(entrypointCode)
 
   // TODO: Make use of the preprocessed program AST after refactoring runners.

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -249,7 +249,7 @@ export async function sourceRunner(
     return await fullJSRunner(code, context, theOptions)
   }
 
-  // Handle preludes
+  // All runners after this point evaluate the prelude.
   if (context.prelude !== null) {
     const prelude = context.prelude
     context.prelude = null

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -229,7 +229,6 @@ export async function sourceRunner(
   hoistAndMergeImports(program)
 
   validateAndAnnotate(program, context)
-  context.unTypecheckedCode.push(code)
 
   if (context.errors.length > 0) {
     return resolvedErrorPromise
@@ -253,6 +252,7 @@ export async function sourceRunner(
   if (context.prelude !== null) {
     const prelude = context.prelude
     context.prelude = null
+    context.unTypecheckedCode.push(prelude)
     await sourceRunner(prelude, context, isVerboseErrorsEnabled, { ...options, isPrelude: true })
     return sourceRunner(code, context, isVerboseErrorsEnabled, options)
   }
@@ -279,6 +279,11 @@ export async function sourceFilesRunner(
   const isVerboseErrorsEnabled = hasVerboseErrors(entrypointCode)
 
   context.variant = determineVariant(context, options)
+  // FIXME: The type checker does not support the typing of multiple files, so
+  //        we only push the code in the entrypoint file. Either way, the type
+  //        checker is currently not used at all.
+  context.unTypecheckedCode.push(entrypointCode)
+
   // TODO: Make use of the preprocessed program AST after refactoring runners.
   // const preprocessedProgram = preprocessFileImports(files, entrypointFilePath, context)
   // if (!preprocessedProgram) {

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -63,7 +63,6 @@ function runConcurrent(
   } else {
     context.nativeStorage.maxExecTime = options.originalMaxExecTime
   }
-  context.previousCode.unshift(code)
   previousCode = code
   try {
     return Promise.resolve({
@@ -132,7 +131,6 @@ async function runNative(
   }
 
   if (!options.isPrelude) {
-    context.previousCode.unshift(code)
     previousCode = code
   }
 

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -243,14 +243,9 @@ export async function sourceRunner(
     return runSubstitution(program, context, theOptions)
   }
 
-  const isNativeRunnable: boolean = determineExecutionMethod(
-    theOptions,
-    context,
-    program,
-    isVerboseErrorsEnabled
-  )
+  determineExecutionMethod(theOptions, context, program, isVerboseErrorsEnabled)
 
-  if (isNativeRunnable && context.variant === Variant.NATIVE) {
+  if (context.executionMethod === 'native' && context.variant === Variant.NATIVE) {
     return await fullJSRunner(code, context, theOptions)
   }
 
@@ -262,7 +257,7 @@ export async function sourceRunner(
     return sourceRunner(code, context, isVerboseErrorsEnabled, options)
   }
 
-  if (isNativeRunnable) {
+  if (context.executionMethod === 'native') {
     return runNative(code, program, context, theOptions)
   }
 

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -245,7 +245,7 @@ export async function sourceRunner(
   determineExecutionMethod(theOptions, context, program, isVerboseErrorsEnabled)
 
   if (context.executionMethod === 'native' && context.variant === Variant.NATIVE) {
-    return await fullJSRunner(code, context, theOptions)
+    return await fullJSRunner(program, context, theOptions)
   }
 
   // All runners after this point evaluate the prelude.

--- a/src/runner/utils.ts
+++ b/src/runner/utils.ts
@@ -44,13 +44,13 @@ export function determineExecutionMethod(
       } else if (areBreakpointsSet()) {
         isNativeRunnable = false
       } else {
-        let hasDeuggerStatement = false
+        let hasDebuggerStatement = false
         simple(program, {
           DebuggerStatement(node: DebuggerStatement) {
-            hasDeuggerStatement = true
+            hasDebuggerStatement = true
           }
         })
-        isNativeRunnable = !hasDeuggerStatement
+        isNativeRunnable = !hasDebuggerStatement
       }
       context.executionMethod = isNativeRunnable ? 'native' : 'interpreter'
     } else {

--- a/src/runner/utils.ts
+++ b/src/runner/utils.ts
@@ -35,10 +35,10 @@ export function determineExecutionMethod(
   context: Context,
   program: Program,
   verboseErrors: boolean
-): boolean {
-  let isNativeRunnable
+): void {
   if (theOptions.executionMethod === 'auto') {
     if (context.executionMethod === 'auto') {
+      let isNativeRunnable
       if (verboseErrors) {
         isNativeRunnable = false
       } else if (areBreakpointsSet()) {
@@ -53,14 +53,10 @@ export function determineExecutionMethod(
         isNativeRunnable = !hasDebuggerStatement
       }
       context.executionMethod = isNativeRunnable ? 'native' : 'interpreter'
-    } else {
-      isNativeRunnable = context.executionMethod === 'native'
     }
   } else {
-    isNativeRunnable = theOptions.executionMethod === 'native'
     context.executionMethod = theOptions.executionMethod
   }
-  return isNativeRunnable
 }
 
 /**

--- a/src/runner/utils.ts
+++ b/src/runner/utils.ts
@@ -36,27 +36,30 @@ export function determineExecutionMethod(
   program: Program,
   verboseErrors: boolean
 ): void {
-  if (theOptions.executionMethod === 'auto') {
-    if (context.executionMethod === 'auto') {
-      let isNativeRunnable
-      if (verboseErrors) {
-        isNativeRunnable = false
-      } else if (areBreakpointsSet()) {
-        isNativeRunnable = false
-      } else {
-        let hasDebuggerStatement = false
-        simple(program, {
-          DebuggerStatement(node: DebuggerStatement) {
-            hasDebuggerStatement = true
-          }
-        })
-        isNativeRunnable = !hasDebuggerStatement
-      }
-      context.executionMethod = isNativeRunnable ? 'native' : 'interpreter'
-    }
-  } else {
+  if (theOptions.executionMethod !== 'auto') {
     context.executionMethod = theOptions.executionMethod
+    return
   }
+
+  if (context.executionMethod !== 'auto') {
+    return
+  }
+
+  let isNativeRunnable
+  if (verboseErrors) {
+    isNativeRunnable = false
+  } else if (areBreakpointsSet()) {
+    isNativeRunnable = false
+  } else {
+    let hasDebuggerStatement = false
+    simple(program, {
+      DebuggerStatement(_node: DebuggerStatement) {
+        hasDebuggerStatement = true
+      }
+    })
+    isNativeRunnable = !hasDebuggerStatement
+  }
+  context.executionMethod = isNativeRunnable ? 'native' : 'interpreter'
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,9 +185,9 @@ export interface Context<T = any> {
   }
 
   /**
-   * Code previously executed in this context
+   * Programs previously executed in this context
    */
-  previousCode: string[]
+  previousPrograms: es.Program[]
 
   /**
    * Whether the evaluation timeout should be increased

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,11 @@ export interface Context<T = any> {
    * Code previously executed in this context
    */
   previousCode: string[]
+
+  /**
+   * Whether the evaluation timeout should be increased
+   */
+  shouldIncreaseEvaluationTimeout: boolean
 }
 
 export type ModuleContext = {

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -124,6 +124,8 @@ async function testInContext(code: string, options: TestOptions): Promise<TestRe
     let pretranspiled: string = ''
     let transpiled: string = ''
     const parsed = parse(code, nativeTestContext)!
+    // Reset errors in context so as not to interfere with actual run.
+    nativeTestContext.errors = []
     if (parsed === undefined) {
       pretranspiled = 'parseError'
     } else {


### PR DESCRIPTION
### Description

This is necessary because after the pre-processing step where non-Source module imports & exports are transformed, we end up with a single AST containing the locations of the original line & column numbers (for user-written code) for use in error messages. Originally, I attempted to transpile the AST back into code (to be compatible with the existing Source runner), but then the location information is lost.

Another benefit of operating on the AST is that all of the existing components, such as the infinite loop detector, continue to work for multiple file programs!

Please see the individual commits for the context behind why each change was necessary.

Part of https://github.com/source-academy/frontend/issues/2176. Related to #1332.

### How to Test

Since this is merely a refactoring PR, there should be no changes in behaviour whatsoever.