### PR TITLE
Add Full TypeScript Chapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@babel/parser": "^7.19.4",
     "@joeychenofficial/alt-ergo-modified": "^2.4.0",
+    "@ts-morph/bootstrap": "^0.18.0",
     "@types/estree": "0.0.52",
     "acorn": "^8.0.3",
     "acorn-class-fields": "^1.0.0",

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -430,7 +430,7 @@ const createContext = <T>(
   externalContext?: T,
   externalBuiltIns: CustomBuiltIns = defaultBuiltIns
 ): Context => {
-  if (chapter === Chapter.FULL_JS) {
+  if (chapter === Chapter.FULL_JS || chapter === Chapter.FULL_TS) {
     // fullJS will include all builtins and preludes of source 4
     return {
       ...createContext(
@@ -440,7 +440,7 @@ const createContext = <T>(
         externalContext,
         externalBuiltIns
       ),
-      chapter: Chapter.FULL_JS
+      chapter
     } as Context
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,7 @@ export async function runFilesInContext(
     return resolvedErrorPromise
   }
 
-  if (context.chapter === Chapter.FULL_JS) {
+  if (context.chapter === Chapter.FULL_JS || context.chapter === Chapter.FULL_TS) {
     const program = parse(code, context)
     if (program === null) {
       return resolvedErrorPromise

--- a/src/parser/__tests__/__snapshots__/fullTS.ts.snap
+++ b/src/parser/__tests__/__snapshots__/fullTS.ts.snap
@@ -1,0 +1,151 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fullTS parser returns ESTree compliant program 1`] = `
+Node {
+  "body": Array [
+    Node {
+      "declarations": Array [
+        Node {
+          "end": 72,
+          "id": Node {
+            "end": 68,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 29,
+                "line": 2,
+              },
+              "identifierName": "x",
+              "source": undefined,
+              "start": Position {
+                "column": 12,
+                "line": 2,
+              },
+            },
+            "name": "x",
+            "start": 51,
+            "type": "Identifier",
+            "typeAnnotation": Node {
+              "end": 68,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 29,
+                  "line": 2,
+                },
+                "identifierName": undefined,
+                "source": undefined,
+                "start": Position {
+                  "column": 13,
+                  "line": 2,
+                },
+              },
+              "start": 52,
+              "type": "TSTypeAnnotation",
+              "typeAnnotation": Node {
+                "end": 68,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 29,
+                    "line": 2,
+                  },
+                  "identifierName": undefined,
+                  "source": undefined,
+                  "start": Position {
+                    "column": 15,
+                    "line": 2,
+                  },
+                },
+                "start": 54,
+                "type": "TSTypeReference",
+                "typeName": Node {
+                  "end": 68,
+                  "loc": SourceLocation {
+                    "end": Position {
+                      "column": 29,
+                      "line": 2,
+                    },
+                    "identifierName": "StringOrNumber",
+                    "source": undefined,
+                    "start": Position {
+                      "column": 15,
+                      "line": 2,
+                    },
+                  },
+                  "name": "StringOrNumber",
+                  "start": 54,
+                  "type": "Identifier",
+                },
+              },
+            },
+          },
+          "init": Node {
+            "end": 72,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 2,
+              },
+              "identifierName": undefined,
+              "source": undefined,
+              "start": Position {
+                "column": 32,
+                "line": 2,
+              },
+            },
+            "raw": "1",
+            "start": 71,
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 2,
+            },
+            "identifierName": undefined,
+            "source": undefined,
+            "start": Position {
+              "column": 12,
+              "line": 2,
+            },
+          },
+          "start": 51,
+          "type": "VariableDeclarator",
+        },
+      ],
+      "end": 73,
+      "kind": "const",
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 34,
+          "line": 2,
+        },
+        "identifierName": undefined,
+        "source": undefined,
+        "start": Position {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "start": 45,
+      "type": "VariableDeclaration",
+    },
+  ],
+  "end": 78,
+  "interpreter": null,
+  "loc": SourceLocation {
+    "end": Position {
+      "column": 4,
+      "line": 3,
+    },
+    "identifierName": undefined,
+    "source": undefined,
+    "start": Position {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "sourceType": "module",
+  "start": 0,
+  "type": "Program",
+}
+`;

--- a/src/parser/__tests__/fullTS.ts
+++ b/src/parser/__tests__/fullTS.ts
@@ -1,0 +1,34 @@
+import { parseError } from '../..'
+import { mockContext } from '../../mocks/context'
+import { Chapter } from '../../types'
+import { FullTSParser } from '../fullTS'
+
+const parser = new FullTSParser()
+let context = mockContext(Chapter.FULL_TS)
+
+beforeEach(() => {
+  context = mockContext(Chapter.FULL_TS)
+})
+
+describe('fullTS parser', () => {
+  it('formats errors correctly', () => {
+    const code = `type StringOrNumber = string | number;
+      const x: StringOrNumber = true;
+    `
+
+    parser.parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(
+      `"Line 2: Type \'boolean\' is not assignable to type \'StringOrNumber\'."`
+    )
+  })
+
+  it('returns ESTree compliant program', () => {
+    const code = `type StringOrNumber = string | number;
+      const x: StringOrNumber = 1;
+    `
+
+    // Resulting program should not have node for type alias declaration
+    const parsedProgram = parser.parse(code, context)
+    expect(parsedProgram).toMatchSnapshot()
+  })
+})

--- a/src/parser/__tests__/fullTS.ts
+++ b/src/parser/__tests__/fullTS.ts
@@ -22,6 +22,16 @@ describe('fullTS parser', () => {
     )
   })
 
+  it('allows usage of builtins/preludes', () => {
+    const code = `const xs = list(1);
+      const ys = list(1);
+      equal(xs, ys);
+    `
+
+    parser.parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
+
   it('returns ESTree compliant program', () => {
     const code = `type StringOrNumber = string | number;
       const x: StringOrNumber = 1;

--- a/src/parser/__tests__/fullTS.ts
+++ b/src/parser/__tests__/fullTS.ts
@@ -32,6 +32,15 @@ describe('fullTS parser', () => {
     expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
   })
 
+  it('allows usage of imports/modules', () => {
+    const code = `import { show, heart } from "rune";
+      show(heart);
+    `
+
+    parser.parse(code, context)
+    expect(parseError(context.errors)).toMatchInlineSnapshot(`""`)
+  })
+
   it('returns ESTree compliant program', () => {
     const code = `type StringOrNumber = string | number;
       const x: StringOrNumber = 1;

--- a/src/parser/fullTS/index.ts
+++ b/src/parser/fullTS/index.ts
@@ -1,0 +1,74 @@
+import { parse as babelParse } from '@babel/parser'
+import { createProjectSync, ts } from '@ts-morph/bootstrap'
+import { Program } from 'estree'
+
+import { Context } from '../..'
+import * as TypedES from '../../typeChecker/tsESTree'
+import { removeTSNodes } from '../../typeChecker/typeErrorChecker'
+import { FatalSyntaxError } from '../errors'
+import { transformBabelASTToESTreeCompliantAST } from '../source/typed/utils'
+import { AcornOptions, Parser } from '../types'
+import { defaultBabelOptions, positionToSourceLocation } from '../utils'
+
+export class FullTSParser implements Parser<AcornOptions> {
+  parse(
+    programStr: string,
+    context: Context,
+    options?: Partial<AcornOptions>,
+    throwOnError?: boolean
+  ): Program | null {
+    const project = createProjectSync({ useInMemoryFileSystem: true })
+    const filename = 'program.ts'
+
+    project.createSourceFile(filename, programStr)
+    const diagnostics = ts.getPreEmitDiagnostics(project.createProgram())
+    const formattedString = project.formatDiagnosticsWithColorAndContext(diagnostics)
+    const lineNumRegex = /(?<=\[7m)\d+/
+
+    diagnostics.forEach(diagnostic => {
+      const message = diagnostic.messageText.toString()
+      const lineNum = lineNumRegex.exec(formattedString.split(message)[1])
+      const position = { line: lineNum === null ? 0 : parseInt(lineNum[0]), column: 0, offset: 0 }
+      context.errors.push(new FatalSyntaxError(positionToSourceLocation(position), message))
+    })
+
+    if (context.errors.length > 0) {
+      return null
+    }
+
+    const ast = babelParse(programStr, {
+      ...defaultBabelOptions,
+      sourceFilename: options?.sourceFile,
+      errorRecovery: throwOnError ?? true
+    })
+
+    if (ast.errors.length) {
+      ast.errors
+        .filter(error => error instanceof SyntaxError)
+        .forEach(error => {
+          context.errors.push(
+            new FatalSyntaxError(
+              positionToSourceLocation((error as any).loc, options?.sourceFile),
+              error.toString()
+            )
+          )
+        })
+
+      return null
+    }
+
+    const typedProgram: TypedES.Program = ast.program as TypedES.Program
+    const transpiledProgram: Program = removeTSNodes(typedProgram)
+    transformBabelASTToESTreeCompliantAST(transpiledProgram)
+
+    return transpiledProgram
+  }
+
+  validate(_ast: Program, _context: Context, _throwOnError: boolean): boolean {
+    return true
+  }
+
+  toString(): string {
+    return 'FullTSParser'
+  }
+}

--- a/src/parser/fullTS/index.ts
+++ b/src/parser/fullTS/index.ts
@@ -10,6 +10,10 @@ import { transformBabelASTToESTreeCompliantAST } from '../source/typed/utils'
 import { AcornOptions, Parser } from '../types'
 import { defaultBabelOptions, positionToSourceLocation } from '../utils'
 
+const IMPORT_TOP_LEVEL_ERROR =
+  'An import declaration can only be used at the top level of a namespace or module.'
+const START_OF_MODULE_ERROR = 'Cannot find module '
+
 export class FullTSParser implements Parser<AcornOptions> {
   parse(
     programStr: string,
@@ -59,6 +63,11 @@ export class FullTSParser implements Parser<AcornOptions> {
     const lineNumRegex = /(?<=\[7m)\d+/
     diagnostics.forEach(diagnostic => {
       const message = diagnostic.messageText.toString()
+      // Ignore errors regarding imports
+      // as TS does not have information about Source modules
+      if (message === IMPORT_TOP_LEVEL_ERROR || message.startsWith(START_OF_MODULE_ERROR)) {
+        return
+      }
       const lineNumRegExpArr = lineNumRegex.exec(formattedString.split(message)[1])
       const lineNum = (lineNumRegExpArr === null ? 0 : parseInt(lineNumRegExpArr[0])) - lineOffset
       // Ignore any errors that occur in builtins/prelude (line number <= 0)

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -3,6 +3,7 @@ import { Program } from 'estree'
 import { Context } from '..'
 import { Chapter, Variant } from '../types'
 import { FullJSParser } from './fullJS'
+import { FullTSParser } from './fullTS'
 import { SourceParser } from './source'
 import { SourceTypedParser } from './source/typed'
 import { AcornOptions, Parser } from './types'
@@ -17,6 +18,9 @@ export function parse<TOptions extends AcornOptions>(
   switch (context.chapter) {
     case Chapter.FULL_JS:
       parser = new FullJSParser()
+      break
+    case Chapter.FULL_TS:
+      parser = new FullTSParser()
       break
     default:
       switch (context.variant) {

--- a/src/parser/source/typed/index.ts
+++ b/src/parser/source/typed/index.ts
@@ -7,18 +7,16 @@ import { DEFAULT_ECMA_VERSION } from '../../../constants'
 import * as TypedES from '../../../typeChecker/tsESTree'
 import { checkForTypeErrors } from '../../../typeChecker/typeErrorChecker'
 import { FatalSyntaxError } from '../../errors'
-import { BabelOptions } from '../../types'
-import { createAcornParserOptions, positionToSourceLocation } from '../../utils'
+import {
+  createAcornParserOptions,
+  defaultBabelOptions,
+  positionToSourceLocation
+} from '../../utils'
 import { SourceParser } from '..'
 import TypeParser from './typeParser'
 import { transformBabelASTToESTreeCompliantAST } from './utils'
 
 export class SourceTypedParser extends SourceParser {
-  static defaultBabelOptions: BabelOptions = {
-    sourceType: 'module',
-    plugins: ['typescript', 'estree']
-  }
-
   parse(
     programStr: string,
     context: Context,
@@ -48,7 +46,7 @@ export class SourceTypedParser extends SourceParser {
     // Parse again with babel parser to capture all type syntax
     // and catch remaining syntax errors not caught by acorn type parser
     const ast = babelParse(programStr, {
-      ...SourceTypedParser.defaultBabelOptions,
+      ...defaultBabelOptions,
       sourceFilename: options?.sourceFile,
       errorRecovery: throwOnError ?? true
     })

--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -14,7 +14,7 @@ import { DEFAULT_ECMA_VERSION } from '../constants'
 import { SourceError } from '../types'
 import { validateAndAnnotate } from '../validator/validator'
 import { MissingSemicolonError, TrailingCommaError } from './errors'
-import { AcornOptions } from './types'
+import { AcornOptions, BabelOptions } from './types'
 
 /**
  * Generates options object for acorn parser
@@ -136,3 +136,8 @@ export const positionToSourceLocation = (position: Position, source?: string): S
   end: { ...position, column: position.column + 1 },
   source
 })
+
+export const defaultBabelOptions: BabelOptions = {
+  sourceType: 'module',
+  plugins: ['typescript', 'estree']
+}

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -1524,7 +1524,7 @@ function containsType(
 /**
  * Traverses through the program and removes all TS-related nodes, returning the result.
  */
-function removeTSNodes(node: tsEs.Node | undefined | null): any {
+export function removeTSNodes(node: tsEs.Node | undefined | null): any {
   if (node === undefined || node === null) {
     return node
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export enum Chapter {
   SOURCE_4 = 4,
   FULL_JS = -1,
   HTML = -2,
+  FULL_TS = -3,
   LIBRARY_PARSER = 100
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,6 +1315,23 @@
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@ts-morph/bootstrap@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.18.0.tgz#23f886caa87575e48b07c9905ddbd56a33ee33f4"
+  integrity sha512-LmYkdorZT7UonhVuATqj8jFBVz/4ykuFdbrA5szk19OAVxEWaytg7TsngC2waUDLfdc93aJrCF9Gs8Extc1Pfg==
+  dependencies:
+    "@ts-morph/common" "~0.18.0"
+
+"@ts-morph/common@~0.18.0":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.18.1.tgz#ca40c3a62c3f9e17142e0af42633ad63efbae0ec"
+  integrity sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==
+  dependencies:
+    fast-glob "^3.2.12"
+    minimatch "^5.1.0"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
 "@types/babel__core@^7.1.14":
   version "7.1.19"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz"
@@ -1906,6 +1923,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -2590,6 +2614,17 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
     picomatch "^2.2.1"
+
+fast-glob@^3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
@@ -3904,6 +3939,13 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.1.0:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz"
@@ -4164,6 +4206,11 @@ parse5@^7.0.0:
   integrity sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==
   dependencies:
     entities "^4.4.0"
+
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-exists@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Adds the Full TypeScript chapter. The `FullTSParser` makes use of the [@ts-morph/bootstrap](https://github.com/dsherret/ts-morph/tree/latest/packages/bootstrap) library to access the TypeScript compiler API, which is run on the code string to retrieve compile-time errors. The errors are presented in the form of a single colour-coded string; regex matching is then used to retrieve the line numbers and format each error into a Source error.

If the code passes the compile check, it will be parsed by the Babel Parser into a Babel ESTree-compliant AST, and AST manipulation is performed so that any TS nodes are removed. The resulting AST is then passed into the existing `fullJSRunner` for evaluation.

Support for Source built-ins and libraries is added by prepending the declarations to the program code. This comes with some caveats:
- The built-in functions cannot be typed, as the functions are only accessed at runtime. Therefore, each declaration is replaced with a stand-in constant with type `any` and value `1`.
- The prelude for source 4 has many lines, which significantly slows down the runtime of the program. Therefore, functions declared in preludes are replaced in the same way as built-ins, to shorten code length.

Any errors related to import declarations are also ignored, as the TS Compiler API does not have access to information on Source Modules.

**How to test:**
Clone the corresponding branch on frontend, link to local js-slang, then proceed to run any TS code.