### PR TITLE
Fix failing test cases for Env Viz

### DIFF
--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -7,6 +7,7 @@
 
 /* tslint:disable:max-classes-per-file */
 import * as es from 'estree'
+import { uniqueId } from 'lodash'
 
 import * as constants from '../constants'
 import * as errors from '../errors/errors'
@@ -46,6 +47,7 @@ import {
   getVariable,
   handleRuntimeError,
   handleSequence,
+  isAssmtInstr,
   isInstr,
   isNode,
   popEnvironment,
@@ -428,6 +430,16 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       context,
       true
     )
+    const next = agenda.peek()
+    if (!(next && isInstr(next) && isAssmtInstr(next))) {
+      if (closure instanceof Closure) {
+        Object.defineProperty(currentEnvironment(context).head, uniqueId(), {
+          value: closure,
+          writable: false,
+          enumerable: true
+        })
+      }
+    }
     stash.push(closure)
   },
 

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -147,6 +147,7 @@ export const valueProducing = (command: es.Node): boolean => {
     type !== 'FunctionDeclaration' &&
     type !== 'ContinueStatement' &&
     type !== 'BreakStatement' &&
+    type !== 'ReturnStatement' &&
     (type !== 'BlockStatement' || command.body.some(valueProducing))
   )
 }

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -9,7 +9,7 @@ import { Environment, Frame, Value } from '../types'
 import * as ast from '../utils/astCreator'
 import * as instr from './instrCreator'
 import { Agenda } from './interpreter'
-import { AgendaItem, Instr } from './types'
+import { AgendaItem, AssmtInstr, Instr, InstrType } from './types'
 
 /**
  * Stack is implemented for agenda and stash registers.
@@ -89,6 +89,16 @@ export const isExpressionBody = (
   body: es.BlockStatement | es.Expression
 ): body is es.Expression => {
   return body.type !== 'BlockStatement'
+}
+
+/**
+ * Typeguard for AssmtInstr. To verify if an instruction is an assignment instruction.
+ *
+ * @param instr an instruction
+ * @returns true if instr is an AssmtInstr, false otherwise.
+ */
+export const isAssmtInstr = (instr: Instr): instr is AssmtInstr => {
+  return instr.instrType === InstrType.ASSIGNMENT
 }
 
 /**


### PR DESCRIPTION
The recent push of the new evaluator has made the test suite for the environment visualiser to fail on the frontend (https://github.com/source-academy/frontend/pull/2351). This pull request aims to resolve the failing test cases.

## Changes
Some functions may be created but not have a corresponding binding in the environment frame (e.g. function expressions in array literals). The explicit control evaluator is modified such that a dummy variable will be created when that occurs. This follows the old interpreter in `src/interpreter`.