### PR TITLE
Fix error when for loop initialisation step does not have declaration

### DIFF
--- a/src/scope-refactoring.ts
+++ b/src/scope-refactoring.ts
@@ -199,13 +199,12 @@ function scopeWhileStatements(nodes: es.WhileStatement[]): BlockFrame[] {
 
 // For statements may declare new variables whose scope is limited to the loop body
 function scopeForStatement(node: es.ForStatement): BlockFrame {
-  const variables = node.init
-    ? (node.init as es.VariableDeclaration).declarations.map((dec: es.VariableDeclarator) => ({
-        type: 'DefinitionNode',
-        name: (dec.id as es.Identifier).name,
-        loc: (dec.id as es.Identifier).loc
-      }))
-    : []
+  const declarations = (node.init as es.VariableDeclaration)?.declarations || []
+  const variables = declarations.map((dec: es.VariableDeclarator) => ({
+    type: 'DefinitionNode',
+    name: (dec.id as es.Identifier).name,
+    loc: (dec.id as es.Identifier).loc
+  }))
   const block = scopeVariables(node.body as es.BlockStatement, node.loc)
   // Any variable declared at the start of the for loop is inserted into the body
   // since its scope is limited to the body


### PR DESCRIPTION
When trying to type the following code:
```js
let i = 10;
for (i = 10; i > 0; i = i - 1) {
```
The editor produces the following error:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at scopeForStatement (scope-refactoring.ts:197:1)
    at scope-refactoring.ts:67:1
    at Array.map (<anonymous>)
    at scopeVariables (scope-refactoring.ts:67:1)
    at getAllOccurrencesInScopeHelper (scope-refactoring.ts:283:1)
    at getAllOccurrencesInScope (index.ts:136:1)
    at UseHighlighting.tsx:31:1
```

The editor tries to highlight all declarations, including those in for loops. But in Source, for loops with assignment expressions as the initialisation step are also allowed. I have traced the code scanning for declarations to `js-slang`, and have modified it so that it first checks if the declarations exist.