### PR TITLE
Make types available to modules

### DIFF
--- a/src/modules/requireProvider.ts
+++ b/src/modules/requireProvider.ts
@@ -1,6 +1,7 @@
 import * as jsslang from '..'
 import * as stdlib from '../stdlib'
 import type { Context } from '../types'
+import * as types from '../types'
 
 /**
  * Returns a function that simulates the job of Node's `require`. The require
@@ -21,7 +22,8 @@ export const getRequireProvider = (context: Context) => (x: string) => {
     'js-slang': {
       ...jsslang,
       dist: {
-        stdlib
+        stdlib,
+        types
       },
       context
     }


### PR DESCRIPTION
Allow modules to import from `js-slang/dist/types`, following the recent change in #1388.

Will be used to modularise remote execution.