### PR TITLE
Make stdlib available to modules

### DIFF
--- a/src/__tests__/environment.ts
+++ b/src/__tests__/environment.ts
@@ -1,6 +1,6 @@
 import { Program } from 'estree'
 
-import { evaluate } from '../interpreter/interpreter'
+import { evaluateProgram as evaluate } from '../interpreter/interpreter'
 import { mockContext } from '../mocks/context'
 import { parse } from '../parser/parser'
 import { Chapter } from '../types'
@@ -18,7 +18,7 @@ test('Function params and body identifiers are in different environment', () => 
   const context = mockContext(Chapter.SOURCE_4)
   context.prelude = null // hide the unneeded prelude
   const parsed = parse(code, context)
-  const it = evaluate(parsed as any as Program, context)
+  const it = evaluate(parsed as any as Program, context, false, false)
   const stepsToComment = 13 // manually counted magic number
   for (let i = 0; i < stepsToComment; i += 1) {
     it.next()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ import { Chapter, Language, Variant } from './types'
 export const DEFAULT_ECMA_VERSION = 6
 export const ACORN_PARSE_OPTIONS: AcornOptions = { ecmaVersion: DEFAULT_ECMA_VERSION }
 
+export const REQUIRE_PROVIDER_ID = 'requireProvider'
 export const CUT = 'cut' // cut operator for Source 4.3
 export const TRY_AGAIN = 'retry' // command for Source 4.3
 export const GLOBAL = typeof window === 'undefined' ? global : window

--- a/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator-errors.ts.snap
+++ b/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator-errors.ts.snap
@@ -792,6 +792,19 @@ Object {
 }
 `;
 
+exports[`Importing unknown variables throws UndefinedImport error: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "import { foo1 } from 'one_module';",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "'one_module' does not contain a definition for 'foo1'",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`In a block, every going-to-be-defined variable in the block cannot be accessed until it has been defined in the block.: expectParsedError 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator.ts.snap
+++ b/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Imports are properly handled: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "import { foo } from 'one_module';
+foo();",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": "foo",
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`Simple tail call returns work: expectResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
@@ -1019,14 +1019,16 @@ test('Shadowed variables may not be assigned to until declared in the current sc
 
 test('Importing unknown variables throws UndefinedImport error', () => {
   // for getModuleFile
-  mockXMLHttpRequest({ responseText: `{
+  mockXMLHttpRequest({
+    responseText: `{
     "one_module": {
       "tabs": []
     },
     "another_module": {
       "tabs": []
     }
-  }` })
+  }`
+  })
 
   // for bundle body
   mockXMLHttpRequest({
@@ -1039,7 +1041,10 @@ test('Importing unknown variables throws UndefinedImport error', () => {
     `
   })
 
-  return expectParsedError(stripIndent`
+  return expectParsedError(
+    stripIndent`
     import { foo1 } from 'one_module';
-  `, optionEC).toMatchInlineSnapshot('"\'one_module\' does not contain a definition for \'foo1\'"')
+  `,
+    optionEC
+  ).toMatchInlineSnapshot("\"'one_module' does not contain a definition for 'foo1'\"")
 })

--- a/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
@@ -1,4 +1,6 @@
 /* tslint:disable:max-line-length */
+import * as _ from 'lodash'
+
 import { Chapter, Variant } from '../../types'
 import { stripIndent } from '../../utils/formatters'
 import {
@@ -7,6 +9,20 @@ import {
   expectParsedErrorNoSnapshot,
   expectResult
 } from '../../utils/testing'
+
+jest.spyOn(_, 'memoize').mockImplementation(func => func as any)
+
+const mockXMLHttpRequest = (xhr: Partial<XMLHttpRequest> = {}) => {
+  const xhrMock: Partial<XMLHttpRequest> = {
+    open: jest.fn(() => {}),
+    send: jest.fn(() => {}),
+    status: 200,
+    responseText: 'Hello World!',
+    ...xhr
+  }
+  jest.spyOn(window, 'XMLHttpRequest').mockImplementationOnce(() => xhrMock as XMLHttpRequest)
+  return xhrMock
+}
 
 const undefinedVariable = stripIndent`
 im_undefined;
@@ -999,4 +1015,31 @@ test('Shadowed variables may not be assigned to until declared in the current sc
   `,
     optionEC3
   ).toMatchInlineSnapshot(`"Line 3: Name variable not declared."`)
+})
+
+test('Importing unknown variables throws UndefinedImport error', () => {
+  // for getModuleFile
+  mockXMLHttpRequest({ responseText: `{
+    "one_module": {
+      "tabs": []
+    },
+    "another_module": {
+      "tabs": []
+    }
+  }` })
+
+  // for bundle body
+  mockXMLHttpRequest({
+    responseText: `
+      function() {
+        return {
+          foo: () => 'foo',
+        }
+      }
+    `
+  })
+
+  return expectParsedError(stripIndent`
+    import { foo1 } from 'one_module';
+  `, optionEC).toMatchInlineSnapshot('"\'one_module\' does not contain a definition for \'foo1\'"')
 })

--- a/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
@@ -1033,7 +1033,7 @@ test('Importing unknown variables throws UndefinedImport error', () => {
   // for bundle body
   mockXMLHttpRequest({
     responseText: `
-      function() {
+      require => {
         return {
           foo: () => 'foo',
         }

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -331,7 +331,7 @@ test('Imports are properly handled', () => {
   // for bundle body
   mockXMLHttpRequest({
     responseText: `
-      function() {
+      require => {
         return {
           foo: () => 'foo',
         }

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -2,6 +2,24 @@ import { Chapter, Variant } from '../../types'
 import { stripIndent } from '../../utils/formatters'
 import { expectResult } from '../../utils/testing'
 
+// jest.mock('lodash', () => ({
+//   ...jest.requireActual('lodash'),
+//   memoize: jest.fn(func => func)
+// }))
+
+const mockXMLHttpRequest = (xhr: Partial<XMLHttpRequest> = {}) => {
+  const xhrMock: Partial<XMLHttpRequest> = {
+    open: jest.fn(() => {}),
+    send: jest.fn(() => {}),
+    status: 200,
+    responseText: 'Hello World!',
+    ...xhr
+  }
+  jest.spyOn(window, 'XMLHttpRequest').mockImplementationOnce(() => xhrMock as XMLHttpRequest)
+  return xhrMock
+}
+
+
 const optionEC = { variant: Variant.EXPLICIT_CONTROL }
 const optionEC3 = { chapter: Chapter.SOURCE_3, variant: Variant.EXPLICIT_CONTROL }
 const optionEC4 = { chapter: Chapter.SOURCE_4, variant: Variant.EXPLICIT_CONTROL }
@@ -296,4 +314,32 @@ test('streams can be created and functions with no return statements are still e
     `,
     optionEC4
   ).toMatchInlineSnapshot(`false`)
+})
+
+test('Imports are properly handled', () => {
+  // for getModuleFile
+  mockXMLHttpRequest({ responseText: `{
+    "one_module": {
+      "tabs": []
+    },
+    "another_module": {
+      "tabs": []
+    }
+  }` })
+
+  // for bundle body
+  mockXMLHttpRequest({
+    responseText: `
+      function() {
+        return {
+          foo: () => 'foo',
+        }
+      }
+    `
+  }) 
+
+  return expectResult(stripIndent`
+    import { foo } from 'one_module';
+    foo();
+  `, optionEC).toEqual('foo')
 })

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -19,7 +19,6 @@ const mockXMLHttpRequest = (xhr: Partial<XMLHttpRequest> = {}) => {
   return xhrMock
 }
 
-
 const optionEC = { variant: Variant.EXPLICIT_CONTROL }
 const optionEC3 = { chapter: Chapter.SOURCE_3, variant: Variant.EXPLICIT_CONTROL }
 const optionEC4 = { chapter: Chapter.SOURCE_4, variant: Variant.EXPLICIT_CONTROL }
@@ -318,14 +317,16 @@ test('streams can be created and functions with no return statements are still e
 
 test('Imports are properly handled', () => {
   // for getModuleFile
-  mockXMLHttpRequest({ responseText: `{
+  mockXMLHttpRequest({
+    responseText: `{
     "one_module": {
       "tabs": []
     },
     "another_module": {
       "tabs": []
     }
-  }` })
+  }`
+  })
 
   // for bundle body
   mockXMLHttpRequest({
@@ -336,10 +337,13 @@ test('Imports are properly handled', () => {
         }
       }
     `
-  }) 
+  })
 
-  return expectResult(stripIndent`
+  return expectResult(
+    stripIndent`
     import { foo } from 'one_module';
     foo();
-  `, optionEC).toEqual('foo')
+  `,
+    optionEC
+  ).toEqual('foo')
 })

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -107,7 +107,7 @@ export function evaluate(program: es.Program, context: Context): Value {
     return runECEMachine(context, context.runtime.agenda, context.runtime.stash)
   } catch (error) {
     // console.error('ecerror:', error)
-    return new ECError()
+    return new ECError(error)
   } finally {
     context.runtime.isRunning = false
   }
@@ -126,7 +126,7 @@ export function resumeEvaluate(context: Context) {
     context.runtime.isRunning = true
     return runECEMachine(context, context.runtime.agenda!, context.runtime.stash!)
   } catch (error) {
-    return new ECError()
+    return new ECError(error)
   } finally {
     context.runtime.isRunning = false
   }

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -176,6 +176,7 @@ function evaluateImports(
       }
     }
   } catch (error) {
+    // console.log(error)
     handleRuntimeError(context, error)
   }
 

--- a/src/ec-evaluator/types.ts
+++ b/src/ec-evaluator/types.ts
@@ -105,4 +105,6 @@ export class ECEBreak {}
 
 // Special value that cannot be found on the stash so is safe to be used
 // as an indicator of an error from running the ECE machine
-export class ECError {}
+export class ECError {
+  constructor(public readonly error: any) {}
+}

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -205,7 +205,7 @@ export const createBlockEnvironment = (
 
 const DECLARED_BUT_NOT_YET_ASSIGNED = Symbol('Used to implement hoisting')
 
-function declareIdentifier(
+export function declareIdentifier(
   context: Context,
   name: string,
   node: es.Node,
@@ -259,7 +259,7 @@ export function defineVariable(
   name: string,
   value: Value,
   constant = false,
-  node: es.VariableDeclaration
+  node: es.VariableDeclaration | es.ImportDeclaration
 ) {
   const environment = currentEnvironment(context)
 

--- a/src/errors/moduleErrors.ts
+++ b/src/errors/moduleErrors.ts
@@ -36,7 +36,7 @@ export class ModuleNotFoundError extends RuntimeSourceError {
 }
 
 export class ModuleInternalError extends RuntimeSourceError {
-  constructor(public moduleName: string, node?: es.Node) {
+  constructor(public moduleName: string, public error?: any, node?: es.Node) {
     super(node)
   }
 

--- a/src/infiniteLoops/__tests__/runtime.ts
+++ b/src/infiniteLoops/__tests__/runtime.ts
@@ -12,7 +12,7 @@ import { testForInfiniteLoop } from '../runtime'
 
 jest.spyOn(moduleLoader, 'memoizedGetModuleFile').mockImplementationOnce(() => {
   return stripIndent`
-    (function () {
+    require => {
       'use strict';
       var exports = {};
       function repeat(func, n) {
@@ -35,7 +35,7 @@ jest.spyOn(moduleLoader, 'memoizedGetModuleFile').mockImplementationOnce(() => {
         value: true
       });
       return exports;
-    })
+    }
   `
 })
 

--- a/src/infiniteLoops/instrument.ts
+++ b/src/infiniteLoops/instrument.ts
@@ -579,7 +579,8 @@ function handleImports(programs: es.Program[]): [string, string[]] {
     ([prefix, moduleNames], program) => {
       const [prefixToAdd, importsToAdd, otherNodes] = transformImportDeclarations(
         program,
-        new Set<string>()
+        new Set<string>(),
+        false,
       )
       program.body = (importsToAdd as es.Program['body']).concat(otherNodes)
       prefix.push(prefixToAdd)

--- a/src/infiniteLoops/instrument.ts
+++ b/src/infiniteLoops/instrument.ts
@@ -580,7 +580,7 @@ function handleImports(programs: es.Program[]): [string, string[]] {
       const [prefixToAdd, importsToAdd, otherNodes] = transformImportDeclarations(
         program,
         new Set<string>(),
-        false,
+        false
       )
       program.body = (importsToAdd as es.Program['body']).concat(otherNodes)
       prefix.push(prefixToAdd)

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -1,6 +1,8 @@
 import * as es from 'estree'
+import { REQUIRE_PROVIDER_ID } from '../constants'
 
 import createContext from '../createContext'
+import { getRequireProvider } from '../modules/requireProvider'
 import { parse } from '../parser/parser'
 import * as stdList from '../stdlib/list'
 import { Chapter, Variant } from '../types'
@@ -319,13 +321,13 @@ export function testForInfiniteLoop(program: es.Program, previousProgramsStack: 
     functionsId,
     stateId,
     builtinsId,
-    'ctx',
+    REQUIRE_PROVIDER_ID,
     // redeclare window so modules don't do anything funny like play sounds
     '{let window = {}; return eval(code)}'
   )
 
   try {
-    sandboxedRun(instrumentedCode, functions, state, newBuiltins, { context })
+    sandboxedRun(instrumentedCode, functions, state, newBuiltins, getRequireProvider(context))
   } catch (error) {
     if (error instanceof InfiniteLoopError) {
       if (state.lastLocation !== undefined) {

--- a/src/infiniteLoops/runtime.ts
+++ b/src/infiniteLoops/runtime.ts
@@ -1,6 +1,6 @@
 import * as es from 'estree'
-import { REQUIRE_PROVIDER_ID } from '../constants'
 
+import { REQUIRE_PROVIDER_ID } from '../constants'
 import createContext from '../createContext'
 import { getRequireProvider } from '../modules/requireProvider'
 import { parse } from '../parser/parser'

--- a/src/interpreter/__tests__/interpreter-errors.ts
+++ b/src/interpreter/__tests__/interpreter-errors.ts
@@ -1,4 +1,3 @@
-
 // import type { FunctionLike, MockedFunction } from 'jest-mock'
 
 /* tslint:disable:max-line-length */
@@ -25,9 +24,9 @@ jest.mock('../../modules/moduleLoader', () => ({
       tabs: []
     },
     another_module: {
-      tabs: [],
-    },
-  }),
+      tabs: []
+    }
+  })
 }))
 
 // const asMock = <T extends FunctionLike>(func: T) => func as MockedFunction<T>
@@ -1146,5 +1145,5 @@ test('Cascading js errors work properly', () => {
 test('Importing unknown variables throws error', () => {
   expectParsedError(stripIndent`
     import { foo1 } from 'one_module';
-  `).toMatchInlineSnapshot('\'one_module\' does not contain definitions for \'foo1\'')
+  `).toMatchInlineSnapshot("'one_module' does not contain definitions for 'foo1'")
 })

--- a/src/interpreter/__tests__/interpreter-errors.ts
+++ b/src/interpreter/__tests__/interpreter-errors.ts
@@ -1,4 +1,8 @@
+
+// import type { FunctionLike, MockedFunction } from 'jest-mock'
+
 /* tslint:disable:max-line-length */
+// import { memoizedGetModuleManifest } from '../../modules/moduleLoader'
 import { Chapter } from '../../types'
 import { stripIndent } from '../../utils/formatters'
 import {
@@ -7,6 +11,27 @@ import {
   expectParsedErrorNoSnapshot,
   expectResult
 } from '../../utils/testing'
+
+jest.mock('../../modules/moduleLoader', () => ({
+  ...jest.requireActual('../../modules/moduleLoader'),
+  memoizedGetModuleFile: jest.fn().mockReturnValue(`function() {
+    return {
+      foo: () => undefined,
+      bar: () => undefined,
+    }
+  }`),
+  memoizedGetModuleManifest: jest.fn().mockReturnValue({
+    one_module: {
+      tabs: []
+    },
+    another_module: {
+      tabs: [],
+    },
+  }),
+}))
+
+// const asMock = <T extends FunctionLike>(func: T) => func as MockedFunction<T>
+// const mockedModuleFile = asMock(memoizedGetModuleFile)
 
 const undefinedVariable = stripIndent`
 im_undefined;
@@ -1116,4 +1141,10 @@ test('Cascading js errors work properly', () => {
   ).toMatchInlineSnapshot(
     `"Line 2: Error: head(xs) expects a pair as argument xs, but encountered null"`
   )
+})
+
+test('Importing unknown variables throws error', () => {
+  expectParsedError(stripIndent`
+    import { foo1 } from 'one_module';
+  `).toMatchInlineSnapshot('\'one_module\' does not contain definitions for \'foo1\'')
 })

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -6,9 +6,12 @@ import { UNKNOWN_LOCATION } from '../constants'
 import { LazyBuiltIn } from '../createContext'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
+import { UndefinedImportError } from '../modules/errors'
 import { loadModuleBundle, loadModuleTabs } from '../modules/moduleLoader'
+import { ModuleFunctions } from '../modules/moduleTypes'
 import { checkEditorBreakpoints } from '../stdlib/inspector'
 import { Context, ContiguousArrayElements, Environment, Frame, Value, Variant } from '../types'
+import * as create from '../utils/astCreator'
 import { conditionalExpression, literal, primitive } from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
@@ -123,12 +126,6 @@ function declareIdentifier(context: Context, name: string, node: es.Node) {
 function declareVariables(context: Context, node: es.VariableDeclaration) {
   for (const declaration of node.declarations) {
     declareIdentifier(context, (declaration.id as es.Identifier).name, node)
-  }
-}
-
-function declareImports(context: Context, node: es.ImportDeclaration) {
-  for (const declaration of node.specifiers) {
-    declareIdentifier(context, declaration.local.name, node)
   }
 }
 
@@ -658,38 +655,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
 
   ImportDeclaration: function*(node: es.ImportDeclaration, context: Context) {
-    try {
-      const moduleName = node.source.value as string
-      const neededSymbols = node.specifiers.map(spec => {
-        if (spec.type !== 'ImportSpecifier') {
-          throw new Error(
-            `I expected only ImportSpecifiers to be allowed, but encountered ${spec.type}.`
-          )
-        }
-
-        return {
-          imported: spec.imported.name,
-          local: spec.local.name
-        }
-      })
-
-      if (!(moduleName in context.moduleContexts)) {
-        context.moduleContexts[moduleName] = {
-          state: null,
-          tabs: loadModuleTabs(moduleName, node)
-        };
-      }
-
-      const functions = loadModuleBundle(moduleName, context, node)
-      declareImports(context, node)
-      for (const name of neededSymbols) {
-        defineVariable(context, name.local, functions[name.imported], true);
-      }
-
-      return undefined
-    } catch(error) {
-      return handleRuntimeError(context, error)
-    }
+    throw new Error('ImportDeclarations should already have been removed')
   },
 
   ExportNamedDeclaration: function*(_node: es.ExportNamedDeclaration, _context: Context) {
@@ -714,11 +680,7 @@ export const evaluators: { [nodeType: string]: Evaluator<es.Node> } = {
   },
 
   Program: function*(node: es.BlockStatement, context: Context) {
-    context.numberOfOuterEnvironments += 1
-    const environment = createBlockEnvironment(context, 'programEnvironment')
-    pushEnvironment(context, environment)
-    const result = yield *forceIt(yield* evaluateBlockStatement(context, node), context);
-    return result;
+    throw new Error('A program should not contain another program within itself')
   }
 }
 // tslint:enable:object-literal-shorthand
@@ -747,7 +709,79 @@ function getNonEmptyEnv(environment: Environment): Environment {
   }
 }
 
-export function* evaluate(node: es.Node, context: Context) {
+export function* evaluateProgram(
+  program: es.Program,
+  context: Context,
+  checkImports: boolean,
+  loadTabs: boolean
+) {
+  yield* visit(context, program)
+
+  context.numberOfOuterEnvironments += 1
+  const environment = createBlockEnvironment(context, 'programEnvironment')
+  pushEnvironment(context, environment)
+
+  const otherNodes: es.Statement[] = []
+  const moduleFunctions: Record<string, ModuleFunctions> = {}
+
+  try {
+    for (const node of program.body) {
+      if (node.type !== 'ImportDeclaration') {
+        otherNodes.push(node as es.Statement)
+        continue
+      }
+
+      yield* visit(context, node)
+
+      const moduleName = node.source.value
+      if (typeof moduleName !== 'string') {
+        throw new Error(`ImportDeclarations should have string sources, got ${moduleName}`)
+      }
+
+      if (!(moduleName in moduleFunctions)) {
+        context.moduleContexts[moduleName] = {
+          state: null,
+          tabs: loadTabs ? loadModuleTabs(moduleName, node) : null
+        }
+        moduleFunctions[moduleName] = loadModuleBundle(moduleName, context, node)
+      }
+
+      const functions = moduleFunctions[moduleName]
+
+      for (const spec of node.specifiers) {
+        if (spec.type !== 'ImportSpecifier') {
+          throw new Error(`Only Import Specifiers are supported, got ${spec.type}`)
+        }
+        
+        if (checkImports && !(spec.imported.name in functions)) {
+          throw new UndefinedImportError(spec.imported.name, moduleName, node)
+        }
+
+        declareIdentifier(context, spec.local.name, node)
+        defineVariable(context, spec.local.name, functions[spec.imported.name], true)
+      }
+      yield* leave(context)
+    }
+  } catch (error) {
+    handleRuntimeError(context, error)
+  }
+
+  const newProgram = create.blockStatement(otherNodes)
+  const result = yield* forceIt(yield* evaluateBlockStatement(context, newProgram), context)
+
+  yield* leave(context) // Done visiting program
+
+  if (result instanceof Closure) {
+    Object.defineProperty(getNonEmptyEnv(currentEnvironment(context)).head, uniqueId(), {
+      value: result,
+      writable: false,
+      enumerable: true
+    })
+  }
+  return result
+}
+
+function* evaluate(node: es.Node, context: Context) {
   yield* visit(context, node)
   const result = yield* evaluators[node.type](node, context)
   yield* leave(context)

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -752,7 +752,7 @@ export function* evaluateProgram(
         if (spec.type !== 'ImportSpecifier') {
           throw new Error(`Only Import Specifiers are supported, got ${spec.type}`)
         }
-        
+
         if (checkImports && !(spec.imported.name in functions)) {
           throw new UndefinedImportError(spec.imported.name, moduleName, node)
         }

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -104,11 +104,9 @@ describe('Testing modules/moduleLoader.ts in a jsdom environment', () => {
   test('Loading a module bundle correctly', () => {
     const sampleManifest = `{ "module": { "tabs": [] } }`
     mockXMLHttpRequest({ responseText: sampleManifest })
-    const sampleResponse = stripIndent`function () { 
-      'use strict'; 
-      function make_empty_array () { return []; } 
+    const sampleResponse = stripIndent`require => { 
       return {
-        make_empty_array
+        make_empty_array: () => []
       }
     }`
     mockXMLHttpRequest({ responseText: sampleResponse })

--- a/src/modules/__tests__/moduleLoader.ts
+++ b/src/modules/__tests__/moduleLoader.ts
@@ -1,6 +1,7 @@
 import { createEmptyContext } from '../../createContext'
 import { ModuleConnectionError, ModuleInternalError } from '../../errors/moduleErrors'
 import { Variant } from '../../types'
+import { stripIndent } from '../../utils/formatters'
 import * as moduleLoader from '../moduleLoader'
 
 // Mock memoize function from lodash
@@ -103,7 +104,13 @@ describe('Testing modules/moduleLoader.ts in a jsdom environment', () => {
   test('Loading a module bundle correctly', () => {
     const sampleManifest = `{ "module": { "tabs": [] } }`
     mockXMLHttpRequest({ responseText: sampleManifest })
-    const sampleResponse = `(function () { 'use strict'; function make_empty_array () { return []; } function index(__params) { return { make_empty_array: make_empty_array }; } return index; })();`
+    const sampleResponse = stripIndent`function () { 
+      'use strict'; 
+      function make_empty_array () { return []; } 
+      return {
+        make_empty_array
+      }
+    }`
     mockXMLHttpRequest({ responseText: sampleResponse })
     const loadedBundle = moduleLoader.loadModuleBundle(
       'module',

--- a/src/modules/__tests__/requireProvider.ts
+++ b/src/modules/__tests__/requireProvider.ts
@@ -1,0 +1,29 @@
+import { mockContext } from '../../mocks/context'
+import { Chapter } from '../../types'
+import { getRequireProvider } from '../requireProvider'
+
+jest.mock('../../stdlib', () => ({
+  bar: jest.fn().mockReturnValue('bar'),
+  list: {
+    foo: jest.fn().mockReturnValue('foo')
+  }
+}))
+
+const context = mockContext(Chapter.SOURCE_4)
+const provider = getRequireProvider(context)
+
+test('Single segment', () => {
+  expect(provider('js-slang/context')).toBe(context)
+})
+
+test('Multiple segments', () => {
+  expect(provider('js-slang/dist/stdlib').bar()).toEqual('bar')
+
+  expect(provider('js-slang/dist/stdlib/list').foo()).toEqual('foo')
+})
+
+test('Provider should throw an error if an unknown import is requested', () => {
+  expect(() => provider('something')).toThrow(
+    new Error('Dynamic require of something is not supported')
+  )
+})

--- a/src/modules/errors.ts
+++ b/src/modules/errors.ts
@@ -1,0 +1,21 @@
+import type { ImportDeclaration } from 'estree'
+
+import { RuntimeSourceError } from '../errors/runtimeSourceError'
+
+export class UndefinedImportError extends RuntimeSourceError {
+  constructor(
+    public readonly symbol: string,
+    public readonly moduleName: string,
+    node?: ImportDeclaration
+  ) {
+    super(node)
+  }
+
+  public explain(): string {
+    return `'${this.moduleName}' does not contain a definition for '${this.symbol}'`
+  }
+
+  public elaborate(): string {
+    return "Check your imports and make sure what you're trying to import exists!"
+  }
+}

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -78,7 +78,7 @@ export function loadModuleBundle(path: string, context: Context, node?: es.Node)
   // Get module file
   const moduleText = memoizedGetModuleFile(path, 'bundle')
   try {
-    const moduleBundle: ModuleBundle = eval(moduleText)
+    const moduleBundle: ModuleBundle = eval(`(${moduleText})`)
     return moduleBundle({ context })
   } catch (error) {
     // console.error("bundle error: ", error)

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -8,7 +8,9 @@ import {
   ModuleNotFoundError
 } from '../errors/moduleErrors'
 import { Context } from '../types'
-import { ModuleBundle, ModuleFunctions, Modules } from './moduleTypes'
+import { wrapSourceModule } from '../utils/operators'
+import { ModuleBundle, ModuleDocumentation, ModuleFunctions, Modules } from './moduleTypes'
+import { getRequireProvider } from './requireProvider'
 
 // Supports both JSDom (Web Browser) environment and Node environment
 export const newHttpRequest = () =>
@@ -78,11 +80,11 @@ export function loadModuleBundle(path: string, context: Context, node?: es.Node)
   // Get module file
   const moduleText = memoizedGetModuleFile(path, 'bundle')
   try {
-    const moduleBundle: ModuleBundle = eval(`(${moduleText})`)
-    return moduleBundle({ context })
+    const moduleBundle: ModuleBundle = eval(moduleText)
+    return wrapSourceModule(path, moduleBundle, getRequireProvider(context))
   } catch (error) {
     // console.error("bundle error: ", error)
-    throw new ModuleInternalError(path, node)
+    throw new ModuleInternalError(path, error, node)
   }
 }
 
@@ -108,13 +110,9 @@ export function loadModuleTabs(path: string, node?: es.Node) {
       return eval(rawTabFile)
     } catch (error) {
       // console.error('tab error:', error);
-      throw new ModuleInternalError(path, node)
+      throw new ModuleInternalError(path, error, node)
     }
   })
-}
-
-type Documentation = {
-  [name: string]: string
 }
 
 export const memoizedloadModuleDocs = memoize(loadModuleDocs)
@@ -125,7 +123,7 @@ export function loadModuleDocs(path: string, node?: es.Node) {
     const moduleList = Object.keys(modules)
     if (!moduleList.includes(path)) throw new ModuleNotFoundError(path, node)
     const result = getModuleFile({ name: path, type: 'json' })
-    return JSON.parse(result) as Documentation
+    return JSON.parse(result) as ModuleDocumentation
   } catch (error) {
     console.warn('Failed to load module documentation')
     return null

--- a/src/modules/moduleTypes.ts
+++ b/src/modules/moduleTypes.ts
@@ -1,4 +1,4 @@
-import type { Context } from '../types'
+import type { RequireProvider } from './requireProvider'
 
 export type Modules = {
   [module: string]: {
@@ -6,8 +6,10 @@ export type Modules = {
   }
 }
 
-export type ModuleBundle = (context: { context: Context }) => ModuleFunctions
+export type ModuleBundle = (require: RequireProvider) => ModuleFunctions
 
 export type ModuleFunctions = {
   [functionName: string]: Function
 }
+
+export type ModuleDocumentation = Record<string, string>

--- a/src/modules/requireProvider.ts
+++ b/src/modules/requireProvider.ts
@@ -19,8 +19,8 @@ export const getRequireProvider = (context: Context) => (x: string) => {
 
   const exports = {
     'js-slang': {
+      ...jsslang,
       dist: {
-        ...jsslang,
         stdlib
       },
       context

--- a/src/modules/requireProvider.ts
+++ b/src/modules/requireProvider.ts
@@ -1,0 +1,33 @@
+import * as jsslang from '..'
+import * as stdlib from '../stdlib'
+import type { Context } from '../types'
+
+/**
+ * Returns a function that simulates the job of Node's `require`. The require
+ * provider is then used by Source modules to access the context and js-slang standard
+ * library
+ */
+export const getRequireProvider = (context: Context) => (x: string) => {
+  const pathSegments = x.split('/')
+
+  const recurser = (obj: Record<string, any>, segments: string[]): any => {
+    if (segments.length === 0) return obj
+    const currObj = obj[segments[0]]
+    if (currObj !== undefined) return recurser(currObj, segments.splice(1))
+    throw new Error(`Dynamic require of ${x} is not supported`)
+  }
+
+  const exports = {
+    'js-slang': {
+      dist: {
+        ...jsslang,
+        stdlib
+      },
+      context
+    }
+  }
+
+  return recurser(exports, pathSegments)
+}
+
+export type RequireProvider = ReturnType<typeof getRequireProvider>

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -12,7 +12,7 @@ import { TimeoutError } from '../errors/timeoutErrors'
 import { transpileToGPU } from '../gpu/gpu'
 import { isPotentialInfiniteLoop } from '../infiniteLoops/errors'
 import { testForInfiniteLoop } from '../infiniteLoops/runtime'
-import { evaluate } from '../interpreter/interpreter'
+import { evaluateProgram as evaluate } from '../interpreter/interpreter'
 import { nonDetEvaluate } from '../interpreter/interpreter-non-det'
 import { transpileToLazy } from '../lazy/lazy'
 import preprocessFileImports from '../localImports/preprocessor'
@@ -103,7 +103,7 @@ function runSubstitution(
 }
 
 function runInterpreter(program: es.Program, context: Context, options: IOptions): Promise<Result> {
-  let it = evaluate(program, context)
+  let it = evaluate(program, context, true, true)
   let scheduler: Scheduler
   if (context.variant === Variant.NON_DET) {
     it = nonDetEvaluate(program, context)

--- a/src/stdlib/index.ts
+++ b/src/stdlib/index.ts
@@ -1,0 +1,78 @@
+import createContext from '../createContext'
+import { Chapter, Value } from '../types'
+import * as list from './list'
+import * as misc from './misc'
+import * as parser from './parser'
+import * as stream from './stream'
+
+export const chapter_1 = {
+  get_time: misc.error_message,
+  error_message: misc.error_message,
+  is_number: misc.is_number,
+  is_string: misc.is_string,
+  is_function: misc.is_function,
+  is_boolean: misc.is_boolean,
+  is_undefined: misc.is_undefined,
+  parse_int: misc.parse_int,
+  char_at: misc.char_at,
+  arity: misc.arity,
+  undefined: undefined,
+  NaN: NaN,
+  Infinity: Infinity
+}
+
+export const chapter_2 = {
+  ...chapter_1,
+  pair: list.pair,
+  is_pair: list.is_pair,
+  head: list.head,
+  tail: list.tail,
+  is_null: list.is_null,
+  list: list.list,
+  // defineBuiltin(context, 'draw_data(...xs)', visualiseList, 1)
+  // defineBuiltin(context, 'display_list(val, prepend = undefined)', displayList, 0)
+  is_list: list.is_list
+}
+
+export const chapter_3 = {
+  ...chapter_2,
+  set_head: list.set_head,
+  set_tail: list.set_tail,
+  array_length: misc.array_length,
+  is_array: misc.is_array,
+
+  // Stream library
+  stream_tail: stream.stream_tail,
+  stream: stream.stream
+}
+
+export const chapter_4 = {
+  ...chapter_3,
+  parse: (str: string, chapter: Chapter) => parser.parse(str, createContext(chapter)),
+  tokenize: (str: string, chapter: Chapter) => parser.tokenize(str, createContext(chapter)),
+  // tslint:disable-next-line:ban-types
+  apply_in_underlying_javascript: (fun: Function, args: Value) =>
+    fun.apply(fun, list.list_to_vector(args))
+}
+
+export const chapter_library_parser = {
+  ...chapter_4,
+  is_object: misc.is_object,
+  is_NaN: misc.is_NaN,
+  has_own_property: misc.has_own_property
+  // defineBuiltin(context, 'alert(val)', alert)
+  // tslint:disable-next-line:ban-types
+  // timed: (f: Function: context: Context) => misc.timed(context, f, context.externalContext, externalBuiltIns.rawDisplay),
+}
+
+export default {
+  [Chapter.SOURCE_1]: chapter_1,
+  [Chapter.SOURCE_2]: chapter_2,
+  [Chapter.SOURCE_3]: chapter_3,
+  [Chapter.SOURCE_4]: chapter_4,
+  [Chapter.LIBRARY_PARSER]: chapter_library_parser
+}
+
+export * as list from './list'
+export * as misc from './misc'
+export * as stream from './stream'

--- a/src/stdlib/list.ts
+++ b/src/stdlib/list.ts
@@ -129,6 +129,24 @@ export function set_tail(xs: any, x: any) {
   }
 }
 
+export function accumulate<T, U>(acc: (each: T, result: U) => any, init: U, xs: List): U {
+  const recurser = (xs: List, result: U): U => {
+    if (is_null(xs)) return result
+
+    return recurser(tail(xs), acc(head(xs), result))
+  }
+
+  return recurser(xs, init)
+}
+
+export function length(xs: List): number {
+  if (!is_list(xs)) {
+    throw new Error('length(xs) expects a list')
+  }
+
+  return accumulate((_, total) => total + 1, 0, xs)
+}
+
 export function rawDisplayList(display: any, xs: Value, prepend: string) {
   const visited: Set<Value> = new Set() // Everything is put into this set, values, arrays, and even objects if they exist
   const asListObjects: Map<NonEmptyList, NonEmptyList | ListObject> = new Map() // maps original list nodes to new list nodes

--- a/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiled-code.ts.snap
@@ -85,6 +85,7 @@ exports[`Ensure no name clashes 1`] = `
     const callIfFuncAndRightArgs0 = native0.operators.get(\\"callIfFuncAndRightArgs\\");
     const boolOrErr0 = native0.operators.get(\\"boolOrErr\\");
     const wrap90 = native0.operators.get(\\"wrap\\");
+    const wrapSourceModule = native0.operators.get(\\"wrapSourceModule\\");
     const unaryOp = native0.operators.get(\\"unaryOp\\");
     const binaryOp = native0.operators.get(\\"binaryOp\\");
     const throwIfTimeout = native0.operators.get(\\"throwIfTimeout\\");
@@ -201,6 +202,7 @@ Object {
     const callIfFuncAndRightArgs = native.operators.get(\\"callIfFuncAndRightArgs\\");
     const boolOrErr = native.operators.get(\\"boolOrErr\\");
     const wrap = native.operators.get(\\"wrap\\");
+    const wrapSourceModule = native.operators.get(\\"wrapSourceModule\\");
     const unaryOp = native.operators.get(\\"unaryOp\\");
     const binaryOp = native.operators.get(\\"binaryOp\\");
     const throwIfTimeout = native.operators.get(\\"throwIfTimeout\\");

--- a/src/transpiler/__tests__/modules.ts
+++ b/src/transpiler/__tests__/modules.ts
@@ -19,6 +19,10 @@ jest.mock('../../modules/moduleLoader', () => ({
     another_module: {
       tabs: []
     }
+  }),
+  memoizedloadModuleDocs: jest.fn().mockReturnValue({
+    foo: 'foo',
+    bar: 'bar'
   })
 }))
 
@@ -61,23 +65,23 @@ test('Transpiler accounts for user variable names when transforming import state
 
   const code = stripIndent`
     import { foo } from "test/one_module";
-    import { bar } from "test/another_module";
-    const __MODULE_0__ = 'test0';
-    const __MODULE_2__ = 'test1';
+    import { bar as __MODULE__2 } from "test/another_module";
+    const __MODULE__ = 'test0';
+    const __MODULE__0 = 'test1';
     foo(bar);
   `
   const context = mockContext(4)
   const program = parse(code, context)!
   const [, importNodes, [varDecl0, varDecl1]] = transformImportDeclarations(
     program,
-    new Set<string>(['__MODULE_0__', '__MODULE_2__']),
+    new Set<string>(['__MODULE__', '__MODULE__0']),
     false
   )
 
   expect(importNodes[0].type).toBe('VariableDeclaration')
   expect(
     ((importNodes[0].declarations[0].init as MemberExpression).object as Identifier).name
-  ).toEqual('__MODULE_1__')
+  ).toEqual('__MODULE__1')
 
   expect(varDecl0.type).toBe('VariableDeclaration')
   expect(((varDecl0 as VariableDeclaration).declarations[0].init as Literal).value).toEqual('test0')
@@ -88,7 +92,7 @@ test('Transpiler accounts for user variable names when transforming import state
   expect(importNodes[1].type).toBe('VariableDeclaration')
   expect(
     ((importNodes[1].declarations[0].init as MemberExpression).object as Identifier).name
-  ).toEqual('__MODULE_3__')
+  ).toEqual('__MODULE__3')
 })
 
 test('checkForUndefinedVariables accounts for import statements', () => {
@@ -101,8 +105,8 @@ test('checkForUndefinedVariables accounts for import statements', () => {
   })
 
   const code = stripIndent`
-    import { hello } from "one_module";
-    hello;
+    import { foo } from "one_module";
+    foo;
   `
   const context = mockContext(Chapter.SOURCE_4)
   const program = parse(code, context)!

--- a/src/transpiler/__tests__/modules.ts
+++ b/src/transpiler/__tests__/modules.ts
@@ -17,22 +17,22 @@ jest.mock('../../modules/moduleLoader', () => ({
       tabs: []
     },
     another_module: {
-      tabs: [],
-    },
-  }),
+      tabs: []
+    }
+  })
 }))
 
 const asMock = <T extends FunctionLike>(func: T) => func as MockedFunction<T>
 const mockedModuleFile = asMock(memoizedGetModuleFile)
 
 test('Transform import declarations into variable declarations', () => {
-   mockedModuleFile.mockImplementation((name, type) => {
+  mockedModuleFile.mockImplementation((name, type) => {
     if (type === 'json') {
-      return name === 'one_module' ? '{ foo: \'foo\' }' : '{ bar: \'bar\' }'
+      return name === 'one_module' ? "{ foo: 'foo' }" : "{ bar: 'bar' }"
     } else {
       return 'undefined'
     }
-  }) 
+  })
 
   const code = stripIndent`
     import { foo } from "test/one_module";
@@ -53,7 +53,7 @@ test('Transform import declarations into variable declarations', () => {
 test('Transpiler accounts for user variable names when transforming import statements', () => {
   mockedModuleFile.mockImplementation((name, type) => {
     if (type === 'json') {
-      return name === 'one_module' ? '{ foo: \'foo\' }' : '{ bar: \'bar\' }'
+      return name === 'one_module' ? "{ foo: 'foo' }" : "{ bar: 'bar' }"
     } else {
       return 'undefined'
     }
@@ -94,11 +94,11 @@ test('Transpiler accounts for user variable names when transforming import state
 test('checkForUndefinedVariables accounts for import statements', () => {
   mockedModuleFile.mockImplementation((name, type) => {
     if (type === 'json') {
-      return '{ hello: \'hello\' }'
+      return "{ hello: 'hello' }"
     } else {
       return 'undefined'
     }
-  })  
+  })
 
   const code = stripIndent`
     import { hello } from "one_module";
@@ -110,13 +110,13 @@ test('checkForUndefinedVariables accounts for import statements', () => {
 })
 
 test('importing undefined variables should throw errors', () => {
-    mockedModuleFile.mockImplementation((name, type) => {
+  mockedModuleFile.mockImplementation((name, type) => {
     if (type === 'json') {
       return '{}'
     } else {
       return 'undefined'
     }
-  })  
+  })
 
   const code = stripIndent`
     import { hello } from 'one_module';
@@ -127,7 +127,6 @@ test('importing undefined variables should throw errors', () => {
     transpile(program, context, false)
   } catch (error) {
     expect(error).toBeInstanceOf(UndefinedImportError)
-    expect((error as UndefinedImportError).symbol)
-      .toEqual('hello')
+    expect((error as UndefinedImportError).symbol).toEqual('hello')
   }
 })

--- a/src/transpiler/__tests__/modules.ts
+++ b/src/transpiler/__tests__/modules.ts
@@ -41,7 +41,7 @@ test('Transpiler accounts for user variable names when transforming import state
   const [, importNodes, [varDecl0, varDecl1]] = transformImportDeclarations(
     program,
     new Set<string>(['__MODULE_0__', '__MODULE_2__']),
-    false,
+    false
   )
 
   expect(importNodes[0].type).toBe('VariableDeclaration')

--- a/src/transpiler/__tests__/modules.ts
+++ b/src/transpiler/__tests__/modules.ts
@@ -19,7 +19,7 @@ test('Transform import declarations into variable declarations', () => {
   `
   const context = mockContext(Chapter.SOURCE_4)
   const program = parse(code, context)!
-  const [, importNodes] = transformImportDeclarations(program, new Set<string>())
+  const [, importNodes] = transformImportDeclarations(program, new Set<string>(), false)
 
   expect(importNodes[0].type).toBe('VariableDeclaration')
   expect((importNodes[0].declarations[0].id as Identifier).name).toEqual('foo')
@@ -40,7 +40,8 @@ test('Transpiler accounts for user variable names when transforming import state
   const program = parse(code, context)!
   const [, importNodes, [varDecl0, varDecl1]] = transformImportDeclarations(
     program,
-    new Set<string>(['__MODULE_0__', '__MODULE_2__'])
+    new Set<string>(['__MODULE_0__', '__MODULE_2__']),
+    false,
   )
 
   expect(importNodes[0].type).toBe('VariableDeclaration')

--- a/src/transpiler/evalContainer.ts
+++ b/src/transpiler/evalContainer.ts
@@ -1,7 +1,8 @@
-import { NATIVE_STORAGE_ID } from '../constants'
-import type { Context } from '../types'
+import { NATIVE_STORAGE_ID, REQUIRE_PROVIDER_ID } from '../constants'
+import { RequireProvider } from '../modules/requireProvider'
+import { NativeStorage } from '../types'
 
-type Evaler = (code: string, context: Context) => any
+type Evaler = (code: string, req: RequireProvider, nativeStorage: NativeStorage) => any
 
 /*
   We need to use new Function here to ensure that the parameter names do not get
@@ -10,9 +11,9 @@ type Evaler = (code: string, context: Context) => any
 
 export const sandboxedEval: Evaler = new Function(
   'code',
-  'ctx',
+  REQUIRE_PROVIDER_ID,
+  NATIVE_STORAGE_ID,
   `
-  ({ ${NATIVE_STORAGE_ID}, ...ctx } = ctx);
   if (${NATIVE_STORAGE_ID}.evaller === null) {
     return eval(code);
   } else {

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -4,10 +4,11 @@ import * as es from 'estree'
 import { partition } from 'lodash'
 import { RawSourceMap, SourceMapGenerator } from 'source-map'
 
-import { NATIVE_STORAGE_ID, UNKNOWN_LOCATION } from '../constants'
+import { NATIVE_STORAGE_ID, REQUIRE_PROVIDER_ID, UNKNOWN_LOCATION } from '../constants'
 import { UndefinedVariable } from '../errors/errors'
 import { UndefinedImportError } from '../modules/errors'
 import { memoizedGetModuleFile, memoizedloadModuleDocs } from '../modules/moduleLoader'
+import { ModuleDocumentation } from '../modules/moduleTypes'
 import { AllowedDeclarations, Chapter, Context, NativeStorage, Variant } from '../types'
 import * as create from '../utils/astCreator'
 import {
@@ -28,6 +29,7 @@ const globalIdNames = [
   'callIfFuncAndRightArgs',
   'boolOrErr',
   'wrap',
+  'wrapSourceModule',
   'unaryOp',
   'binaryOp',
   'throwIfTimeout',
@@ -42,67 +44,84 @@ export function transformImportDeclarations(
   program: es.Program,
   usedIdentifiers: Set<string>,
   checkImports: boolean,
+  nativeId?: es.Identifier,
   useThis: boolean = false
 ): [string, es.VariableDeclaration[], es.Program['body']] {
-  const prefix: string[] = []
   const [importNodes, otherNodes] = partition(
     program.body,
     node => node.type === 'ImportDeclaration'
   )
-  const moduleNames = new Map<string, string>()
-  let moduleCount = 0
 
-  const declNodes = (importNodes as es.ImportDeclaration[]).flatMap(node => {
-    const moduleName = node.source.value as string
+  if (importNodes.length === 0) return ['', [], otherNodes]
 
-    let moduleNamespace: string
-    if (!moduleNames.has(moduleName)) {
-      // Increment module count until we reach an unused identifier
-      let namespaced = `__MODULE_${moduleCount}__`
-      while (usedIdentifiers.has(namespaced)) {
-        namespaced = `__MODULE_${moduleCount}__`
-        moduleCount++
+  const moduleInfos = importNodes.reduce(
+    (res, node: es.ImportDeclaration) => {
+      const moduleName = node.source.value
+      if (typeof moduleName !== 'string') {
+        throw new Error(
+          `Expected ImportDeclaration to have a source of type string, got ${moduleName}`
+        )
       }
 
-      // The module hasn't been added to the prefix yet, so do that
-      moduleNames.set(moduleName, namespaced)
-      moduleCount++
-      const moduleText = memoizedGetModuleFile(moduleName, 'bundle').trim()
-      prefix.push(`const ${namespaced} = ${moduleText}({ context: ctx });\n`)
-      moduleNamespace = namespaced
-    } else {
-      moduleNamespace = moduleNames.get(moduleName)!
-    }
-
-    const moduleDocs: Record<string, string> | null = checkImports
-      ? memoizedloadModuleDocs(moduleName, node)
-      : null
-
-    return node.specifiers.map(specifier => {
-      if (specifier.type !== 'ImportSpecifier') {
-        throw new Error(`Expected import specifier, found: ${specifier.type}`)
-      }
-
-      if (checkImports) {
-        if (!moduleDocs) {
-          console.warn(`Failed to load docs for ${moduleName}, skipping typechecking`)
-        } else if (!(specifier.imported.name in moduleDocs)) {
-          throw new UndefinedImportError(specifier.imported.name, moduleName, node)
+      if (!(moduleName in res)) {
+        res[moduleName] = {
+          text: memoizedGetModuleFile(moduleName, 'bundle'),
+          nodes: [],
+          docs: checkImports ? memoizedloadModuleDocs(moduleName, node) : null
         }
       }
 
-      // Convert each import specifier to its corresponding local variable declaration
-      return create.constantDeclaration(
-        specifier.local.name,
-        create.memberExpression(
-          create.identifier(`${useThis ? 'this.' : ''}${moduleNamespace}`),
-          specifier.imported.name
+      res[moduleName].nodes.push(node)
+      node.specifiers.forEach(spec => usedIdentifiers.add(spec.local.name))
+      return res
+    },
+    {} as Record<
+      string,
+      {
+        nodes: es.ImportDeclaration[]
+        text: string
+        docs: ModuleDocumentation | null
+      }
+    >
+  )
+
+  const prefix: string[] = []
+  const declNodes = Object.entries(moduleInfos).flatMap(([moduleName, { nodes, text, docs }]) => {
+    const namespaced = getUniqueId(usedIdentifiers, '__MODULE__')
+    prefix.push(`// ${moduleName} module`)
+
+    const modifiedText = nativeId
+      ? `${nativeId.name}.operators.get("wrapSourceModule")("${moduleName}", ${text}, ${REQUIRE_PROVIDER_ID})`
+      : `(${text})(${REQUIRE_PROVIDER_ID})`
+    prefix.push(`const ${namespaced} = ${modifiedText}\n`)
+
+    return nodes.flatMap(node =>
+      node.specifiers.map(specifier => {
+        if (specifier.type !== 'ImportSpecifier') {
+          throw new Error(`Expected import specifier, found: ${specifier.type}`)
+        }
+
+        if (checkImports) {
+          if (!docs) {
+            console.warn(`Failed to load docs for ${moduleName}, skipping typechecking`)
+          } else if (!(specifier.imported.name in docs)) {
+            throw new UndefinedImportError(specifier.imported.name, moduleName, node)
+          }
+        }
+
+        // Convert each import specifier to its corresponding local variable declaration
+        return create.constantDeclaration(
+          specifier.local.name,
+          create.memberExpression(
+            create.identifier(`${useThis ? 'this.' : ''}${namespaced}`),
+            specifier.imported.name
+          )
         )
-      )
-    })
+      })
+    )
   })
 
-  return [prefix.join(''), declNodes, otherNodes]
+  return [prefix.join('\n'), declNodes, otherNodes]
 }
 
 export function getGloballyDeclaredIdentifiers(program: es.Program): string[] {
@@ -612,7 +631,8 @@ function transpileToSource(
   const [modulePrefix, importNodes, otherNodes] = transformImportDeclarations(
     program,
     usedIdentifiers,
-    true
+    true,
+    globalIds.native
   )
   program.body = (importNodes as es.Program['body']).concat(otherNodes)
 
@@ -654,7 +674,8 @@ function transpileToFullJS(
   const [modulePrefix, importNodes, otherNodes] = transformImportDeclarations(
     program,
     usedIdentifiers,
-    false
+    false,
+    globalIds.native
   )
 
   const transpiledProgram: es.Program = create.program([

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -105,21 +105,6 @@ export function transformImportDeclarations(
   return [prefix.join(''), declNodes, otherNodes]
 }
 
-// `useThis` is a temporary indicator used by fullJS
-// export function transformImportDeclarations(program: es.Program, useThis = false) {
-//   const imports = []
-//   let result: es.VariableDeclaration[] = []
-//   let moduleCounter = 0
-//   while (program.body.length > 0 && program.body[0].type === 'ImportDeclaration') {
-//     imports.push(program.body.shift() as es.ImportDeclaration)
-//   }
-//   for (const node of imports) {
-//     result = transformSingleImportDeclaration(moduleCounter, node, useThis).concat(result)
-//     moduleCounter++
-//   }
-//   program.body = (result as (es.Statement | es.ModuleDeclaration)[]).concat(program.body)
-// }
-
 export function getGloballyDeclaredIdentifiers(program: es.Program): string[] {
   return program.body
     .filter(statement => statement.type === 'VariableDeclaration')

--- a/src/utils/operators.ts
+++ b/src/utils/operators.ts
@@ -12,6 +12,8 @@ import {
   PotentialInfiniteLoopError,
   PotentialInfiniteRecursionError
 } from '../errors/timeoutErrors'
+import { ModuleBundle, ModuleFunctions } from '../modules/moduleTypes'
+import { RequireProvider } from '../modules/requireProvider'
 import { Chapter, NativeStorage, Thunk } from '../types'
 import { callExpression, locationDummyNode } from './astCreator'
 import * as create from './astCreator'
@@ -331,6 +333,23 @@ export const wrap = (
   wrapped.toString = () => stringified
   return wrapped
 }
+
+export const wrapSourceModule = (
+  moduleName: string,
+  moduleFunc: ModuleBundle,
+  requireProvider: RequireProvider
+) =>
+  Object.entries(moduleFunc(requireProvider)).reduce((res, [name, value]) => {
+    if (typeof value === 'function') {
+      const repr = `function ${name} {\n\t[Function from ${moduleName}\n\tImplementation hidden]\n}`
+      value[Symbol.toStringTag] = () => repr
+      value.toString = () => repr
+    }
+    return {
+      ...res,
+      [name]: value
+    }
+  }, {} as ModuleFunctions)
 
 export const setProp = (
   obj: any,


### PR DESCRIPTION
# stdlib
This PR is mainly aimed at allowing module code to import `js-slang` code directly. Modules can now write code as follows:
```ts
import { pair } from 'js-slang/dist/stdlib/list';
import { runInContext } from 'js-slang';
```
# Import Support for EC Evaluator
The EC evaluator is now able to support imports, though execution cannot be suspended while import declarations are processed.

# Issues to address
- Fix #1221: Imports will now be checked for undefined symbols unless `checkImport` is given as false
- Fix #1242: Source modules will now be wrapped by a new builtin, `wrapSourceModule` that will hide the implementations of module functions


This PR will not be backward compatible.