### PR TITLE
Repl module "default_js_slang" function support

### DIFF
--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -140,11 +140,11 @@ async function runNative(
     appendModulesToContext(transpiledProgram, context)
 
     // Repl module "default_js_slang" function support (Wang Zihan)
-    if( context.moduleContexts['repl'] !== undefined ) {
-      ( context.moduleContexts['repl'] as any ).js_slang = {};
-      ( context.moduleContexts['repl'] as any ).js_slang.sourceFilesRunner = sourceFilesRunner;
-      if( ( context.moduleContexts['repl'] as any ).js_slang.context === undefined )
-        ( context.moduleContexts['repl'] as any ).js_slang.context = context;
+    if (context.moduleContexts['repl'] !== undefined) {
+      ;(context.moduleContexts['repl'] as any).js_slang = {}
+      ;(context.moduleContexts['repl'] as any).js_slang.sourceFilesRunner = sourceFilesRunner
+      if ((context.moduleContexts['repl'] as any).js_slang.context === undefined)
+        (context.moduleContexts['repl'] as any).js_slang.context = context
     }
 
     switch (context.variant) {

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -138,6 +138,15 @@ async function runNative(
   let sourceMapJson: RawSourceMap | undefined
   try {
     appendModulesToContext(transpiledProgram, context)
+
+    // Repl module "default_js_slang" function support (Wang Zihan)
+    if( context.moduleContexts['repl'] !== undefined ) {
+      ( context.moduleContexts['repl'] as any ).js_slang = {};
+      ( context.moduleContexts['repl'] as any ).js_slang.sourceFilesRunner = sourceFilesRunner;
+      if( ( context.moduleContexts['repl'] as any ).js_slang.context === undefined )
+        ( context.moduleContexts['repl'] as any ).js_slang.context = context;
+    }
+
     switch (context.variant) {
       case Variant.GPU:
         transpileToGPU(transpiledProgram)


### PR DESCRIPTION
My module "repl" have a function called "default_js_slang" that allows students to run code in js-slang side through my module. This function need support from js-slang side to get the evaluation function and context in "sourceRunner.ts".
https://github.com/source-academy/modules/pull/188