### PR TITLE
Use UNKNOWN_LOCATION if node location does not exist

### DIFF
--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -9,7 +9,7 @@
 import * as es from 'estree'
 import { uniqueId } from 'lodash'
 
-import * as constants from '../constants'
+import { UNKNOWN_LOCATION } from '../constants'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import Closure from '../interpreter/closure'
@@ -629,7 +629,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
           // The error could've arisen when the builtin called a source function which errored.
           // If the cause was a source error, we don't want to include the error.
           // However if the error came from the builtin itself, we need to handle it.
-          const loc = command.srcNode ? command.srcNode.loc! : constants.UNKNOWN_LOCATION
+          const loc = command.srcNode.loc ?? UNKNOWN_LOCATION
           handleRuntimeError(context, new errors.ExceptionError(error, loc))
         }
       }

--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -3,6 +3,7 @@
 import { baseGenerator, generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../constants'
 import { ErrorSeverity, ErrorType, SourceError, Value } from '../types'
 import { stringify } from '../utils/stringify'
 import { RuntimeSourceError } from './runtimeSourceError'
@@ -24,8 +25,11 @@ export class InterruptedError extends RuntimeSourceError {
 export class ExceptionError implements SourceError {
   public type = ErrorType.RUNTIME
   public severity = ErrorSeverity.ERROR
+  public location: es.SourceLocation
 
-  constructor(public error: Error, public location: es.SourceLocation) {}
+  constructor(public error: Error, location?: es.SourceLocation | null) {
+    this.location = location ?? UNKNOWN_LOCATION
+  }
 
   public explain() {
     return this.error.toString()
@@ -216,7 +220,7 @@ export class GetInheritedPropertyError extends RuntimeSourceError {
 
   constructor(node: es.Node, private obj: Value, private prop: string) {
     super(node)
-    this.location = node.loc!
+    this.location = node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/errors/runtimeSourceError.ts
+++ b/src/errors/runtimeSourceError.ts
@@ -9,7 +9,7 @@ export class RuntimeSourceError implements SourceError {
   public location: es.SourceLocation
 
   constructor(node?: es.Node) {
-    this.location = node ? node.loc! : UNKNOWN_LOCATION
+    this.location = node?.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../constants'
 import * as tsEs from '../typeChecker/tsESTree'
 import { ErrorSeverity, ErrorType, NodeWithInferredType, SArray, SourceError, Type } from '../types'
 import { simplify, stripIndent } from '../utils/formatters'
@@ -15,7 +16,7 @@ export class InvalidArrayIndexType implements SourceError {
   constructor(public node: NodeWithInferredType<es.Node>, public receivedType: Type) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -38,7 +39,7 @@ export class ArrayAssignmentError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -58,7 +59,7 @@ export class ReassignConstError implements SourceError {
   constructor(public node: NodeWithInferredType<es.AssignmentExpression>) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -82,7 +83,7 @@ export class DifferentAssignmentError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -115,7 +116,7 @@ export class CyclicReferenceError implements SourceError {
   constructor(public node: NodeWithInferredType<es.Node>) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -148,7 +149,7 @@ export class DifferentNumberArgumentsError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -171,7 +172,7 @@ export class InvalidArgumentTypesError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -268,7 +269,7 @@ export class InvalidTestConditionError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -293,7 +294,7 @@ export class UndefinedIdentifierError implements SourceError {
   constructor(public node: NodeWithInferredType<es.Identifier>, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -320,7 +321,7 @@ export class ConsequentAlternateMismatchError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -348,7 +349,7 @@ export class CallingNonFunctionType implements SourceError {
   constructor(public node: NodeWithInferredType<es.CallExpression>, public callerType: Type) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -379,7 +380,7 @@ export class InconsistentPredicateTestError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -413,7 +414,7 @@ export class TypeMismatchError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -432,7 +433,7 @@ export class TypeNotFoundError implements SourceError {
   constructor(public node: tsEs.Node, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -451,7 +452,7 @@ export class FunctionShouldHaveReturnValueError implements SourceError {
   constructor(public node: tsEs.FunctionDeclaration | tsEs.ArrowFunctionExpression) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -470,7 +471,7 @@ export class TypeNotCallableError implements SourceError {
   constructor(public node: tsEs.CallExpression, public typeName: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -493,7 +494,7 @@ export class TypecastError implements SourceError {
   ) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -512,7 +513,7 @@ export class TypeNotAllowedError implements SourceError {
   constructor(public node: tsEs.TSType, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -531,7 +532,7 @@ export class UndefinedVariableTypeError implements SourceError {
   constructor(public node: tsEs.Node, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -558,7 +559,7 @@ export class InvalidNumberOfArgumentsTypeError implements SourceError {
   }
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -582,7 +583,7 @@ export class InvalidNumberOfTypeArgumentsForGenericTypeError implements SourceEr
   constructor(public node: tsEs.Node, public name: string, public expected: number) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -601,7 +602,7 @@ export class TypeNotGenericError implements SourceError {
   constructor(public node: tsEs.Node, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -620,7 +621,7 @@ export class TypeAliasNameNotAllowedError implements SourceError {
   constructor(public node: tsEs.TSTypeAliasDeclaration, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -639,7 +640,7 @@ export class TypeParameterNameNotAllowedError implements SourceError {
   constructor(public node: tsEs.TSTypeParameter, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -658,7 +659,7 @@ export class InvalidIndexTypeError implements SourceError {
   constructor(public node: tsEs.MemberExpression, public typeName: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -677,7 +678,7 @@ export class InvalidArrayAccessTypeError implements SourceError {
   constructor(public node: tsEs.MemberExpression, public typeName: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -696,7 +697,7 @@ export class ConstNotAssignableTypeError implements SourceError {
   constructor(public node: tsEs.AssignmentExpression, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {
@@ -715,7 +716,7 @@ export class DuplicateTypeAliasError implements SourceError {
   constructor(public node: tsEs.TSTypeAliasDeclaration, public name: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/errors/validityErrors.ts
+++ b/src/errors/validityErrors.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../constants'
 import { ErrorSeverity, ErrorType, SourceError } from '../types'
 
 export class NoAssignmentToForVariable implements SourceError {
@@ -9,7 +10,7 @@ export class NoAssignmentToForVariable implements SourceError {
   constructor(public node: es.AssignmentExpression) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -155,7 +155,7 @@ class GPUTransformer {
         kernelFunction,
         create.literal(currentKernelId++)
       ],
-      node.loc!
+      node.loc
     )
 
     create.mutateToExpressionStatement(node, createKernelSourceCall)

--- a/src/interpreter/closure.ts
+++ b/src/interpreter/closure.ts
@@ -60,12 +60,12 @@ export default class Closure extends Callable {
       return body.type !== 'BlockStatement'
     }
     const functionBody = isExpressionBody(node.body)
-      ? [returnStatement(node.body, node.body.loc!)]
+      ? [returnStatement(node.body, node.body.loc)]
       : dummyReturn
       ? [node.body, returnStatement(identifier('undefined', dummyLocation()), dummyLocation())]
       : node.body
     const closure = new Closure(
-      blockArrowFunction(node.params as es.Identifier[], functionBody, node.loc!),
+      blockArrowFunction(node.params as es.Identifier[], functionBody, node.loc),
       environment,
       context
     )

--- a/src/interpreter/interpreter-non-det.ts
+++ b/src/interpreter/interpreter-non-det.ts
@@ -2,8 +2,7 @@
 import * as es from 'estree'
 import { cloneDeep, uniqueId } from 'lodash'
 
-import * as constants from '../constants'
-import { CUT } from '../constants'
+import { CUT, UNKNOWN_LOCATION } from '../constants'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { Context, Environment, Frame, Value } from '../types'
@@ -252,9 +251,9 @@ function* getAmbArgs(context: Context, call: es.CallExpression) {
 
 function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
   if (node.operator === '&&') {
-    return conditionalExpression(node.left, node.right, literal(false), node.loc!)
+    return conditionalExpression(node.left, node.right, literal(false), node.loc)
   } else {
-    return conditionalExpression(node.left, literal(true), node.right, node.loc!)
+    return conditionalExpression(node.left, literal(true), node.right, node.loc)
   }
 }
 
@@ -679,7 +678,7 @@ export function* apply(
         -context.numberOfOuterEnvironments
       )
 
-      const loc = node ? node.loc! : constants.UNKNOWN_LOCATION
+      const loc = node.loc ?? UNKNOWN_LOCATION
       if (!(e instanceof RuntimeSourceError || e instanceof errors.ExceptionError)) {
         // The error could've arisen when the builtin called a source function which errored.
         // If the cause was a source error, we don't want to include the error.

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -2,7 +2,7 @@
 import * as es from 'estree'
 import { isEmpty, uniqueId } from 'lodash'
 
-import * as constants from '../constants'
+import { UNKNOWN_LOCATION } from '../constants'
 import { LazyBuiltIn } from '../createContext'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
@@ -287,9 +287,9 @@ function* getArgs(context: Context, call: es.CallExpression) {
 
 function transformLogicalExpression(node: es.LogicalExpression): es.ConditionalExpression {
   if (node.operator === '&&') {
-    return conditionalExpression(node.left, node.right, literal(false), node.loc!)
+    return conditionalExpression(node.left, node.right, literal(false), node.loc)
   } else {
-    return conditionalExpression(node.left, literal(true), node.right, node.loc!)
+    return conditionalExpression(node.left, literal(true), node.right, node.loc)
   }
 }
 
@@ -811,7 +811,7 @@ export function* apply(
           -context.numberOfOuterEnvironments
         )
 
-        const loc = node ? node.loc! : constants.UNKNOWN_LOCATION
+        const loc = node.loc ?? UNKNOWN_LOCATION
         if (!(e instanceof RuntimeSourceError || e instanceof errors.ExceptionError)) {
           // The error could've arisen when the builtin called a source function which errored.
           // If the cause was a source error, we don't want to include the error.
@@ -838,7 +838,7 @@ export function* apply(
           -context.numberOfOuterEnvironments
         )
 
-        const loc = node ? node.loc! : constants.UNKNOWN_LOCATION
+        const loc = node.loc ?? UNKNOWN_LOCATION
         if (!(e instanceof RuntimeSourceError || e instanceof errors.ExceptionError)) {
           // The error could've arisen when the builtin called a source function which errored.
           // If the cause was a source error, we don't want to include the error.

--- a/src/lazy/lazy.ts
+++ b/src/lazy/lazy.ts
@@ -21,7 +21,7 @@ function transformFunctionDeclarationsToArrowFunctions(program: es.Program) {
       node = node as es.VariableDeclaration
       const asArrowFunction = create.callExpression(
         create.identifier('makeLazyFunction', node.loc),
-        [create.blockArrowFunction(params as es.Identifier[], body, node.loc!)],
+        [create.blockArrowFunction(params as es.Identifier[], body, node.loc)],
         node.loc
       )
       node.declarations = [

--- a/src/name-extractor/index.ts
+++ b/src/name-extractor/index.ts
@@ -1,6 +1,7 @@
 import * as es from 'estree'
 
 import { Context } from '../'
+import { UNKNOWN_LOCATION } from '../constants'
 import { ModuleConnectionError, ModuleNotFoundError } from '../errors/moduleErrors'
 import { findAncestors, findIdentifierNode } from '../finder'
 import { memoizedloadModuleDocs } from '../modules/moduleLoader'
@@ -111,7 +112,7 @@ export function getKeywords(
   // The rest of the keywords are only valid at the beginning of a statement
   if (
     ancestors[0].type === 'ExpressionStatement' &&
-    ancestors[0].loc!.start === identifier.loc!.start
+    (ancestors[0].loc ?? UNKNOWN_LOCATION).start === (identifier.loc ?? UNKNOWN_LOCATION).start
   ) {
     addAllowedKeywords(keywordsInBlock)
     // Keywords only allowed in functions

--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -1,5 +1,6 @@
 import { Node, SourceLocation } from 'estree'
 
+import { UNKNOWN_LOCATION } from '../constants'
 import { ErrorSeverity, ErrorType, SourceError } from '../types'
 import { stripIndent } from '../utils/formatters'
 
@@ -55,7 +56,7 @@ export class DisallowedConstructError implements SourceError {
   }
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/bracesAroundFor.ts
+++ b/src/parser/source/rules/bracesAroundFor.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class BracesAroundForError implements SourceError {
@@ -10,7 +11,7 @@ export class BracesAroundForError implements SourceError {
   constructor(public node: es.ForStatement) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/bracesAroundIfElse.ts
+++ b/src/parser/source/rules/bracesAroundIfElse.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 import { stripIndent } from '../../../utils/formatters'
 
@@ -11,7 +12,7 @@ export class BracesAroundIfElseError implements SourceError {
   constructor(public node: es.IfStatement, private branch: 'consequent' | 'alternate') {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/bracesAroundWhile.ts
+++ b/src/parser/source/rules/bracesAroundWhile.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class BracesAroundWhileError implements SourceError {
@@ -10,7 +11,7 @@ export class BracesAroundWhileError implements SourceError {
   constructor(public node: es.WhileStatement) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/forStatementMustHaveAllParts.ts
+++ b/src/parser/source/rules/forStatementMustHaveAllParts.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 import { stripIndent } from '../../../utils/formatters'
 
@@ -10,7 +11,7 @@ export class ForStatmentMustHaveAllParts implements SourceError {
   constructor(public node: es.ForStatement, private missingParts: string[]) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noDeclareMutable.ts
+++ b/src/parser/source/rules/noDeclareMutable.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { Chapter, ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 const mutableDeclarators = ['let', 'var']
@@ -12,7 +13,7 @@ export class NoDeclareMutableError implements SourceError {
   constructor(public node: es.VariableDeclaration) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noDotAbbreviation.ts
+++ b/src/parser/source/rules/noDotAbbreviation.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { Chapter, ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoDotAbbreviationError implements SourceError {
@@ -9,7 +10,7 @@ export class NoDotAbbreviationError implements SourceError {
   constructor(public node: es.MemberExpression) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noEval.ts
+++ b/src/parser/source/rules/noEval.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoEval implements SourceError {
@@ -9,7 +10,7 @@ export class NoEval implements SourceError {
   constructor(public node: es.Identifier) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noFunctionDeclarationWithoutIdentifier.ts
+++ b/src/parser/source/rules/noFunctionDeclarationWithoutIdentifier.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoFunctionDeclarationWithoutIdentifierError implements SourceError {
@@ -9,7 +10,7 @@ export class NoFunctionDeclarationWithoutIdentifierError implements SourceError 
   constructor(public node: es.FunctionDeclaration) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noHolesInArrays.ts
+++ b/src/parser/source/rules/noHolesInArrays.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 import { stripIndent } from '../../../utils/formatters'
 
@@ -10,7 +11,7 @@ export class NoHolesInArrays implements SourceError {
   constructor(public node: es.ArrayExpression) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noIfWithoutElse.ts
+++ b/src/parser/source/rules/noIfWithoutElse.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { Chapter, ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 import { stripIndent } from '../../../utils/formatters'
 
@@ -11,7 +12,7 @@ export class NoIfWithoutElseError implements SourceError {
   constructor(public node: es.IfStatement) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noImplicitDeclareUndefined.ts
+++ b/src/parser/source/rules/noImplicitDeclareUndefined.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 import { stripIndent } from '../../../utils/formatters'
 
@@ -10,7 +11,7 @@ export class NoImplicitDeclareUndefinedError implements SourceError {
   constructor(public node: es.Identifier) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noImplicitReturnUndefined.ts
+++ b/src/parser/source/rules/noImplicitReturnUndefined.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 import { stripIndent } from '../../../utils/formatters'
 
@@ -10,7 +11,7 @@ export class NoImplicitReturnUndefinedError implements SourceError {
   constructor(public node: es.ReturnStatement) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noNull.ts
+++ b/src/parser/source/rules/noNull.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { Chapter, ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoNullError implements SourceError {
@@ -9,7 +10,7 @@ export class NoNullError implements SourceError {
   constructor(public node: es.Literal) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noSpreadInArray.ts
+++ b/src/parser/source/rules/noSpreadInArray.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoSpreadInArray implements SourceError {
@@ -9,7 +10,7 @@ export class NoSpreadInArray implements SourceError {
   constructor(public node: es.SpreadElement) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noTemplateExpression.ts
+++ b/src/parser/source/rules/noTemplateExpression.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoTemplateExpressionError implements SourceError {
@@ -9,7 +10,7 @@ export class NoTemplateExpressionError implements SourceError {
   constructor(public node: es.TemplateLiteral) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noUnspecifiedLiteral.ts
+++ b/src/parser/source/rules/noUnspecifiedLiteral.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 const specifiedLiterals = ['boolean', 'string', 'number']
@@ -11,7 +12,7 @@ export class NoUnspecifiedLiteral implements SourceError {
   constructor(public node: es.Literal) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noUnspecifiedOperator.ts
+++ b/src/parser/source/rules/noUnspecifiedOperator.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoUnspecifiedOperatorError implements SourceError {
@@ -12,7 +13,7 @@ export class NoUnspecifiedOperatorError implements SourceError {
   }
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noUpdateAssignment.ts
+++ b/src/parser/source/rules/noUpdateAssignment.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoUpdateAssignment implements SourceError {
@@ -10,7 +11,7 @@ export class NoUpdateAssignment implements SourceError {
   constructor(public node: es.AssignmentExpression) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/noVar.ts
+++ b/src/parser/source/rules/noVar.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class NoVarError implements SourceError {
@@ -10,7 +11,7 @@ export class NoVarError implements SourceError {
   constructor(public node: es.VariableDeclaration) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/singleVariableDeclaration.ts
+++ b/src/parser/source/rules/singleVariableDeclaration.ts
@@ -1,6 +1,7 @@
 import { generate } from 'astring'
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class MultipleDeclarationsError implements SourceError {
@@ -18,7 +19,7 @@ export class MultipleDeclarationsError implements SourceError {
   }
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/parser/source/rules/strictEquality.ts
+++ b/src/parser/source/rules/strictEquality.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../../../constants'
 import { ErrorSeverity, ErrorType, Rule, SourceError } from '../../../types'
 
 export class StrictEqualityError implements SourceError {
@@ -9,7 +10,7 @@ export class StrictEqualityError implements SourceError {
   constructor(public node: es.BinaryExpression) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
 
   public explain() {

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -444,7 +444,7 @@ function substituteMain(
         target.operator,
         dummyExpression(),
         dummyExpression(),
-        target.loc!
+        target.loc
       )
       seenBefore.set(target, substedBinaryExpression)
       let nextIndex = index
@@ -462,7 +462,7 @@ function substituteMain(
       const substedUnaryExpression = ast.unaryExpression(
         target.operator,
         dummyExpression(),
-        target.loc!
+        target.loc
       )
       seenBefore.set(target, substedUnaryExpression)
       if (pathNotEnded(index)) {
@@ -480,7 +480,7 @@ function substituteMain(
         dummyExpression(),
         dummyExpression(),
         dummyExpression(),
-        target.loc!
+        target.loc
       )
       seenBefore.set(target, substedConditionalExpression)
       let nextIndex = index
@@ -524,7 +524,7 @@ function substituteMain(
 
     CallExpression(target: es.CallExpression, index: number): es.CallExpression {
       const dummyArgs = target.arguments.map(() => dummyExpression())
-      const substedCallExpression = ast.callExpression(dummyExpression(), dummyArgs, target.loc!)
+      const substedCallExpression = ast.callExpression(dummyExpression(), dummyArgs, target.loc)
       seenBefore.set(target, substedCallExpression)
       const arr: number[] = []
       let nextIndex = index
@@ -971,7 +971,7 @@ function substituteMain(
     },
 
     ReturnStatement(target: es.ReturnStatement, index: number): es.ReturnStatement {
-      const substedReturnStatement = ast.returnStatement(dummyExpression(), target.loc!)
+      const substedReturnStatement = ast.returnStatement(dummyExpression(), target.loc)
       seenBefore.set(target, substedReturnStatement)
       if (pathNotEnded(index)) {
         allPaths[index].push('argument')
@@ -1120,7 +1120,7 @@ function substituteMain(
         dummyExpression(),
         dummyBlockStatement(),
         dummyBlockStatement(),
-        target.loc!
+        target.loc
       )
       seenBefore.set(target, substedIfStatement)
       let nextIndex = index
@@ -1526,7 +1526,7 @@ function reduceMain(
             operator,
             left,
             reducedRight as es.Expression,
-            node.loc!
+            node.loc
           )
           return [reducedExpression, cont, path, str]
         }
@@ -1537,7 +1537,7 @@ function reduceMain(
           operator,
           reducedLeft as es.Expression,
           right,
-          node.loc!
+          node.loc
         )
         return [reducedExpression, cont, path, str]
       }
@@ -1565,7 +1565,7 @@ function reduceMain(
         const reducedExpression = ast.unaryExpression(
           operator,
           reducedArgument as es.Expression,
-          node.loc!
+          node.loc
         )
         return [reducedExpression, cont, path, str]
       }
@@ -1596,7 +1596,7 @@ function reduceMain(
           reducedTest as es.Expression,
           consequent,
           alternate,
-          node.loc!
+          node.loc
         )
         return [reducedExpression, cont, path, str]
       }
@@ -1616,9 +1616,9 @@ function reduceMain(
             node.operator === '&&'
               ? left.value
                 ? right
-                : ast.literal(false, node.loc!)
+                : ast.literal(false, node.loc)
               : left.value
-              ? ast.literal(true, node.loc!)
+              ? ast.literal(true, node.loc)
               : right
           return [result as es.Expression, context, paths, explain(node)]
         }
@@ -1630,7 +1630,7 @@ function reduceMain(
             node.operator,
             reducedLeft as es.Expression,
             right,
-            node.loc!
+            node.loc
           ) as substituterNodes,
           cont,
           path,
@@ -1652,7 +1652,7 @@ function reduceMain(
         paths[0].push('callee')
         const [reducedCallee, cont, path, str] = reduce(callee, context, paths)
         return [
-          ast.callExpression(reducedCallee as es.Expression, args as es.Expression[], node.loc!),
+          ast.callExpression(reducedCallee as es.Expression, args as es.Expression[], node.loc),
           cont,
           path,
           str
@@ -1682,7 +1682,7 @@ function reduceMain(
                 ast.callExpression(
                   callee as es.Expression,
                   reducedArgs as es.Expression[],
-                  node.loc!
+                  node.loc
                 ),
                 cont,
                 path,
@@ -2274,7 +2274,7 @@ function reduceMain(
           reducedTest as es.Expression,
           consequent as es.BlockStatement,
           alternate as es.IfStatement | es.BlockStatement,
-          node.loc!
+          node.loc
         )
         return [reducedIfStatement, cont, path, str]
       }

--- a/src/typeChecker/internalTypeErrors.ts
+++ b/src/typeChecker/internalTypeErrors.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../constants'
 import { ErrorSeverity, ErrorType, NodeWithInferredType, SourceError, Type } from '../types'
 import { typeToString } from '../utils/stringify'
 import * as tsEs from './tsESTree'
@@ -14,7 +15,7 @@ export class TypeError implements SourceError {
   }
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
   public explain() {
     return this.message
@@ -62,7 +63,7 @@ export class TypecheckError implements SourceError {
   constructor(public node: tsEs.Node | tsEs.TSType, public message: string) {}
 
   get location() {
-    return this.node.loc!
+    return this.node.loc ?? UNKNOWN_LOCATION
   }
   public explain() {
     return this.message

--- a/src/utils/operators.ts
+++ b/src/utils/operators.ts
@@ -120,7 +120,7 @@ export function callIfFuncAndRightArgs(
     } catch (error) {
       // if we already handled the error, simply pass it on
       if (!(error instanceof RuntimeSourceError || error instanceof ExceptionError)) {
-        throw new ExceptionError(error, dummy.loc!)
+        throw new ExceptionError(error, dummy.loc)
       } else {
         throw error
       }
@@ -134,7 +134,7 @@ export function callIfFuncAndRightArgs(
     } catch (error) {
       // if we already handled the error, simply pass it on
       if (!(error instanceof RuntimeSourceError || error instanceof ExceptionError)) {
-        throw new ExceptionError(error, dummy.loc!)
+        throw new ExceptionError(error, dummy.loc)
       } else {
         throw error
       }
@@ -292,7 +292,7 @@ export const callIteratively = (f: any, nativeStorage: NativeStorage, ...args: a
     } catch (error) {
       // if we already handled the error, simply pass it on
       if (!(error instanceof RuntimeSourceError || error instanceof ExceptionError)) {
-        throw new ExceptionError(error, dummy.loc!)
+        throw new ExceptionError(error, dummy.loc)
       } else {
         throw error
       }

--- a/src/vm/svml-compiler.ts
+++ b/src/vm/svml-compiler.ts
@@ -1,5 +1,6 @@
 import * as es from 'estree'
 
+import { UNKNOWN_LOCATION } from '../constants'
 import { ConstAssignment, UndefinedVariable } from '../errors/errors'
 import { parse } from '../parser/parser'
 import {
@@ -217,7 +218,7 @@ function extractAndRenameNames(
       const node = stmt as es.VariableDeclaration
       let name = (node.declarations[0].id as es.Identifier).name
       if (rename) {
-        const loc = node.loc!.start // should be present
+        const loc = (node.loc ?? UNKNOWN_LOCATION).start
         const oldName = name
         do {
           name = `${name}-${loc.line}-${loc.column}`
@@ -236,7 +237,7 @@ function extractAndRenameNames(
       }
       let name = node.id.name
       if (rename) {
-        const loc = node.loc!.start // should be present
+        const loc = (node.loc ?? UNKNOWN_LOCATION).start
         const oldName = name
         do {
           name = `${name}-${loc.line}-${loc.column}`
@@ -1050,7 +1051,7 @@ function transformForLoopsToWhileLoops(program: es.Program) {
         // loc is used for renaming. It doesn't matter if we use the same location, as the
         // renaming function will notice that they are the same, and rename it further so that
         // there aren't any clashes.
-        const loc = init!.loc!
+        const loc = init!.loc
         const copyOfLoopVarName = 'copy-of-' + loopVarName
         const innerBlock = create.blockStatement([
           create.constantDeclaration(loopVarName, create.identifier(copyOfLoopVarName), loc),


### PR DESCRIPTION
This change is necessary for multiple file programs to work correctly in the frontend. This is because the AST nodes which are added by the preprocessor do not have a corresponding location (due to not being parsed from code in the first place). One of the instances of `.loc!` is being called (no idea which because it's almost impossible to trace without proper error handling), resulting in the evaluation of multiple-file programs dying.

We really should ban the use of the non-null assertion operator (`!`). Its only purpose is to let lazy programmers write code that bypass the type checker.

Part of https://github.com/source-academy/frontend/issues/2176.