### PR TITLE
Remove syntax highlighting for 'as'

### DIFF
--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -85,7 +85,7 @@ export function HighlightRulesSelector(
     const ChapterKeywordSelector = () => {
       const output = []
       if (id >= 1) {
-        output.push('import', 'as', 'const', 'else', 'if', 'return', 'function', 'debugger')
+        output.push('import', 'const', 'else', 'if', 'return', 'function', 'debugger')
       }
       if (id >= 2) {
         output.push('export')

--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -578,10 +578,6 @@ export function HighlightRulesSelector(
               regex: '(function)(\\s+)([a-zA-Z0-9$_\u00a1-\uffff][a-zA-Z0-9d$_\u00a1-\uffff]*)'
             },
             {
-              token: 'keyword',
-              regex: '(?:\\b(as|AS)\\b)'
-            },
-            {
               token: ['keyword', 'storage.type.variable.ts'],
               regex: '(type)(\\s+[a-zA-Z0-9_?.$][\\w?.$]*)'
             },


### PR DESCRIPTION
It turns out that `as` is not a keyword in JavaScript. The following is a valid program:
```js
const as = 5;
```

Related to #1381. Part of https://github.com/source-academy/frontend/issues/2176.