### PR TITLE
Add syntax highlighting for 'export' & 'as' keywords

### DIFF
--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -87,6 +87,9 @@ export function HighlightRulesSelector(
       if (id >= 1) {
         output.push('import', 'const', 'else', 'if', 'return', 'function', 'debugger')
       }
+      if (id >= 2) {
+        output.push('export')
+      }
       if (id >= 3) {
         output.push('while', 'for', 'break', 'continue', 'let')
       }
@@ -95,6 +98,9 @@ export function HighlightRulesSelector(
 
     const ChapterAndVariantForbiddenWordSelector = () => {
       const forbiddenWords = []
+      if (id < 2) {
+        forbiddenWords.push('export')
+      }
       if (id < 3) {
         forbiddenWords.push('while', 'for', 'break', 'continue', 'let')
       }
@@ -131,7 +137,7 @@ export function HighlightRulesSelector(
           'variable.language':
             'this|arguments|' + // Pseudo
             'var|yield|async|await|with|switch|throw|try|eval|' + // forbidden words
-            'class|enum|extends|super|export|implements|private|public|' +
+            'class|enum|extends|super|implements|private|public|' +
             'interface|package|protected|static|in|of|instanceof|new|' +
             'case|catch|default|delete|do|finally|' +
             ChapterAndVariantForbiddenWordSelector()

--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -85,7 +85,7 @@ export function HighlightRulesSelector(
     const ChapterKeywordSelector = () => {
       const output = []
       if (id >= 1) {
-        output.push('import', 'const', 'else', 'if', 'return', 'function', 'debugger')
+        output.push('import', 'as', 'const', 'else', 'if', 'return', 'function', 'debugger')
       }
       if (id >= 2) {
         output.push('export')


### PR DESCRIPTION
`export` is marked as a valid keyword for Source 2+ onwards while `as` is always valid. The latter is available in Source 1 because renaming Source module imports is allowed.

Related to https://github.com/source-academy/frontend/pull/2389. Part of https://github.com/source-academy/frontend/issues/2176.