### PR TITLE
Add support for generic types to Source Typed

### DIFF
--- a/docs/specs/source_1_typed_bnf.tex
+++ b/docs/specs/source_1_typed_bnf.tex
@@ -14,9 +14,8 @@
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{names} \ \textbf{\texttt{)}}[\texttt{:}\ \textit{type}]\ \textit{block} \quad
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{function declaration}}\\
-&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name} \ 
-                                            \textbf{\texttt{=}}\  \textit{type} \ \textbf{\texttt{;}}
-                                                           && \textrm{type alias declaration}\\
+&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name}[<\textit{name}\ (\ \textbf{\texttt{,}} \ \textit{name}\ ) ...>] \ 
+                                                           \textbf{\texttt{=}}\  \textit{alias-type} \textbf{\texttt{;}} && \textrm{type alias declaration}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
@@ -39,7 +38,10 @@
                                           \textit{\href{https://sourceacademy.org/sicpjs/1.3.3\#footnote-1}{if-statement}} \ )
                                                             && \textrm{\href{https://sourceacademy.org/sicpjs/1.3.2\#p12}{conditional statement}}   \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement} ...   \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.8\#p14}{block statement}}\\[1mm]         
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.8\#p14}{block statement}}\\[1mm]       
+\end{alignat*}
+
+\begin{alignat*}{9} 
 && \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p1}{primitive boolean expression}}\\
@@ -88,7 +90,14 @@
 && \textit{type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
 &&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
 &&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{type reference}\\
+&&                       && |   &\quad &&  \textit{name}[<\textit{type}\ (\ \textbf{\texttt{,}} \ \textit{type}\ ) ...>]   && \textrm{type reference}\\
 &&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{type} && \textrm{function type}\\
 &&                       && |   &\quad &&   \textit{type}\ \texttt{\textbf{|}}\ \textit{type} && \textrm{union type}\\
+&& \textit{alias-type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
+&&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
+&&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
+&&                       && |   &\quad &&  \textit{name}[<\textit{alias-type}\ (\ \textbf{\texttt{,}} \ \textit{alias-type}\ ) ...>]   && \textrm{type reference}\\
+&&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{alias-type} && \textrm{function type}\\
+&&                       && |   &\quad &&   \textit{alias-type}\ \texttt{\textbf{|}}\ \textit{alias-type} && \textrm{union type}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{type parameter}\\
 \end{alignat*}

--- a/docs/specs/source_1_typed_typing.tex
+++ b/docs/specs/source_1_typed_typing.tex
@@ -41,8 +41,7 @@ Support for \texttt{typeof} operations is also added to Source \S 1 Typed.
 \subsection{Type Environment}
 
 In order to keep track of the type of names in a program, we define a
-\emph{type environment}, denoted by $\Gamma$. More
-formally,
+\emph{type environment}, denoted by $\Gamma$. More formally,
 the partial function $\Gamma$ from names to types expresses a 
 context, in which a name $x$ is associated with type $\Gamma(x)$. 
 
@@ -155,6 +154,14 @@ $\Gamma_{-1}$
 & $[$ & \texttt{undefined} & $\leftarrow$  & $\Undefined$ & & & $]$ & $\Gamma_0$ \\
 & \end{tabular}
 
+In order to support the definition of type aliases, we define a separate
+\emph{type alias environment}, denoted by $\Gamma_{alias}$. Unlike $\Gamma$,
+$\Gamma_{alias}$ binds names to special \emph{type functions} of the form $<T_1, \ldots, T_n> \rightarrow t$
+where $T_1 \ldots T_n$ are type parameters $t$ is the return type expressed in terms of $T_1 \ldots T_n$.
+$<>$ is used to differentiate type functions from function types, which are of the form $(t_1, \ldots, t_n) \rightarrow t$.
+
+Since $\Gamma$ and $\Gamma_{alias}$ are separate environments, the same name $x$ can be used for both variables and type aliases.
+
 \subsection{Success Types}
 
 In order for type checks to be performed in Source \S 1 Typed, we introduce the notion of success types.
@@ -221,8 +228,8 @@ For function applications (including applications of binary and unary operators)
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \wedge \Any \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots, \Gamma \vdash E_n : t'_n
+    }{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
 \]
 \noindent
 
@@ -230,42 +237,51 @@ The type of the operator must be a function type with the right number of parame
 and the type of every argument must be a success type of the corresponding parameter type of the function type.
 If all of the conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
-If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+If the type of the operator is $\Any$, the return type will be $\Any$.
 
 Applications of binary and unary operators are treated the same as function applications, with the exception of the \texttt{+} operator.
+We use the $\subseteq$ operator to indicate that a type is a subset of another type, as defined below:
+
+\begin{itemize}
+\item{A type is a subset of type $\Number$ if it is of type $\Number$, literal number type,
+  or a union type containing any number of literal number types.}
+\item{A type is a subset of type $\String$ if it is of type $\String$, literal string type,
+  or a union type containing any number of literal string types.}
+\end{itemize}
+
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on the left side is of type $\Number$ or literal number type,
+\item{If the expression on the left side is a subset of type $\Number$,
   check that the other expression is a success type of $\Number$. The return type is $\Number$.}
-\item{If the expression on the left side is of type $\String$ or literal string type,
+\item{If the expression on the left side is a subset of type $\String$,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
-\item{If the expression on the right side is of type $\Number$ or literal number type,
+\item{If the expression on the right side is a subset of type $\Number$,
   check that the other expression is a success type of $\Number$. The return type is $\Number$.}
-\item{If the expression on the right side is of type $\String$ or literal string type,
+\item{If the expression on the right side is a subset of type $\String$,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
-\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
+\item{If the expression on the left side cannot be narrowed to a subset of either $\Number$ or $\String$, check that both sides are success types of 
   $\Number\ |\ \String$. The return type is $\Number\ |\ \String$.}
 \end{itemize}
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq \Number
     \quad t_1 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq \String
     \quad t_1 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number
     \quad t_0 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \String
     \quad t_0 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
@@ -307,24 +323,36 @@ For as expressions, the type to cast the expression to must be a success type of
 
 \subsubsection{Typing Relations on Statements}
 
-For constant declarations, the declared type of $x$, $t$, is added to the type environment.
-As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
-The derived type of the expression $E$ must be a success type of the type declared for name $x$.
-The type of the constant declaration statement itself is $\Undefined$.
+For type alias declarations, the binding of name $x$ to type function $<T_1, \ldots, T_n> \rightarrow t$ is added to the type alias environment.
+If no type parameters are given, the type function is assumed to take in 0 type arguments.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
-    \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+  \Rule{\Gamma_{alias} [x \leftarrow <> \rightarrow t] \Gamma_{alias}'}{\Gamma \vdash (\texttt{type}\ x = t \texttt{;}) : \Undefined}
+  \Rule{\Gamma_{alias} [x \leftarrow <T_1, \ldots, T_n> \rightarrow T] \Gamma_{alias}'
+    }{\Gamma \vdash (\texttt{type}\ x<T_1, \ldots, T_n> = t \texttt{;}) : \Undefined}
 \]
 \noindent
 
-For type alias declarations, the declared type of $x$, $t$, is added to the type environment.
-The type of the type alias declaration itself is $\Undefined$.
+For constant declarations, the declared type of $x$, $t$, is added to the type environment.
+If the type annotation for $x$ is absent, the declared type $t$ is assumed to be $\Any$.
+
+If the type annotation is a type reference to a type alias with name $T$,
+$t$ is first derived by applying the type arguments $t_1, \ldots, t_n$ to the type function for $T$,
+replacing all instances of type variables $T_1, \ldots, T_n$ in $t$ with $t_1, \ldots, t_n$ respectively.
+
+The derived type of the expression $E$, $t_E$, must be a success type of $t$.
+The type of the statement itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma'}{\Gamma \vdash (\texttt{type}\ x = t\texttt{;}) : \Undefined}
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t_E \quad t_E \wedge t \neq \emptyset}{
+    \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+\]
+\noindent
+\[
+  \Rule{\Gamma_{alias}(T)<t_1, \ldots, t_n> = t \quad \Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t_E \quad
+    t_E \wedge t \neq \emptyset}{\Gamma \vdash (\texttt{const}\ x \texttt{:}\ T<t_1, \ldots, t_n> = E\texttt{;}) : \Undefined}
 \]
 \noindent
 

--- a/docs/specs/source_2_typed_bnf.tex
+++ b/docs/specs/source_2_typed_bnf.tex
@@ -14,9 +14,8 @@
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                    \textbf{\texttt{(}}\  \textit{names} \ \textbf{\texttt{)}}[\texttt{:}\ \textit{type}]\ \textit{block} \quad
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{function declaration}}\\
-&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name} \ 
-                                            \textbf{\texttt{=}}\  \textit{type} \ \textbf{\texttt{;}}
-                                                           && \textrm{type alias declaration}\\
+&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name}[<\textit{name}\ (\ \textbf{\texttt{,}} \ \textit{name}\ ) ...>] \ 
+                                                           \textbf{\texttt{=}}\  \textit{alias-type} \textbf{\texttt{;}} && \textrm{type alias declaration}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
@@ -39,7 +38,10 @@
                                           \textit{\href{https://sourceacademy.org/sicpjs/1.3.3\#footnote-1}{if-statement}} \ )
                                                             && \textrm{\href{https://sourceacademy.org/sicpjs/1.3.2\#p12}{conditional statement}}   \\[1mm]
 && \textit{block}        && ::= &      && \textbf{\texttt{\{}}\  \textit{statement} ...   \ \textbf{\texttt{\}}} \quad
-                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.8\#p14}{block statement}}\\[1mm]         
+                                                           && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.8\#p14}{block statement}}\\[1mm]
+\end{alignat*}
+
+\begin{alignat*}{9} 
 && \textit{expression}   && ::= &\quad &&  \textit{number}   && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.1\#p3}{primitive number expression}}\\
 &&                       && |   &\quad && \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}}
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.6\#p1}{primitive boolean expression}}\\
@@ -90,9 +92,18 @@
 && \textit{type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
 &&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{null}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
 &&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{type reference}\\
+&&                       && |   &\quad &&  \textit{name}[<\textit{type}\ (\ \textbf{\texttt{,}} \ \textit{type}\ ) ...>]   && \textrm{type reference}\\
 &&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{type} && \textrm{function type}\\
 &&                       && |   &\quad &&   \textit{type}\ \texttt{\textbf{|}}\ \textit{type} && \textrm{union type}\\
 &&                       && |   &\quad &&   \textit{Pair<type, type>} && \textrm{pair type}\\
 &&                       && |   &\quad &&   \textit{List<type>} && \textrm{list type}\\
+&& \textit{alias-type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
+&&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{null}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
+&&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
+&&                       && |   &\quad &&  \textit{name}[<\textit{alias-type}\ (\ \textbf{\texttt{,}} \ \textit{alias-type}\ ) ...>]   && \textrm{type reference}\\
+&&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{alias-type} && \textrm{function type}\\
+&&                       && |   &\quad &&   \textit{alias-type}\ \texttt{\textbf{|}}\ \textit{alias-type} && \textrm{union type}\\
+&&                       && |   &\quad &&   \textit{Pair<alias-type, alias-type>} && \textrm{pair type}\\
+&&                       && |   &\quad &&   \textit{List<alias-type>} && \textrm{list type}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{type parameter}\\
 \end{alignat*}

--- a/docs/specs/source_2_typed_typing.tex
+++ b/docs/specs/source_2_typed_typing.tex
@@ -42,8 +42,7 @@ Support for \texttt{typeof} operations is also added to Source \S 2 Typed.
 \subsection{Type Environment}
 
 In order to keep track of the type of names in a program, we define a
-\emph{type environment}, denoted by $\Gamma$. More
-formally,
+\emph{type environment}, denoted by $\Gamma$. More formally,
 the partial function $\Gamma$ from names to types expresses a 
 context, in which a name $x$ is associated with type $\Gamma(x)$. 
 
@@ -164,6 +163,22 @@ $\Gamma_{-1}$
 & $[$ & \texttt{is\_list} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ $\Gamma_0$ \\
 & \end{tabular}
 
+In order to support the definition of type aliases, we define a separate
+\emph{type alias environment}, denoted by $\Gamma_{alias}$. Unlike $\Gamma$,
+$\Gamma_{alias}$ binds names to special \emph{type functions} of the form $<T_1, \ldots, T_n> \rightarrow t$
+where $T_1 \ldots T_n$ are type parameters $t$ is the return type expressed in terms of $T_1 \ldots T_n$.
+$<>$ is used to differentiate type functions from function types, which are of the form $(t_1, \ldots, t_n) \rightarrow t$.
+
+Since $\Gamma$ and $\Gamma_{alias}$ are separate environments, the same name $x$ can be used for both variables and type aliases.
+
+The initial type alias environment $\Gamma_{alias0}$ is as follows:
+
+\begin{tabular}[fragile]{lllllllll}
+$\Gamma_{alias-1}$
+& $[$ & \texttt{Pair} & $\leftarrow$ & $<T_{head}, T_{tail}>$ & $\rightarrow$ & $Pair<T_{head}, T_{tail}>$ & $]$ \\
+& $[$ & \texttt{List} & $\leftarrow$ & $<T_{elem}>$ & $\rightarrow$ & $List<T_{elem}>$ & $]$ $\Gamma_{alias0}$ \\
+& \end{tabular}
+
 \subsection{Success Types}
 
 In order for type checks to be performed in Source \S 3 Typed, we introduce the notion of success types.
@@ -230,8 +245,8 @@ For function applications (including applications of binary and unary operators)
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \wedge \Any \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots, \Gamma \vdash E_n : t'_n
+    }{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
 \]
 \noindent
 
@@ -239,42 +254,51 @@ The type of the operator must be a function type with the right number of parame
 and the type of every argument must be a success type of the corresponding parameter type of the function type.
 If all of the conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
-If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+If the type of the operator is $\Any$, the return type will be $\Any$.
 
 Applications of binary and unary operators are treated the same as function applications, with the exception of the \texttt{+} operator.
+We use the $\subseteq$ operator to indicate that a type is a subset of another type, as defined below:
+
+\begin{itemize}
+\item{A type is a subset of type $\Number$ if it is of type $\Number$, literal number type,
+  or a union type containing any number of literal number types.}
+\item{A type is a subset of type $\String$ if it is of type $\String$, literal string type,
+  or a union type containing any number of literal string types.}
+\end{itemize}
+
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on the left side is of type $\Number$ or literal number type,
+\item{If the expression on the left side is a subset of type $\Number$,
   check that the other expression is a success type of $\Number$. The return type is $\Number$.}
-\item{If the expression on the left side is of type $\String$ or literal string type,
+\item{If the expression on the left side is a subset of type $\String$,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
-\item{If the expression on the right side is of type $\Number$ or literal number type,
+\item{If the expression on the right side is a subset of type $\Number$,
   check that the other expression is a success type of $\Number$. The return type is $\Number$.}
-\item{If the expression on the right side is of type $\String$ or literal string type,
+\item{If the expression on the right side is a subset of type $\String$,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
-\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
+\item{If the expression on the left side cannot be narrowed to a subset of either $\Number$ or $\String$, check that both sides are success types of 
   $\Number\ |\ \String$. The return type is $\Number\ |\ \String$.}
 \end{itemize}
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq \Number
     \quad t_1 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq \String
     \quad t_1 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number
     \quad t_0 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \String
     \quad t_0 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
@@ -316,24 +340,36 @@ For as expressions, the type to cast the expression to must be a success type of
 
 \subsubsection{Typing Relations on Statements}
 
-For constant declarations, the declared type of $x$, $t$, is added to the type environment.
-As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
-The derived type of the expression $E$ must be a success type of the type declared for name $x$.
-The type of the constant declaration statement itself is $\Undefined$.
+For type alias declarations, the binding of name $x$ to type function $<T_1, \ldots, T_n> \rightarrow t$ is added to the type alias environment.
+If no type parameters are given, the type function is assumed to take in 0 type arguments.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
-    \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+  \Rule{\Gamma_{alias} [x \leftarrow <> \rightarrow t] \Gamma_{alias}'}{\Gamma \vdash (\texttt{type}\ x = t \texttt{;}) : \Undefined}
+  \Rule{\Gamma_{alias} [x \leftarrow <T_1, \ldots, T_n> \rightarrow T] \Gamma_{alias}'
+    }{\Gamma \vdash (\texttt{type}\ x<T_1, \ldots, T_n> = t \texttt{;}) : \Undefined}
 \]
 \noindent
 
-For type alias declarations, the declared type of $x$, $t$, is added to the type environment.
-The type of the type alias declaration itself is $\Undefined$.
+For constant declarations, the declared type of $x$, $t$, is added to the type environment.
+If the type annotation for $x$ is absent, the declared type $t$ is assumed to be $\Any$.
+
+If the type annotation is a type reference to a type alias with name $T$,
+$t$ is first derived by applying the type arguments $t_1, \ldots, t_n$ to the type function for $T$,
+replacing all instances of type variables $T_1, \ldots, T_n$ in $t$ with $t_1, \ldots, t_n$ respectively.
+
+The derived type of the expression $E$, $t_E$, must be a success type of $t$.
+The type of the statement itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma'}{\Gamma \vdash (\texttt{type}\ x = t\texttt{;}) : \Undefined}
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t_E \quad t_E \wedge t \neq \emptyset}{
+    \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+\]
+\noindent
+\[
+  \Rule{\Gamma_{alias}(T)<t_1, \ldots, t_n> = t \quad \Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t_E \quad
+    t_E \wedge t \neq \emptyset}{\Gamma \vdash (\texttt{const}\ x \texttt{:}\ T<t_1, \ldots, t_n> = E\texttt{;}) : \Undefined}
 \]
 \noindent
 

--- a/docs/specs/source_3_typed_bnf.tex
+++ b/docs/specs/source_3_typed_bnf.tex
@@ -17,8 +17,8 @@
 &&                       && |   &\quad && \textbf{\texttt{function}}\  \textit{name} \ 
                                                     \textbf{\texttt{(}}\  \textit{rest-names} \ \textbf{\texttt{)}}[\texttt{:}\ \textit{type}]\ \textit{block} \quad
                                                             && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{function declaration}}\\
-&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name} \ 
-                                                           \textbf{\texttt{=}}\  \textit{type} \ \textbf{\texttt{;}} && \textrm{type alias declaration}\\
+&&                       && |   &\quad && \textbf{\texttt{type}}\  \textit{name}[<\textit{name}\ (\ \textbf{\texttt{,}} \ \textit{name}\ ) ...>] \ 
+                                                           \textbf{\texttt{=}}\  \textit{alias-type} \textbf{\texttt{;}} && \textrm{type alias declaration}\\
 &&                       && |   &\quad && \textbf{\texttt{return}}\  \textit{expression} \ \textbf{\texttt{;}}
                                                            && \textrm{\href{https://sourceacademy.org/sicpjs/1.1.4\#p4}{return statement}}\\
 &&                       && |   &\quad && \textit{if-statement} \quad
@@ -140,10 +140,20 @@
 && \textit{type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
 &&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{null}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
 &&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
-&&                       && |   &\quad &&  \textit{name}   && \textrm{type reference}\\
+&&                       && |   &\quad &&  \textit{name}[<\textit{type}\ (\ \textbf{\texttt{,}} \ \textit{type}\ ) ...>]   && \textrm{type reference}\\
 &&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{type} && \textrm{function type}\\
 &&                       && |   &\quad &&   \textit{type}\ \texttt{\textbf{|}}\ \textit{type} && \textrm{union type}\\
 &&                       && |   &\quad &&   \textit{Pair<type, type>} && \textrm{pair type}\\
 &&                       && |   &\quad &&   \textit{List<type>} && \textrm{list type}\\
 &&                       && |   &\quad &&   \textit{type[]} && \textrm{array type}\\
+&& \textit{alias-type}         && ::= &\quad &&  \texttt{number}\ |\ \texttt{boolean}\ |\ \texttt{string} \\
+&&                       &&     &      &&  |\ \texttt{undefined}\ |\ \texttt{null}\ |\ \texttt{void}\ |\ \texttt{any}\ && \textrm{basic type}\\
+&&                       && |   &\quad &&  \textit{number}\ |\ \textit{string}\ |\ \textbf{\texttt{true}}\ |\ \textbf{\texttt{false}} && \textrm{literal type}\\
+&&                       && |   &\quad &&  \textit{name}[<\textit{alias-type}\ (\ \textbf{\texttt{,}} \ \textit{alias-type}\ ) ...>]   && \textrm{type reference}\\
+&&                       && |   &\quad &&   (\ \textit{names}\ )\ \texttt{\textbf{=>}}\ \textit{alias-type} && \textrm{function type}\\
+&&                       && |   &\quad &&   \textit{alias-type}\ \texttt{\textbf{|}}\ \textit{alias-type} && \textrm{union type}\\
+&&                       && |   &\quad &&   \textit{Pair<alias-type, alias-type>} && \textrm{pair type}\\
+&&                       && |   &\quad &&   \textit{List<alias-type>} && \textrm{list type}\\
+&&                       && |   &\quad &&   \textit{alias-type[]} && \textrm{array type}\\
+&&                       && |   &\quad &&  \textit{name}   && \textrm{type parameter}\\
 \end{alignat*}

--- a/docs/specs/source_3_typed_typing.tex
+++ b/docs/specs/source_3_typed_typing.tex
@@ -42,8 +42,7 @@ Support for \texttt{typeof} operations is also added to Source \S 3 Typed.
 \subsection{Type Environment}
 
 In order to keep track of the type of names in a program, we define a
-\emph{type environment}, denoted by $\Gamma$. More
-formally,
+\emph{type environment}, denoted by $\Gamma$. More formally,
 the partial function $\Gamma$ from names to types expresses a 
 context, in which a name $x$ is associated with type $\Gamma(x)$. 
 
@@ -124,6 +123,9 @@ $\Gamma_{-1}$
 & $[$ & \texttt{math\_imul} & $\leftarrow$  & $(\Number, \Number)$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_LN2} & $\leftarrow$  & $\Number$ & & & $]$ \\
 & $[$ & \texttt{math\_LN10} & $\leftarrow$  & $\Number$ & & & $]$ \\
+& \end{tabular}
+
+\begin{tabular}[fragile]{lllllllll}
 & $[$ & \texttt{math\_log} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_log1p} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_log2} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
@@ -136,9 +138,6 @@ $\Gamma_{-1}$
 & $[$ & \texttt{math\_pow} & $\leftarrow$  & $(\Number, \Number)$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_random} & $\leftarrow$  & $()$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_round} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
-& \end{tabular}
-
-\begin{tabular}[fragile]{lllllllll}
 & $[$ & \texttt{math\_sign} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_sin} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
 & $[$ & \texttt{math\_sinh} & $\leftarrow$  & $\Number$ & $\rightarrow$ & $\Number$ & $]$ \\
@@ -166,6 +165,22 @@ $\Gamma_{-1}$
 & $[$ & \texttt{set\_tail} & $\leftarrow$  & \textit{Pair<} $T_1,\ T_2$ \textit{>} & $\rightarrow$ & $\Undefined$ & $]$ \\
 & $[$ & \texttt{is\_array} & $\leftarrow$  & $\Any$ & $\rightarrow$ & $\Bool$ & $]$ \\
 & $[$ & \texttt{array\_length} & $\leftarrow$  & $\Any$[] & $\rightarrow$ & $\Number$ & $]$ $\Gamma_0$ \\
+& \end{tabular}
+
+In order to support the definition of type aliases, we define a separate
+\emph{type alias environment}, denoted by $\Gamma_{alias}$. Unlike $\Gamma$,
+$\Gamma_{alias}$ binds names to special \emph{type functions} of the form $<T_1, \ldots, T_n> \rightarrow t$
+where $T_1 \ldots T_n$ are type parameters $t$ is the return type expressed in terms of $T_1 \ldots T_n$.
+$<>$ is used to differentiate type functions from function types, which are of the form $(t_1, \ldots, t_n) \rightarrow t$.
+
+Since $\Gamma$ and $\Gamma_{alias}$ are separate environments, the same name $x$ can be used for both variables and type aliases.
+
+The initial type alias environment $\Gamma_{alias0}$ is as follows:
+
+\begin{tabular}[fragile]{lllllllll}
+$\Gamma_{alias-1}$
+& $[$ & \texttt{Pair} & $\leftarrow$ & $<T_{head}, T_{tail}>$ & $\rightarrow$ & $Pair<T_{head}, T_{tail}>$ & $]$ \\
+& $[$ & \texttt{List} & $\leftarrow$ & $<T_{elem}>$ & $\rightarrow$ & $List<T_{elem}>$ & $]$ $\Gamma_{alias0}$ \\
 & \end{tabular}
 
 \subsection{Success Types}
@@ -234,8 +249,8 @@ For function applications (including applications of binary and unary operators)
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots,  \Gamma \vdash E_n : t'_n
-  \quad (\forall 1 \leq i \leq n)(t'_i \wedge \Any \neq \emptyset)}{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
+  \Rule{\Gamma \vdash E_0 : \Any \quad \Gamma \vdash E_1 : t'_1, \ldots, \Gamma \vdash E_n : t'_n
+    }{\Gamma \vdash (E_0\ \Lp \ E_1, \ldots, E_n\ \Rp) : \Any}
 \]
 \noindent
 
@@ -243,42 +258,51 @@ The type of the operator must be a function type with the right number of parame
 and the type of every argument must be a success type of the corresponding parameter type of the function type.
 If all of the conditions are met, the type of the function application is the same
 as the return type of the function type that is the type of the operator.
-If the type of the operator is $\Any$, the types for the arguments will be checked against $\Any$ and the return type will be $\Any$.
+If the type of the operator is $\Any$, the return type will be $\Any$.
 
 Applications of binary and unary operators are treated the same as function applications, with the exception of the \texttt{+} operator.
+We use the $\subseteq$ operator to indicate that a type is a subset of another type, as defined below:
+
+\begin{itemize}
+\item{A type is a subset of type $\Number$ if it is of type $\Number$, literal number type,
+  or a union type containing any number of literal number types.}
+\item{A type is a subset of type $\String$ if it is of type $\String$, literal string type,
+  or a union type containing any number of literal string types.}
+\end{itemize}
+
 For the \texttt{+} operator, the following rules are applied, in order of priority:
 
 \begin{itemize}
-\item{If the expression on the left side is of type $\Number$ or literal number type,
+\item{If the expression on the left side is a subset of type $\Number$,
   check that the other expression is a success type of $\Number$. The return type is $\Number$.}
-\item{If the expression on the left side is of type $\String$ or literal string type,
+\item{If the expression on the left side is a subset of type $\String$,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
-\item{If the expression on the right side is of type $\Number$ or literal number type,
+\item{If the expression on the right side is a subset of type $\Number$,
   check that the other expression is a success type of $\Number$. The return type is $\Number$.}
-\item{If the expression on the right side is of type $\String$ or literal string type,
+\item{If the expression on the right side is a subset of type $\String$,
   check that the other expression is a success type of $\String$. The return type is $\String$.}
-\item{If the expression on the left side cannot be narrowed to either $\Number$ or $\String$, check that both sides are success types of 
+\item{If the expression on the left side cannot be narrowed to a subset of either $\Number$ or $\String$, check that both sides are success types of 
   $\Number\ |\ \String$. The return type is $\Number\ |\ \String$.}
 \end{itemize}
 
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \Number \vee t_0 = \textit{literal number type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq \Number
     \quad t_1 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 = \String \vee t_0 = \textit{literal string type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_0 \subseteq \String
     \quad t_1 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \Number \vee t_1 = \textit{literal number type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \Number
     \quad t_0 \wedge \Number \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \Number}
 \]
 \noindent
 \[
-  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 = \String \vee t_1 = \textit{literal string type}
+  \Rule{\Gamma \vdash E_0 : t_0 \quad \Gamma \vdash E_1 : t_1 \quad t_1 \subseteq \String
     \quad t_0 \wedge \String \neq \emptyset}{\Gamma \vdash E_0\ + \ E_1 : \String}
 \]
 \noindent
@@ -332,27 +356,36 @@ The type of the assignment itself is the type of the right expression.
 
 \subsubsection{Typing Relations on Statements}
 
-For constant declarations, the declared type of $x$, $t$, is added to the type environment.
-As type syntax is optional, if the type annotation for $x$ absent, the declared type $t$ is assumed to be $\Any$.
-The derived type of the expression $E$ must be a success type of the type declared for name $x$.
-The type of the constant declaration statement itself is $\Undefined$.
+For type alias declarations, the binding of name $x$ to type function $<T_1, \ldots, T_n> \rightarrow t$ is added to the type alias environment.
+If no type parameters are given, the type function is assumed to take in 0 type arguments.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
-    \Gamma \vdash (\texttt{const}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
-  \qquad
-  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t' \quad t' \wedge t \neq \emptyset}{
-    \Gamma \vdash (\texttt{let}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+  \Rule{\Gamma_{alias} [x \leftarrow <> \rightarrow t] \Gamma_{alias}'}{\Gamma \vdash (\texttt{type}\ x = t \texttt{;}) : \Undefined}
+  \Rule{\Gamma_{alias} [x \leftarrow <T_1, \ldots, T_n> \rightarrow T] \Gamma_{alias}'
+    }{\Gamma \vdash (\texttt{type}\ x<T_1, \ldots, T_n> = t \texttt{;}) : \Undefined}
 \]
 \noindent
 
-For type alias declarations, the declared type of $x$, $t$, is added to the type environment.
-The type of the type alias declaration itself is $\Undefined$.
+For constant and variable declarations, the declared type of $x$, $t$, is added to the type environment.
+If the type annotation for $x$ is absent, the declared type $t$ is assumed to be $\Any$.
+
+If the type annotation is a type reference to a type alias with name $T$,
+$t$ is first derived by applying the type arguments $t_1, \ldots, t_n$ to the type function for $T$,
+replacing all instances of type variables $T_1, \ldots, T_n$ in $t$ with $t_1, \ldots, t_n$ respectively.
+
+The derived type of the expression $E$, $t_E$, must be a success type of $t$.
+The type of the statement itself is $\Undefined$.
 
 \noindent
 \[
-  \Rule{\Gamma [x \leftarrow t] \Gamma'}{\Gamma \vdash (\texttt{type}\ x = t\texttt{;}) : \Undefined}
+  \Rule{\Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t_E \quad t_E \wedge t \neq \emptyset}{
+    \Gamma \vdash (\texttt{const/let}\ x \texttt{:}\ t = E\texttt{;}) : \Undefined}
+\]
+\noindent
+\[
+  \Rule{\Gamma_{alias}(T)<t_1, \ldots, t_n> = t \quad \Gamma [x \leftarrow t] \Gamma' \quad \Gamma' \vdash E : t_E \quad
+    t_E \wedge t \neq \emptyset}{\Gamma \vdash (\texttt{const/let}\ x \texttt{:}\ T<t_1, \ldots, t_n> = E\texttt{;}) : \Undefined}
 \]
 \noindent
 

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -594,6 +594,25 @@ export class InvalidNumberOfTypeArgumentsForGenericTypeError implements SourceEr
   }
 }
 
+export class TypeNotGenericError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+
+  constructor(public node: tsEs.TSTypeReference, public name: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Type '${this.name}' is not generic.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}
+
 export class TypeAliasNameNotAllowedError implements SourceError {
   public type = ErrorType.TYPE
   public severity = ErrorSeverity.ERROR
@@ -606,6 +625,25 @@ export class TypeAliasNameNotAllowedError implements SourceError {
 
   public explain() {
     return `Type alias name cannot be '${this.name}'.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}
+
+export class TypeParameterNameNotAllowedError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+
+  constructor(public node: tsEs.TSTypeParameter, public name: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Type parameter name cannot be '${this.name}'.`
   }
 
   public elaborate() {

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -707,3 +707,22 @@ export class ConstNotAssignableTypeError implements SourceError {
     return this.explain()
   }
 }
+
+export class DuplicateTypeAliasError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+
+  constructor(public node: tsEs.TSTypeAliasDeclaration, public name: string) {}
+
+  get location() {
+    return this.node.loc!
+  }
+
+  public explain() {
+    return `Type alias '${this.name}' has already been declared.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}

--- a/src/typeChecker/__tests__/source1Typed.test.ts
+++ b/src/typeChecker/__tests__/source1Typed.test.ts
@@ -177,11 +177,11 @@ describe('function types', () => {
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(`
-      "Line 7: Type '(any, string) => any' is not assignable to type '(number, number) => number'.
-      Line 8: Type '(number, any) => any' is not assignable to type '(string, string) => string'.
+      "Line 7: Type '(any, string) => string' is not assignable to type '(number, number) => number'.
+      Line 8: Type '(number, any) => number' is not assignable to type '(string, string) => string'.
       Line 9: Type '(any, any) => string' is not assignable to type '(number, number) => number'.
       Line 10: Type '(any, any) => number' is not assignable to type '(string, string) => string'.
-      Line 11: Type '(string) => any' is not assignable to type '(number, number) => number'.
+      Line 11: Type '(string) => string' is not assignable to type '(number, number) => number'.
       Line 12: Type '(number, any, any) => any' is not assignable to type '(string, string) => string'.
       Line 14: Type '(any) => any' is not assignable to type '() => number'."
     `)

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -75,7 +75,7 @@ describe('pair', () => {
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"Line 1: Type alias name cannot be 'Pair'."`
+      `"Line 1: Type alias 'Pair' has already been declared."`
     )
   })
 })
@@ -117,7 +117,7 @@ describe('list', () => {
 
     parse(code, context)
     expect(parseError(context.errors)).toMatchInlineSnapshot(
-      `"Line 1: Type alias name cannot be 'List'."`
+      `"Line 1: Type alias 'List' has already been declared."`
     )
   })
 })

--- a/src/typeChecker/__tests__/source2Typed.test.ts
+++ b/src/typeChecker/__tests__/source2Typed.test.ts
@@ -216,3 +216,20 @@ describe('tail', () => {
     )
   })
 })
+
+describe('list library functions (select)', () => {
+  it('handles types correctly', () => {
+    const code = `const xs: List<number> = list(1, 2, 3);
+      const ys1: List<boolean> = reverse(xs);
+      const ys2: List<boolean> = map((x: number): string => '1', xs);
+      const res: string = accumulate((a: number, b: number): number => a + b, 0, xs);
+    `
+
+    parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`
+      "Line 2: Type 'List<number>' is not assignable to type 'List<boolean>'.
+      Line 3: Type 'List<string>' is not assignable to type 'List<boolean>'.
+      Line 4: Type 'number' is not assignable to type 'string'."
+    `)
+  })
+})

--- a/src/typeChecker/tsESTree.ts
+++ b/src/typeChecker/tsESTree.ts
@@ -799,10 +799,15 @@ export interface TSAsExpression extends BaseTSNode {
 export interface TSTypeReference extends BaseTSNode {
   type: 'TSTypeReference'
   typeName: Identifier
-  typeParameters: TSTypeParameterInstantiation
+  typeParameters?: TSTypeParameterInstantiation
 }
 
 export interface TSTypeParameterInstantiation extends BaseTSNode {
   type: 'TSTypeParameterInstantiation'
-  params: TSType[]
+  params: (TSType | TSTypeParameter)[]
+}
+
+export interface TSTypeParameter extends BaseTSNode {
+  type: 'TSTypeParameter'
+  name: string
 }

--- a/src/typeChecker/typeChecker.ts
+++ b/src/typeChecker/typeChecker.ts
@@ -85,7 +85,7 @@ function traverse(node: NodeWithInferredType<es.Node>, constraints?: Constraint[
       }
     }
   } else {
-    node.inferredType = tVar(typeIdCounter)
+    node.inferredType = tVar(`T${typeIdCounter}`)
     typeIdCounter++
   }
   switch (node.type) {
@@ -176,7 +176,7 @@ function traverse(node: NodeWithInferredType<es.Node>, constraints?: Constraint[
           }
         }
       } else {
-        funcDeclNode.functionInferredType = tVar(typeIdCounter)
+        funcDeclNode.functionInferredType = tVar(`T${typeIdCounter}`)
       }
       typeIdCounter++
       funcDeclNode.params.forEach(param => {
@@ -1175,7 +1175,7 @@ function _infer(
       const literalVal = node.value
       const typeOfLiteral = typeof literalVal
       if (literalVal === null) {
-        return addToConstraintList(constraints, [storedType, tList(tVar(typeIdCounter++))])
+        return addToConstraintList(constraints, [storedType, tList(tVar(`T${typeIdCounter++}`))])
       } else if (typeOfLiteral === 'number') {
         return addToConstraintList(constraints, [storedType, tNumber])
       } else if (typeOfLiteral === 'boolean') {
@@ -1421,7 +1421,7 @@ function _infer(
       elements.forEach(element => {
         newConstraints = infer(element, env, newConstraints)
       })
-      const arrayElementType = tVar(typeIdCounter++)
+      const arrayElementType = tVar(`T${typeIdCounter++}`)
       newConstraints = addToConstraintList(newConstraints, [storedType, tArray(arrayElementType)])
       elements.forEach(element => {
         try {

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -766,7 +766,7 @@ function typeCheckAndReturnArrowFunctionType(
 
   const types = getParamTypes(params, context)
   // Return type will always be last item in types array
-  types.push(expectedReturnType)
+  types.push(node.returnType ? expectedReturnType : actualReturnType)
   return tFunc(...types)
 }
 

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -4,6 +4,7 @@ import { cloneDeep, isEqual } from 'lodash'
 import { ModuleNotFoundError } from '../errors/moduleErrors'
 import {
   ConstNotAssignableTypeError,
+  DuplicateTypeAliasError,
   FunctionShouldHaveReturnValueError,
   InvalidArrayAccessTypeError,
   InvalidIndexTypeError,
@@ -610,8 +611,8 @@ function addTypeDeclarationsToEnvironment(
           context.errors.push(new TypeAliasNameNotAllowedError(node, alias))
           break
         }
-        if (context.chapter >= 2 && (alias === 'Pair' || alias === 'List')) {
-          context.errors.push(new TypeAliasNameNotAllowedError(node, alias))
+        if (lookupTypeAlias(alias, env) !== undefined) {
+          context.errors.push(new DuplicateTypeAliasError(node, alias))
           break
         }
 
@@ -1048,42 +1049,6 @@ function getAnnotatedType(typeNode: tsEs.TSType, context: Context): Type {
       throw new TypecheckError(typeNode, 'Intersection types are not allowed')
     case 'TSTypeReference':
       const name = typeNode.typeName.name
-      if (context.chapter >= 2) {
-        // Special types for Source 2+: Pair, List
-        if (name === 'Pair') {
-          if (!typeNode.typeParameters || typeNode.typeParameters.params.length !== 2) {
-            context.errors.push(
-              new InvalidNumberOfTypeArgumentsForGenericTypeError(typeNode, name, 2)
-            )
-            return tPair(tAny, tAny)
-          }
-          const typeParams = typeNode.typeParameters.params.filter(
-            (param): param is tsEs.TSType => param.type !== 'TSTypeParameter'
-          )
-          if (typeParams.length !== typeNode.typeParameters.params.length) {
-            throw new TypecheckError(typeNode, 'Invalid type parameter type')
-          }
-          return tPair(
-            getAnnotatedType(typeParams[0], context),
-            getAnnotatedType(typeParams[1], context)
-          )
-        }
-        if (name === 'List') {
-          if (!typeNode.typeParameters || typeNode.typeParameters.params.length !== 1) {
-            context.errors.push(
-              new InvalidNumberOfTypeArgumentsForGenericTypeError(typeNode, name, 1)
-            )
-            return tList(tAny)
-          }
-          const typeParams = typeNode.typeParameters.params.filter(
-            (param): param is tsEs.TSType => param.type !== 'TSTypeParameter'
-          )
-          if (typeParams.length !== typeNode.typeParameters.params.length) {
-            throw new TypecheckError(typeNode, 'Invalid type parameter type')
-          }
-          return tList(getAnnotatedType(typeParams[0], context))
-        }
-      }
       return lookupTypeAliasAndRemoveForAllAndPredicateTypes(typeNode, name, context)
     case 'TSParenthesizedType':
       return getAnnotatedType(typeNode.typeAnnotation, context)

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -634,6 +634,8 @@ function addTypeDeclarationsToEnvironment(
           break
         }
         if (lookupTypeAlias(alias, env) !== undefined) {
+          // Only happens when attempting to declare type aliases that share names with predeclared types (e.g. Pair, List)
+          // Declaration of two type aliases with the same name will be caught as syntax error by parser
           context.errors.push(new DuplicateTypeAliasError(node, alias))
           break
         }

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -240,6 +240,11 @@ export function tPred(ifTrueType: Type | ForAll): PredicateType {
 export const headType = tVar('headType')
 export const tailType = tVar('tailType')
 
+// Stream type used in Source Typed
+export function tStream(elementType: Type): FunctionType {
+  return tFunc(tPair(elementType, tVar('Stream', [elementType])))
+}
+
 // Types for preludes
 export const predeclaredNames: [string, BindableType][] = [
   // constants
@@ -393,20 +398,26 @@ export const source1TypeOverrides: [string, BindableType][] = [
 
 export const source2TypeOverrides: [string, BindableType][] = [
   // list library functions
-  ['accumulate', tFunc(tFunc(tAny, tAny, tAny), tAny, tList(tAny), tAny)],
-  ['append', tFunc(tList(tAny), tList(tAny), tList(tAny))],
-  ['build_list', tFunc(tFunc(tAny, tAny), tNumber, tList(tAny))],
+  [
+    'accumulate',
+    tForAll(tFunc(tFunc(tVar('T'), tVar('U'), tVar('U')), tVar('U'), tList(tVar('T')), tVar('U')))
+  ],
+  [
+    'append',
+    tForAll(tFunc(tList(tVar('T')), tList(tVar('U')), tList(tUnion(tVar('T'), tVar('U')))))
+  ],
+  ['build_list', tForAll(tFunc(tFunc(tNumber, tVar('T')), tNumber, tList(tVar('T'))))],
   ['enum_list', tFunc(tNumber, tNumber, tList(tNumber))],
-  ['filter', tFunc(tFunc(tAny, tBool), tList(tAny), tList(tAny))],
-  ['for_each', tFunc(tFunc(tAny, tAny), tList(tAny), tBool)],
+  ['filter', tForAll(tFunc(tFunc(tVar('T'), tBool), tList(tVar('T')), tList(tVar('T'))))],
+  ['for_each', tForAll(tFunc(tFunc(tVar('T'), tAny), tList(tVar('T')), tLiteral(true)))],
   ['length', tFunc(tList(tAny), tNumber)],
-  ['list_ref', tFunc(tList(tAny), tNumber, tAny)],
+  ['list_ref', tForAll(tFunc(tList(tVar('T')), tNumber, tVar('T')))],
   ['list_to_string', tFunc(tList(tAny), tString)],
-  ['map', tFunc(tFunc(tAny, tAny), tList(tAny), tList(tAny))],
-  ['member', tFunc(tAny, tList(tAny), tList(tAny))],
-  ['remove', tFunc(tAny, tList(tAny), tList(tAny))],
-  ['remove_all', tFunc(tAny, tList(tAny), tList(tAny))],
-  ['reverse', tFunc(tList(tAny), tList(tAny))],
+  ['map', tForAll(tFunc(tFunc(tVar('T'), tVar('U')), tList(tVar('T')), tList(tVar('U'))))],
+  ['member', tForAll(tFunc(tVar('T'), tList(tVar('T')), tList(tVar('T'))))],
+  ['remove', tForAll(tFunc(tVar('T'), tList(tVar('T')), tList(tVar('T'))))],
+  ['remove_all', tForAll(tFunc(tVar('T'), tList(tVar('T')), tList(tVar('T'))))],
+  ['reverse', tForAll(tFunc(tList(tVar('T')), tList(tVar('T'))))],
   // misc functions
   // TODO: Add support for type checking of functions with variable no. of args
   ['display_list', tForAll(tAny)],
@@ -417,31 +428,34 @@ export const source2TypeOverrides: [string, BindableType][] = [
 export const source3TypeOverrides: [string, BindableType][] = [
   // array functions
   ['array_length', tFunc(tArray(tAny), tNumber)],
-  // mutating pair functions
-  ['set_head', tFunc(tPair(tAny, tAny), tAny, tUndef)],
-  ['set_tail', tFunc(tPair(tAny, tAny), tAny, tUndef)],
   // stream library functions
-  ['build_stream', tFunc(tFunc(tAny, tAny), tNumber, tPair(tAny, tFunc(tAny)))],
-  ['enum_stream', tFunc(tNumber, tNumber, tPair(tNumber, tFunc(tAny)))],
-  ['eval_stream', tFunc(tPair(tAny, tFunc(tAny)), tNumber, tList(tAny))],
-  ['integers_from', tFunc(tNumber, tPair(tNumber, tFunc(tAny)))],
-  ['list_to_stream', tFunc(tList(tAny), tPair(tAny, tFunc(tAny)))],
-  ['stream', tAny],
+  ['build_stream', tForAll(tFunc(tFunc(tNumber, tVar('T')), tNumber, tStream(tVar('T'))))],
+  ['enum_stream', tFunc(tNumber, tNumber, tStream(tNumber))],
+  ['eval_stream', tForAll(tFunc(tStream(tVar('T')), tNumber, tList(tVar('T'))))],
+  ['integers_from', tFunc(tNumber, tStream(tNumber))],
+  ['is_stream', tFunc(tAny, tBool)],
+  ['list_to_stream', tForAll(tFunc(tList(tVar('T')), tStream(tVar('T'))))],
   [
     'stream_append',
-    tFunc(tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))
+    tForAll(tFunc(tStream(tVar('T')), tStream(tVar('U')), tStream(tUnion(tVar('T'), tVar('U')))))
   ],
-  ['stream_filter', tFunc(tFunc(tAny, tBool), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_for_each', tFunc(tFunc(tAny, tAny), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_length', tFunc(tPair(tAny, tFunc(tAny)), tNumber)],
-  ['stream_map', tFunc(tFunc(tAny, tAny), tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_member', tFunc(tAny, tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_ref', tFunc(tPair(tAny, tFunc(tAny)), tNumber, tAny)],
-  ['stream_remove', tFunc(tAny, tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_remove_all', tFunc(tAny, tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_reverse', tFunc(tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_tail', tFunc(tPair(tAny, tFunc(tAny)), tPair(tAny, tFunc(tAny)))],
-  ['stream_to_list', tFunc(tPair(tAny, tFunc(tAny)), tList(tAny))]
+  [
+    'stream_filter',
+    tForAll(tFunc(tFunc(tVar('T'), tBool), tStream(tVar('T')), tStream(tVar('T'))))
+  ],
+  ['stream_for_each', tForAll(tFunc(tFunc(tVar('T'), tAny), tStream(tVar('T')), tLiteral(true)))],
+  ['stream_length', tFunc(tStream(tAny), tNumber)],
+  [
+    'stream_map',
+    tForAll(tFunc(tFunc(tVar('T'), tVar('U')), tStream(tVar('T')), tStream(tVar('U'))))
+  ],
+  ['stream_member', tForAll(tFunc(tVar('T'), tStream(tVar('T')), tStream(tVar('T'))))],
+  ['stream_ref', tForAll(tFunc(tStream(tVar('T')), tNumber, tVar('T')))],
+  ['stream_remove', tForAll(tFunc(tVar('T'), tStream(tVar('T')), tStream(tVar('T'))))],
+  ['stream_remove_all', tForAll(tFunc(tVar('T'), tStream(tVar('T')), tStream(tVar('T'))))],
+  ['stream_reverse', tForAll(tFunc(tStream(tVar('T')), tStream(tVar('T'))))],
+  ['stream_tail', tForAll(tFunc(tStream(tVar('T')), tStream(tVar('T'))))],
+  ['stream_to_list', tForAll(tFunc(tStream(tVar('T')), tList(tVar('T'))))]
 ]
 
 export const source4TypeOverrides: [string, BindableType][] = [
@@ -469,10 +483,7 @@ const pairTypeAlias: [string, BindableType] = [
   tForAll(tPair(headType, tailType), [headType, tailType])
 ]
 const listTypeAlias: [string, BindableType] = ['List', tForAll(tList(tVar('T')), [tVar('T')])]
-const streamTypeAlias: [string, BindableType] = [
-  'Stream',
-  tForAll(tFunc(tPair(tVar('T'), tVar('Stream', [tVar('T')]))), [tVar('T')])
-]
+const streamTypeAlias: [string, BindableType] = ['Stream', tForAll(tStream(tVar('T')), [tVar('T')])]
 
 // Creates type environment for the appropriate Source chapter
 export function createTypeEnvironment(chapter: Chapter): TypeEnvironment {

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -65,7 +65,7 @@ export function lookupDeclKind(
   return undefined
 }
 
-export function lookupTypeAlias(name: string, env: TypeEnvironment): Type | undefined {
+export function lookupTypeAlias(name: string, env: TypeEnvironment): BindableType | undefined {
   for (let i = env.length - 1; i >= 0; i--) {
     if (env[i].typeAliasMap.has(name)) {
       return env[i].typeAliasMap.get(name)
@@ -82,7 +82,7 @@ export function setDeclKind(name: string, kind: AllowedDeclarations, env: TypeEn
   env[env.length - 1].declKindMap.set(name, kind)
 }
 
-export function setTypeAlias(name: string, type: Type, env: TypeEnvironment): void {
+export function setTypeAlias(name: string, type: BindableType, env: TypeEnvironment): void {
   env[env.length - 1].typeAliasMap.set(name, type)
 }
 
@@ -175,10 +175,11 @@ export function tList(elementType: Type, typeAsPair?: Pair): List {
   }
 }
 
-export function tForAll(polyType: Type): ForAll {
+export function tForAll(polyType: Type, typeParamNames?: string[]): ForAll {
   return {
     kind: 'forall',
-    polyType
+    polyType,
+    typeParamNames
   }
 }
 

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -243,18 +243,18 @@ export const tailType = tVar('tailType')
 // Types for preludes
 export const predeclaredNames: [string, BindableType][] = [
   // constants
-  ['Infinity', tNumber],
-  ['NaN', tNumber],
+  ['Infinity', tPrimitive('number', Infinity)],
+  ['NaN', tPrimitive('number', NaN)],
   ['undefined', tUndef],
-  ['math_E', tNumber],
-  ['math_LN2', tNumber],
-  ['math_LN10', tNumber],
-  ['math_LOG2E', tNumber],
-  ['math_LOG10E', tNumber],
-  ['math_PI', tNumber],
-  ['math_SQRT1_2', tNumber],
-  ['math_SQRT2', tNumber],
-  // is something functions
+  ['math_E', tPrimitive('number', Math.E)],
+  ['math_LN2', tPrimitive('number', Math.LN2)],
+  ['math_LN10', tPrimitive('number', Math.LN10)],
+  ['math_LOG2E', tPrimitive('number', Math.LOG2E)],
+  ['math_LOG10E', tPrimitive('number', Math.LOG10E)],
+  ['math_PI', tPrimitive('number', Math.PI)],
+  ['math_SQRT1_2', tPrimitive('number', Math.SQRT1_2)],
+  ['math_SQRT2', tPrimitive('number', Math.SQRT2)],
+  // predicate functions
   ['is_boolean', tPred(tBool)],
   ['is_number', tPred(tNumber)],
   ['is_string', tPred(tString)],
@@ -377,17 +377,6 @@ export const temporaryStreamFuncs: [string, BindableType][] = [
 // Prelude function type overrides for Source Typed variant
 // No need to override predicate functions as they are automatically handled by type checker
 export const source1TypeOverrides: [string, BindableType][] = [
-  // constants
-  ['Infinity', tPrimitive('number', Infinity)],
-  ['NaN', tPrimitive('number', NaN)],
-  ['math_E', tPrimitive('number', Math.E)],
-  ['math_LN2', tPrimitive('number', Math.LN2)],
-  ['math_LN10', tPrimitive('number', Math.LN10)],
-  ['math_LOG2E', tPrimitive('number', Math.LOG2E)],
-  ['math_LOG10E', tPrimitive('number', Math.LOG10E)],
-  ['math_PI', tPrimitive('number', Math.PI)],
-  ['math_SQRT1_2', tPrimitive('number', Math.SQRT1_2)],
-  ['math_SQRT2', tPrimitive('number', Math.SQRT2)],
   // math functions
   // TODO: Add support for type checking of functions with variable no. of args
   ['math_hypot', tForAll(tNumber)],

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -142,10 +142,10 @@ export function tPrimitive(name: Primitive['name'], value?: string | number | bo
   }
 }
 
-export function tVar(name: string | number): Variable {
+export function tVar(name: string): Variable {
   return {
     kind: 'variable',
-    name: `T${name}`,
+    name,
     constraint: 'none'
   }
 }
@@ -153,39 +153,39 @@ export function tVar(name: string | number): Variable {
 export function tAddable(name: string): Variable {
   return {
     kind: 'variable',
-    name: `${name}`,
+    name,
     constraint: 'addable'
   }
 }
 
-export function tPair(var1: Type, var2: Type): Pair {
+export function tPair(headType: Type, tailType: Type): Pair {
   return {
     kind: 'pair',
-    headType: var1,
-    tailType: var2
+    headType,
+    tailType
   }
 }
 
-export function tList(var1: Type, typeAsPair?: Pair): List {
+export function tList(elementType: Type, typeAsPair?: Pair): List {
   return {
     kind: 'list',
-    elementType: var1,
+    elementType,
     // Used in Source Typed variants to check for type mismatches against pairs
     typeAsPair
   }
 }
 
-export function tForAll(type: Type): ForAll {
+export function tForAll(polyType: Type): ForAll {
   return {
     kind: 'forall',
-    polyType: type
+    polyType
   }
 }
 
-export function tArray(var1: Type): SArray {
+export function tArray(elementType: Type): SArray {
   return {
     kind: 'array',
-    elementType: var1
+    elementType
   }
 }
 

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -128,8 +128,15 @@ export function formatTypeString(type: Type, formatAsLiteral?: boolean): string 
       return elementTypeString.includes('|') || elementTypeString.includes('=>')
         ? `(${elementTypeString})[]`
         : `${elementTypeString}[]`
+    case 'variable':
+      if (type.typeArgs) {
+        return `${type.name}<${type.typeArgs
+          .map(param => formatTypeString(param, formatAsLiteral))
+          .join(', ')}>`
+      }
+      return type.name
     default:
-      return type.kind
+      return type
   }
 }
 
@@ -142,11 +149,12 @@ export function tPrimitive(name: Primitive['name'], value?: string | number | bo
   }
 }
 
-export function tVar(name: string): Variable {
+export function tVar(name: string, typeArgs?: Type[]): Variable {
   return {
     kind: 'variable',
     name,
-    constraint: 'none'
+    constraint: 'none',
+    typeArgs
   }
 }
 
@@ -175,11 +183,11 @@ export function tList(elementType: Type, typeAsPair?: Pair): List {
   }
 }
 
-export function tForAll(polyType: Type, typeParamNames?: string[]): ForAll {
+export function tForAll(polyType: Type, typeParams?: Variable[]): ForAll {
   return {
     kind: 'forall',
     polyType,
-    typeParamNames
+    typeParams
   }
 }
 

--- a/src/typeChecker/utils.ts
+++ b/src/typeChecker/utils.ts
@@ -475,14 +475,27 @@ const predeclaredConstTypes: [string, Type][] = [
   ['math_SQRT2', tLiteral(Math.SQRT2)]
 ]
 
+const pairTypeAlias: [string, BindableType] = [
+  'Pair',
+  tForAll(tPair(headType, tailType), [headType, tailType])
+]
+const listTypeAlias: [string, BindableType] = ['List', tForAll(tList(tVar('T')), [tVar('T')])]
+const streamTypeAlias: [string, BindableType] = [
+  'Stream',
+  tForAll(tFunc(tPair(tVar('T'), tVar('Stream', [tVar('T')]))), [tVar('T')])
+]
+
 // Creates type environment for the appropriate Source chapter
 export function createTypeEnvironment(chapter: Chapter): TypeEnvironment {
   const initialTypeMappings = [...predeclaredNames, ...primitiveFuncs]
+  const initialTypeAliasMappings: [string, BindableType][] = [...predeclaredConstTypes]
   if (chapter >= 2) {
     initialTypeMappings.push(...pairFuncs, ...listFuncs)
+    initialTypeAliasMappings.push(pairTypeAlias, listTypeAlias)
   }
   if (chapter >= 3) {
     initialTypeMappings.push(...postS3equalityFuncs, ...mutatingPairFuncs, ...arrayFuncs)
+    initialTypeAliasMappings.push(streamTypeAlias)
   } else {
     initialTypeMappings.push(...preS3equalityFuncs)
   }
@@ -491,7 +504,7 @@ export function createTypeEnvironment(chapter: Chapter): TypeEnvironment {
     {
       typeMap: new Map(initialTypeMappings),
       declKindMap: new Map(initialTypeMappings.map(val => [val[0], 'const'])),
-      typeAliasMap: new Map(predeclaredConstTypes)
+      typeAliasMap: new Map(initialTypeAliasMappings)
     }
   ]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -419,6 +419,8 @@ export type BindableType = Type | ForAll | PredicateType
 export interface ForAll {
   kind: 'forall'
   polyType: Type
+  // Used in Source Typed variant
+  typeParamNames?: string[]
 }
 
 export interface PredicateType {
@@ -440,5 +442,5 @@ export type PredicateTest = {
 export type TypeEnvironment = {
   typeMap: Map<string, BindableType>
   declKindMap: Map<string, AllowedDeclarations>
-  typeAliasMap: Map<string, Type>
+  typeAliasMap: Map<string, BindableType>
 }[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,10 +374,15 @@ export interface Primitive {
   value?: string | number | boolean
 }
 
+// In Source Typed, Variable type is used for
+// 1. Type parameters
+// 2. Type references of generic types with type arguments
 export interface Variable {
   kind: 'variable'
   name: string
   constraint: Constraint
+  // Used in Source Typed variant to store type arguments of generic types
+  typeArgs?: Type[]
 }
 
 // cannot name Function, conflicts with TS
@@ -416,11 +421,12 @@ export interface LiteralType {
 
 export type BindableType = Type | ForAll | PredicateType
 
+// In Source Typed, ForAll type is used for generic types
 export interface ForAll {
   kind: 'forall'
   polyType: Type
-  // Used in Source Typed variant
-  typeParamNames?: string[]
+  // Used in Source Typed variant to store type parameters of generic types
+  typeParams?: Variable[]
 }
 
 export interface PredicateType {


### PR DESCRIPTION
Changes:

- Adds generic types to Source Typed specs
- Adds logic for declaration of type aliases with type parameters (generic types)
- Adds Stream type (Source 3+ Typed)
- Refactored logic for Pair and List types to make use of generic types
- Tightens typings for library functions