### PR TITLE
Add source file path to error messages for multi-file programs (non-transpiled)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ let verboseErrors: boolean = false
 
 export function parseError(errors: SourceError[], verbose: boolean = verboseErrors): string {
   const errorMessagesArr = errors.map(error => {
+    const filePath = error.location?.source ? `[${error.location.source}] ` : ''
     const line = error.location ? error.location.start.line : '<unknown>'
     const column = error.location ? error.location.start.column : '<unknown>'
     const explanation = error.explain()
@@ -73,10 +74,10 @@ export function parseError(errors: SourceError[], verbose: boolean = verboseErro
       // way to display it.
       const elaboration = error.elaborate()
       return line < 1
-        ? `${explanation}\n${elaboration}\n`
-        : `Line ${line}, Column ${column}: ${explanation}\n${elaboration}\n`
+        ? `${filePath}${explanation}\n${elaboration}\n`
+        : `${filePath}Line ${line}, Column ${column}: ${explanation}\n${elaboration}\n`
     } else {
-      return line < 1 ? explanation : `Line ${line}: ${explanation}`
+      return line < 1 ? explanation : `${filePath}Line ${line}: ${explanation}`
     }
   })
   return errorMessagesArr.join('\n')

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,14 @@ let verboseErrors: boolean = false
 
 export function parseError(errors: SourceError[], verbose: boolean = verboseErrors): string {
   const errorMessagesArr = errors.map(error => {
-    const filePath = error.location?.source ? `[${error.location.source}] ` : ''
+    // FIXME: Either refactor the parser to output an ESTree-compliant AST, or modify the ESTree types.
+    const filePath = error.location?.source
+      ? `[${error.location.source}] `
+      : // @ts-ignore - Typed Source makes use of Babel parser which is NOT compliant with ESTree. Instead of using `source`, it makes use of `filename`.
+      error.location?.filename
+      ? // @ts-ignore - Typed Source makes use of Babel parser which is NOT compliant with ESTree. Instead of using `source`, it makes use of `filename`.
+        `[${error.location.filename}] `
+      : ''
     const line = error.location ? error.location.start.line : '<unknown>'
     const column = error.location ? error.location.start.column : '<unknown>'
     const explanation = error.explain()

--- a/src/localImports/__tests__/errorMessages.ts
+++ b/src/localImports/__tests__/errorMessages.ts
@@ -1,0 +1,134 @@
+import { parseError, runFilesInContext } from '../../index'
+import { mockContext } from '../../mocks/context'
+import { Chapter } from '../../types'
+
+describe('syntax errors', () => {
+  let context = mockContext(Chapter.SOURCE_4)
+
+  beforeEach(() => {
+    context = mockContext(Chapter.SOURCE_4)
+  })
+
+  describe('FatalSyntaxError', () => {
+    test('file path is not part of error message if the program is single-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          const x = 1;
+          const x = 1;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"Line 3: SyntaxError: Identifier 'x' has already been declared (3:16)"`
+      )
+    })
+
+    test('file path is part of error message if the program is multi-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          const x = 1;
+          const x = 1;
+        `,
+        '/b.js': `
+          const y = 2;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"[/a.js] Line 3: SyntaxError: Identifier 'x' has already been declared (3:16)"`
+      )
+    })
+  })
+
+  describe('MissingSemicolonError', () => {
+    test('file path is not part of error message if the program is single-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          const x = 1
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"Line 2: Missing semicolon at the end of statement"`
+      )
+    })
+
+    test('file path is part of error message if the program is multi-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          const x = 1
+        `,
+        '/b.js': `
+          const y = 2;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"[/a.js] Line 2: Missing semicolon at the end of statement"`
+      )
+    })
+  })
+
+  describe('TrailingCommaError', () => {
+    test('file path is not part of error message if the program is single-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          const x = [1, 2, 3,];
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(`"Line 2: Trailing comma"`)
+    })
+
+    test('file path is part of error message if the program is multi-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          const x = [1, 2, 3,];
+        `,
+        '/b.js': `
+          const y = 2;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(`"[/a.js] Line 2: Trailing comma"`)
+    })
+  })
+})
+
+describe('non-syntax errors (non-transpiled)', () => {
+  let context = mockContext(Chapter.SOURCE_4)
+
+  beforeEach(() => {
+    context = mockContext(Chapter.SOURCE_4)
+    context.executionMethod = 'interpreter'
+  })
+
+  describe('SourceError', () => {
+    test('file path is not part of error message if the program is single-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          1 + 'hello';
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"Line 2: Expected number on right hand side of operation, got string."`
+      )
+    })
+
+    test('file path is part of error message if the program is multi-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          1 + 'hello';
+        `,
+        '/b.js': `
+          const y = 2;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"[/a.js] Line 2: Expected number on right hand side of operation, got string."`
+      )
+    })
+  })
+})

