### PR TITLE
Use 'ubuntu-latest' environment for CI when deploying documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Use Node.js


### PR DESCRIPTION
Aligns the environment of the CI job that deploys documentation with the one that runs tests to `ubuntu-latest`. This is because `ubuntu-18.04` is reaching end of life on 1st April 2023.

Fixes #1385.