### PR TITLE
Fix git pre-push hook running a non-existent command

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn ci
+yarn jsdoc && yarn autocomplete && yarn format:ci && yarn eslint && yarn test


### PR DESCRIPTION
Instead of adding back the `ci` script to `package.json`, I think it's better to call each command individually so that the behaviour is more obvious.

Fixes #1358.