--- a/src/localImports/__tests__/errorMessages.ts
+++ b/src/localImports/__tests__/errorMessages.ts
@@ -1,6 +1,6 @@
 import { parseError, runFilesInContext } from '../../index'
 import { mockContext } from '../../mocks/context'
-import { Chapter } from '../../types'
+import { Chapter, Variant } from '../../types'
 
 describe('syntax errors', () => {
   let context = mockContext(Chapter.SOURCE_4)
@@ -128,6 +128,45 @@ describe('non-syntax errors (non-transpiled)', () => {
       await runFilesInContext(files, '/a.js', context)
       expect(parseError(context.errors)).toMatchInlineSnapshot(
         `"[/a.js] Line 2: Expected number on right hand side of operation, got string."`
+      )
+    })
+  })
+})
+
+// We specifically test typed Source because it makes use of the Babel parser.
+describe('non-syntax errors (non-transpiled & typed)', () => {
+  let context = mockContext(Chapter.SOURCE_4, Variant.TYPED)
+
+  beforeEach(() => {
+    context = mockContext(Chapter.SOURCE_4, Variant.TYPED)
+    context.executionMethod = 'interpreter'
+  })
+
+  describe('SourceError', () => {
+    test('file path is not part of error message if the program is single-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          2 + 'hello';
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"Line 2: Type 'string' is not assignable to type 'number'."`
+      )
+    })
+
+    test('file path is part of error message if the program is multi-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          2 + 'hello';
+        `,
+        '/b.js': `
+          const y = 2;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"[/a.js] Line 2: Type 'string' is not assignable to type 'number'."`
       )
     })
   })

--- a/src/localImports/preprocessor.ts
+++ b/src/localImports/preprocessor.ts
@@ -69,6 +69,10 @@ const parseProgramsAndConstructImportGraph = (
   const programs: Record<string, es.Program> = {}
   const importGraph = new DirectedGraph()
 
+  // If there is more than one file, tag AST nodes with the source file path.
+  const numOfFiles = Object.keys(files).length
+  const shouldAddSourceFileToAST = numOfFiles > 1
+
   const parseFile = (currentFilePath: string): void => {
     const code = files[currentFilePath]
     if (code === undefined) {
@@ -76,7 +80,13 @@ const parseProgramsAndConstructImportGraph = (
       return
     }
 
-    const program = parse(code, context)
+    // Tag AST nodes with the source file path for use in error messages.
+    const parserOptions = shouldAddSourceFileToAST
+      ? {
+          sourceFile: currentFilePath
+        }
+      : {}
+    const program = parse(code, context, parserOptions)
     if (program === undefined) {
       return
     }

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -142,8 +142,7 @@ export function parse(source: string, context: Context, options: Partial<AcornOp
       const typedProgram = babelParse(source, {
         sourceType: 'module',
         plugins: ['typescript', 'estree'],
-        // Note that not all Acorn options work for the Babel parser, though there is a huge overlap.
-        ...options
+        sourceFilename: options.sourceFile
       }).program as unknown as tsEs.Program
 
       // Checks for type errors, then removes any TS-related nodes as they are not compatible with acorn-walk.

--- a/src/runner/__tests__/runners.ts
+++ b/src/runner/__tests__/runners.ts
@@ -85,7 +85,7 @@ const JAVASCRIPT_CODE_SNIPPETS_ERRORS: CodeSnippetTestCase[] = [
     value: undefined,
     errors: [
       new FatalSyntaxError(
-        { start: { line: 1, column: 8 }, end: { line: 1, column: 9 } },
+        { start: { line: 1, column: 8 }, end: { line: 1, column: 9 }, source: undefined },
         'SyntaxError: Unexpected token (1:8)'
       )
     ]


### PR DESCRIPTION
## Description

The Acorn parser [provides an option `sourceFile` which adds a `source` attribute onto the `loc` object of every AST node](https://github.com/acornjs/acorn/tree/master/acorn/#interface). When we evaluate a program that consists of more than one file, we enable this option on the Acorn parser. Then, whenever we print error messages, if the `source` attribute exists, we also print out the full path of the file in front of the error message.

Note that this currently does not work for transpiled programs because they do not respect the `loc` object of the AST. There is some conversion being done before transpilation. I will deal with adding the source file path to errors messages for transpiled multi-file programs in another PR.

## Source Typed

For Source Typed, the Babel parser is used instead. While it does have [an equivalent `sourceFilename` option](https://babeljs.io/docs/en/babel-parser#options), the attribute is named `filename` instead of `source`. This leads to type errors, which we are forced to suppress. Ideally, the parser should always output ESTree-compliant ASTs (which isn't the case now). If this is not possible to achieve, then perhaps we will have to modify the ESTree types to allow for the `filename` attribute on the `loc` object.