### PR TITLE
Add source file path to error messages for multi-file programs (transpiled)

### DIFF
--- a/src/localImports/__tests__/errorMessages.ts
+++ b/src/localImports/__tests__/errorMessages.ts
@@ -133,6 +133,43 @@ describe('non-syntax errors (non-transpiled)', () => {
   })
 })
 
+describe('non-syntax errors (transpiled)', () => {
+  let context = mockContext(Chapter.SOURCE_4)
+
+  beforeEach(() => {
+    context = mockContext(Chapter.SOURCE_4)
+  })
+
+  describe('SourceError', () => {
+    test('file path is not part of error message if the program is single-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          1 + 'hello';
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"Line 2: Expected number on right hand side of operation, got string."`
+      )
+    })
+
+    test('file path is part of error message if the program is multi-file', async () => {
+      const files: Record<string, string> = {
+        '/a.js': `
+          1 + 'hello';
+        `,
+        '/b.js': `
+          const y = 2;
+        `
+      }
+      await runFilesInContext(files, '/a.js', context)
+      expect(parseError(context.errors)).toMatchInlineSnapshot(
+        `"[/a.js] Line 2: Expected number on right hand side of operation, got string."`
+      )
+    })
+  })
+})
+
 // We specifically test typed Source because it makes use of the Babel parser.
 describe('non-syntax errors (non-transpiled & typed)', () => {
   let context = mockContext(Chapter.SOURCE_4, Variant.TYPED)

--- a/src/localImports/__tests__/errorMessages.ts
+++ b/src/localImports/__tests__/errorMessages.ts
@@ -138,6 +138,7 @@ describe('non-syntax errors (transpiled)', () => {
 
   beforeEach(() => {
     context = mockContext(Chapter.SOURCE_4)
+    context.executionMethod = 'native'
   })
 
   describe('SourceError', () => {

--- a/src/runner/__tests__/runners.ts
+++ b/src/runner/__tests__/runners.ts
@@ -77,7 +77,7 @@ const JAVASCRIPT_CODE_SNIPPETS_ERRORS: CodeSnippetTestCase[] = [
           const a = b;
           `,
     value: undefined,
-    errors: [new UndefinedVariable('b', locationDummyNode(2, 20))]
+    errors: [new UndefinedVariable('b', locationDummyNode(2, 20, 'source'))]
   },
   {
     name: 'SYNTAX ERROR',
@@ -99,7 +99,7 @@ const JAVASCRIPT_CODE_SNIPPETS_ERRORS: CodeSnippetTestCase[] = [
             h();
             `,
     value: undefined,
-    errors: [new UndefinedVariable('g', locationDummyNode(3, 14))]
+    errors: [new UndefinedVariable('g', locationDummyNode(3, 14, 'source'))]
   }
 ]
 

--- a/src/runner/errors.ts
+++ b/src/runner/errors.ts
@@ -101,6 +101,7 @@ export async function toSourceError(error: Error, sourceMap?: RawSourceMap): Pro
 
   let { line, column } = errorLocation
   let identifier: string = 'UNKNOWN'
+  let source: string | null = null
 
   if (sourceMap && !(line === -1 || column === -1)) {
     // Get original lines, column and identifier
@@ -112,6 +113,7 @@ export async function toSourceError(error: Error, sourceMap?: RawSourceMap): Pro
     line = originalPosition.line ?? -1 // use -1 in place of null
     column = originalPosition.column ?? -1
     identifier = originalPosition.name ?? identifier
+    source = originalPosition.source ?? null
   }
 
   const errorMessage: string = error.message
@@ -119,9 +121,9 @@ export async function toSourceError(error: Error, sourceMap?: RawSourceMap): Pro
     possibleMessages.some(possibleMessage => errorMessage.includes(possibleMessage))
 
   if (errorMessageContains(ASSIGNMENT_TO_CONST_ERROR_MESSAGES)) {
-    return new ConstAssignment(locationDummyNode(line, column), identifier)
+    return new ConstAssignment(locationDummyNode(line, column, source), identifier)
   } else if (errorMessageContains(UNDEFINED_VARIABLE_MESSAGES)) {
-    return new UndefinedVariable(identifier, locationDummyNode(line, column))
+    return new UndefinedVariable(identifier, locationDummyNode(line, column, source))
   } else {
     const location =
       line === -1 || column === -1

--- a/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
@@ -94,7 +94,7 @@ exports[`Ensure no name clashes 1`] = `
     native0.evaller = program => eval(program);
     undefined;
     const boolOrErr = 1;
-    setProp(boolOrErr, 123, 1, 2, 0);
+    setProp(boolOrErr, 123, 1, 2, 0, null);
     const f = wrap90((callIfFuncAndRightArgs, wrap0, wrap1, wrap2, wrap3, wrap4, wrap5, wrap6, wrap7, wrap8, wrap9) => {
       let wrap = 2;
       wrap0;

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -5,8 +5,8 @@ import { AllowedDeclarations, BlockExpression, FunctionDeclarationExpression } f
 export const getVariableDecarationName = (decl: es.VariableDeclaration) =>
   (decl.declarations[0].id as es.Identifier).name
 
-export const locationDummyNode = (line: number, column: number) =>
-  literal('Dummy', { start: { line, column }, end: { line, column } })
+export const locationDummyNode = (line: number, column: number, source: string | null) =>
+  literal('Dummy', { start: { line, column }, end: { line, column }, source })
 
 export const identifier = (name: string, loc?: es.SourceLocation | null): es.Identifier => ({
   type: 'Identifier',

--- a/src/vm/svml-machine.ts
+++ b/src/vm/svml-machine.ts
@@ -1683,7 +1683,7 @@ function run(): any {
   while (RUNNING) {
     // infinite loop protection
     if (Date.now() - startTime > MAX_TIME) {
-      throw new PotentialInfiniteLoopError(locationDummyNode(-1, -1), MAX_TIME)
+      throw new PotentialInfiniteLoopError(locationDummyNode(-1, -1, null), MAX_TIME)
     }
 
     if (TO > 0) {


### PR DESCRIPTION
## Description

Updated the transpiler to make use of the source file path when Source errors are thrown.

Related to #1350. Part of https://github.com/source-academy/frontend/issues/2176.