### PR TITLE
Add Interactive Environment Visualiser

### DIFF
--- a/src/__tests__/inspect.ts
+++ b/src/__tests__/inspect.ts
@@ -13,7 +13,9 @@ function flattenEnvironments(result: Result): Environment[] {
     .map((env: Environment) => ({ ...env, tail: null }))
 }
 
-test('debugger; statement basic test', () => {
+// Test suite skipped since functionality of debugger statements
+// has been changed for environment visualiser.
+xtest('debugger; statement basic test', () => {
   const code1 = `
   let a = 2;
   debugger;
@@ -33,7 +35,7 @@ test('debugger; statement basic test', () => {
   })
 })
 
-test('debugger; statement in function', () => {
+xtest('debugger; statement in function', () => {
   const code1 = `
   function a(x){
     debugger;
@@ -56,7 +58,7 @@ test('debugger; statement in function', () => {
   })
 })
 
-test('debugger; statement execution sequence', () => {
+xtest('debugger; statement execution sequence', () => {
   const code1 = `
   function a(x){
     return x;
@@ -79,7 +81,7 @@ test('debugger; statement execution sequence', () => {
   })
 })
 
-test('debugger; statement test function scope', () => {
+xtest('debugger; statement test function scope', () => {
   const code1 = `
   function a(x){
     let b = 10 * x;
@@ -113,7 +115,7 @@ test('debugger; statement test function scope', () => {
   })
 })
 
-test('debugger; statement hoisting', () => {
+xtest('debugger; statement hoisting', () => {
   const code1 = `
   function a(x){
     debugger;
@@ -139,7 +141,7 @@ test('debugger; statement hoisting', () => {
   })
 })
 
-test('debugger; pauses for', () => {
+xtest('debugger; pauses for', () => {
   const code1 = `
   function a(x){
     for (let i=0; i<x; i=i+1){
@@ -163,7 +165,7 @@ test('debugger; pauses for', () => {
   })
 })
 
-test('debugger; pauses while', () => {
+xtest('debugger; pauses while', () => {
   const code1 = `
   function a(x){
     while(x > 1){
@@ -198,7 +200,7 @@ test('debugger; pauses while', () => {
  * behavior of the debugger; statement.
  */
 
-test('setBreakpointAtLine basic', () => {
+xtest('setBreakpointAtLine basic', () => {
   const code1 = `
   const a = 10;
   const b = 20;
@@ -219,7 +221,7 @@ test('setBreakpointAtLine basic', () => {
   })
 })
 
-test('setBreakpointAtLine function 1', () => {
+xtest('setBreakpointAtLine function 1', () => {
   const code1 = `
   function a(x){
     return x + x;
@@ -244,7 +246,7 @@ test('setBreakpointAtLine function 1', () => {
   })
 })
 
-test('setBreakpointAtLine function 2', () => {
+xtest('setBreakpointAtLine function 2', () => {
   const code1 = `
   function a(x){
     return x + x;
@@ -269,7 +271,7 @@ test('setBreakpointAtLine function 2', () => {
   })
 })
 
-test('setBreakpointAtLine function 3', () => {
+xtest('setBreakpointAtLine function 3', () => {
   // this code will never break because the breakpoint is at a bracket which
   // will never be evaluated.
   const code1 = `
@@ -296,7 +298,7 @@ test('setBreakpointAtLine function 3', () => {
   })
 })
 
-test('setBreakpointAtLine function 4', () => {
+xtest('setBreakpointAtLine function 4', () => {
   const code1 = `
   function a(x){
     return x + x;
@@ -321,7 +323,7 @@ test('setBreakpointAtLine function 4', () => {
   })
 })
 
-test('setBreakpointAtLine granularity 1', () => {
+xtest('setBreakpointAtLine granularity 1', () => {
   // this tests that we can indeed stop at individual lines
   const code1 = `
   function a(ctrlf){
@@ -359,7 +361,7 @@ test('setBreakpointAtLine granularity 1', () => {
   })
 })
 
-test('setBreakpointAtLine granularity 2', () => {
+xtest('setBreakpointAtLine granularity 2', () => {
   // this tests that we can indeed stop at individual lines
   const code1 = `
   function a(ctrlf){
@@ -392,7 +394,7 @@ test('setBreakpointAtLine granularity 2', () => {
   })
 })
 
-test('setBreakpointAtLine granularity 3', () => {
+xtest('setBreakpointAtLine granularity 3', () => {
   // this tests that we can indeed stop at individual lines
   const code1 = `
   function a(ctrlf){
@@ -431,7 +433,7 @@ test('setBreakpointAtLine granularity 3', () => {
   })
 })
 
-test('setBreakpointAtLine for loops', () => {
+xtest('setBreakpointAtLine for loops', () => {
   // test stuff in loops work fine
   const code1 = `
   for(let i=1;i<10;i=i*2) {
@@ -477,7 +479,7 @@ test('setBreakpointAtLine for loops', () => {
   })
 })
 
-test('setBreakpointAtLine while loops', () => {
+xtest('setBreakpointAtLine while loops', () => {
   // test stuff in loops work fine
   const code1 = `
   let a = 9;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,5 +38,6 @@ export const sourceLanguages: Language[] = [
   { chapter: Chapter.SOURCE_3, variant: Variant.CONCURRENT },
   { chapter: Chapter.SOURCE_3, variant: Variant.NON_DET },
   { chapter: Chapter.SOURCE_4, variant: Variant.DEFAULT },
-  { chapter: Chapter.SOURCE_4, variant: Variant.GPU }
+  { chapter: Chapter.SOURCE_4, variant: Variant.GPU },
+  { chapter: Chapter.SOURCE_4, variant: Variant.EXPLICIT_CONTROL }
 ]

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -106,7 +106,8 @@ const createEmptyRuntime = () => ({
   agenda: null,
   stash: null,
   envSteps: -1,
-  envStepsTotal: 0
+  envStepsTotal: 0,
+  breakpointSteps: []
 })
 
 const createEmptyDebugger = () => ({

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -102,7 +102,11 @@ const createEmptyRuntime = () => ({
   environmentTree: new EnvTree(),
   environments: [],
   value: undefined,
-  nodes: []
+  nodes: [],
+  agenda: null,
+  stash: null,
+  envSteps: -1,
+  envStepsTotal: 0
 })
 
 const createEmptyDebugger = () => ({

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -216,10 +216,9 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
   context.runtime.nodes = []
   let steps = 0
   let command = agenda.pop()
-  console.log('runtime steps: ', context.runtime.envSteps)
   while (command) {
     if (!isPrelude && steps === context.runtime.envSteps) {
-      agenda.push(ast.debuggerStatement())
+      return stash.peek()
     }
     if (isNode(command)) {
       context.runtime.nodes.shift()
@@ -230,11 +229,6 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
         // We can put this under isNode since context.runtime.break
         // will only be updated after a debugger statement and so we will
         // run into a node immediately after.
-        console.log('BROKEN')
-        if (context.runtime.envSteps === -1) {
-          context.runtime.envSteps = steps
-          console.log('eval done', steps)
-        }
         return new ECEBreak()
       }
     } else {
@@ -242,10 +236,13 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
       cmdEvaluators[command.instrType](command, context, agenda, stash)
     }
     command = agenda.pop()
-    if (!isPrelude && context.runtime.envSteps === -1 && !command) {
-      command = ast.debuggerStatement()
-    }
+    // if (!isPrelude && context.runtime.envSteps === -1 && !command) {
+    //   command = ast.debuggerStatement()
+    // }
     steps += 1
+  }
+  if (!isPrelude) {
+    context.runtime.envStepsTotal = steps
   }
   return stash.peek()
 }

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -225,6 +225,17 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
     if (envChanging(command)) {
       steps += 1
     }
+    if (isNode(command) && command.type === 'DebuggerStatement') {
+      steps += 1
+
+      // Skip debugger if running for the first time
+      if (context.runtime.envSteps === -1) {
+        command = agenda.pop()
+        context.runtime.breakpointSteps.push(steps)
+        continue
+      }
+    }
+
     if (isNode(command)) {
       context.runtime.nodes.shift()
       context.runtime.nodes.unshift(command)
@@ -234,7 +245,7 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
         // We can put this under isNode since context.runtime.break
         // will only be updated after a debugger statement and so we will
         // run into a node immediately after.
-        return new ECEBreak()
+        // return new ECEBreak()
       }
     } else {
       // Command is an instrucion

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -216,6 +216,7 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash) {
   let command = agenda.pop()
   while (command) {
     if (isNode(command)) {
+      context.runtime.nodes.shift()
       context.runtime.nodes.unshift(command)
       checkEditorBreakpoints(context, command)
       cmdEvaluators[command.type](command, context, agenda, stash)
@@ -225,7 +226,6 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash) {
         // run into a node immediately after.
         return new ECEBreak()
       }
-      context.runtime.nodes.shift()
     } else {
       // Node is an instrucion
       cmdEvaluators[command.instrType](command, context, agenda, stash)

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -228,11 +228,9 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
     if (isNode(command) && command.type === 'DebuggerStatement') {
       steps += 1
 
-      // Skip debugger if running for the first time
+      // Record debugger step if running for the first time
       if (context.runtime.envSteps === -1) {
-        command = agenda.pop()
         context.runtime.breakpointSteps.push(steps)
-        continue
       }
     }
 
@@ -245,6 +243,7 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
         // We can put this under isNode since context.runtime.break
         // will only be updated after a debugger statement and so we will
         // run into a node immediately after.
+        // With the new evaluator, we don't return a break
         // return new ECEBreak()
       }
     } else {

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -216,10 +216,14 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
   context.runtime.break = false
   context.runtime.nodes = []
   let steps = 0
+
   let command = agenda.pop()
   while (command) {
     if (!isPrelude && steps === context.runtime.envSteps) {
       return stash.peek()
+    }
+    if (envChanging(command)) {
+      steps += 1
     }
     if (isNode(command)) {
       context.runtime.nodes.shift()
@@ -233,11 +237,8 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
         return new ECEBreak()
       }
     } else {
-      // Node is an instrucion
+      // Command is an instrucion
       cmdEvaluators[command.instrType](command, context, agenda, stash)
-    }
-    if (command && envChanging(command)) {
-      steps += 1
     }
     command = agenda.pop()
   }

--- a/src/ec-evaluator/types.ts
+++ b/src/ec-evaluator/types.ts
@@ -96,7 +96,8 @@ export type CmdEvaluator = (
   command: AgendaItem,
   context: Context,
   agenda: Agenda,
-  stash: Stash
+  stash: Stash,
+  isPrelude: boolean
 ) => void
 
 // Special class that cannot be found on the stash so is safe to be used

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -9,7 +9,7 @@ import { Environment, Frame, Value } from '../types'
 import * as ast from '../utils/astCreator'
 import * as instr from './instrCreator'
 import { Agenda } from './interpreter'
-import { AgendaItem, AssmtInstr, Instr, InstrType } from './types'
+import { AgendaItem, AppInstr, AssmtInstr, Instr, InstrType } from './types'
 
 /**
  * Stack is implemented for agenda and stash registers.
@@ -169,7 +169,11 @@ export const envChanging = (command: AgendaItem): boolean => {
     return type === 'Program' || (type === 'BlockStatement' && hasDeclarations(command))
   } else {
     const type = command.instrType
-    return type === InstrType.ASSIGNMENT || type === InstrType.ARRAY_ASSIGNMENT
+    return (
+      type === InstrType.ASSIGNMENT ||
+      type === InstrType.ARRAY_ASSIGNMENT ||
+      (type === InstrType.APPLICATION && (command as AppInstr).numOfArgs > 0)
+    )
   }
 }
 

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -133,7 +133,7 @@ export const reduceConditional = (
 }
 
 /**
- * To determine if an agenda item is value producing. JavaScript distinguishes valu producing
+ * To determine if an agenda item is value producing. JavaScript distinguishes value producing
  * statements and non-value producing statements.
  * Refer to https://sourceacademy.nus.edu.sg/sicpjs/4.1.2 exercise 4.8.
  *
@@ -150,6 +150,27 @@ export const valueProducing = (command: es.Node): boolean => {
     type !== 'ReturnStatement' &&
     (type !== 'BlockStatement' || command.body.some(valueProducing))
   )
+}
+
+/**
+ * To determine if an agenda item changes the environment.
+ * There is a change in the environment when
+ *  1. pushEnvironment() is called when creating a new frame, if there are variable declarations.
+ *     Called in Program, BlockStatement, and Application instructions.
+ *  2. there is an assignment.
+ *     Called in Assignment and Array Assignment instructions.
+ *
+ * @param command Agenda item to check against.
+ * @returns true if it changes the environment, false otherwise.
+ */
+export const envChanging = (command: AgendaItem): boolean => {
+  if (isNode(command)) {
+    const type = command.type
+    return type === 'Program' || (type === 'BlockStatement' && hasDeclarations(command))
+  } else {
+    const type = command.instrType
+    return type === InstrType.ASSIGNMENT || type === InstrType.ARRAY_ASSIGNMENT
+  }
 }
 
 /**
@@ -252,6 +273,15 @@ export function declareFunctionsAndVariables(
     }
   }
   return hasDeclarations
+}
+
+function hasDeclarations(node: es.BlockStatement): boolean {
+  for (const statement of node.body) {
+    if (statement.type === 'VariableDeclaration' || statement.type === 'FunctionDeclaration') {
+      return true
+    }
+  }
+  return false
 }
 
 export function defineVariable(

--- a/src/interpreter/closure.ts
+++ b/src/interpreter/closure.ts
@@ -54,7 +54,8 @@ export default class Closure extends Callable {
     node: es.ArrowFunctionExpression,
     environment: Environment,
     context: Context,
-    dummyReturn?: boolean
+    dummyReturn?: boolean,
+    predefined?: boolean
   ) {
     function isExpressionBody(body: es.BlockStatement | es.Expression): body is es.Expression {
       return body.type !== 'BlockStatement'
@@ -67,7 +68,8 @@ export default class Closure extends Callable {
     const closure = new Closure(
       blockArrowFunction(node.params as es.Identifier[], functionBody, node.loc),
       environment,
-      context
+      context,
+      predefined
     )
 
     // Set the closure's node to point back at the original one
@@ -83,10 +85,18 @@ export default class Closure extends Callable {
   // tslint:disable-next-line:ban-types
   public fun: Function
 
+  /** Keeps track of whether the closure is a pre-defined function */
+  public preDefined?: boolean
+
   /** The original node that created this Closure */
   public originalNode: es.Function
 
-  constructor(public node: es.Function, public environment: Environment, context: Context) {
+  constructor(
+    public node: es.Function,
+    public environment: Environment,
+    context: Context,
+    isPredefined?: boolean
+  ) {
     super(function (this: any, ...args: any[]) {
       return funJS.apply(this, args)
     })
@@ -104,6 +114,7 @@ export default class Closure extends Callable {
     // .fun seems to only be used in interpreter's NewExpression handler, which uses .fun.prototype.
     const funJS = closureToJS(this, context, this.functionName)
     this.fun = funJS
+    this.preDefined = isPredefined == undefined ? undefined : isPredefined
   }
 
   public toString(): string {

--- a/src/mocks/context.ts
+++ b/src/mocks/context.ts
@@ -31,7 +31,11 @@ export function mockRuntimeContext(): Context {
         raw: '0',
         range: [0, 1]
       }
-    ]
+    ],
+    agenda: null,
+    stash: null,
+    envSteps: -1,
+    envStepsTotal: 0
   }
   return context
 }

--- a/src/mocks/context.ts
+++ b/src/mocks/context.ts
@@ -35,7 +35,8 @@ export function mockRuntimeContext(): Context {
     agenda: null,
     stash: null,
     envSteps: -1,
-    envStepsTotal: 0
+    envStepsTotal: 0,
+    breakpointSteps: []
   }
   return context
 }

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -206,7 +206,7 @@ async function runNative(
 }
 
 function runECEvaluator(program: es.Program, context: Context, options: IOptions): Promise<Result> {
-  const value = ECEvaluate(program, context)
+  const value = ECEvaluate(program, context, options)
   return ECEResultPromise(context, value)
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,7 @@ export interface Context<T = any> {
     stash: Stash | null
     envSteps: number
     envStepsTotal: number
+    breakpointSteps: number[]
   }
 
   numberOfOuterEnvironments: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export interface Context<T = any> {
     nodes: es.Node[]
     agenda?: Agenda
     stash?: Stash
+    envSteps?: number
   }
 
   numberOfOuterEnvironments: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,7 @@ export interface Context<T = any> {
     agenda?: Agenda
     stash?: Stash
     envSteps?: number
+    envStepsTotal?: number
   }
 
   numberOfOuterEnvironments: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,10 +135,10 @@ export interface Context<T = any> {
     environmentTree: EnvTree
     environments: Environment[]
     nodes: es.Node[]
-    agenda?: Agenda
-    stash?: Stash
-    envSteps?: number
-    envStepsTotal?: number
+    agenda: Agenda | null
+    stash: Stash | null
+    envSteps: number
+    envStepsTotal: number
   }
 
   numberOfOuterEnvironments: number

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -374,4 +374,4 @@ export const forStatement = (
   body
 })
 
-export const debuggerStatement = () : es.DebuggerStatement => ({type: 'DebuggerStatement'})
+export const debuggerStatement = (): es.DebuggerStatement => ({ type: 'DebuggerStatement' })

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -379,5 +379,3 @@ export const forStatement = (
   body,
   loc
 })
-
-export const debuggerStatement = (): es.DebuggerStatement => ({ type: 'DebuggerStatement' })

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -373,3 +373,5 @@ export const forStatement = (
   update,
   body
 })
+
+export const debuggerStatement = () : es.DebuggerStatement => ({type: 'DebuggerStatement'})

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -102,9 +102,13 @@ export const functionExpression = (
   loc
 })
 
-export const blockStatement = (body: es.Statement[]): es.BlockStatement => ({
+export const blockStatement = (
+  body: es.Statement[],
+  loc?: es.SourceLocation | null
+): es.BlockStatement => ({
   type: 'BlockStatement',
-  body
+  body,
+  loc
 })
 
 export const program = (body: es.Statement[]): es.Program => ({
@@ -365,13 +369,15 @@ export const forStatement = (
   init: es.VariableDeclaration | es.Expression,
   test: es.Expression,
   update: es.Expression,
-  body: es.Statement
+  body: es.Statement,
+  loc?: es.SourceLocation | null
 ): es.ForStatement => ({
   type: 'ForStatement',
   init,
   test,
   update,
-  body
+  body,
+  loc
 })
 
 export const debuggerStatement = (): es.DebuggerStatement => ({ type: 'DebuggerStatement' })


### PR DESCRIPTION
# Interactive Environment Visualiser

The new interactive environment visualiser is a revamp of the current environment visualiser. It uses an explicit control evaluator as described in #1361, and allows users to step through the program to see changes to the environment. There is a corresponding pull request on the frontend https://github.com/source-academy/frontend/pull/2441.

## Description

Currently, the environment visualiser runs when the program encounters a breakpoint. In the new visualiser, the user has to open the environment tab before running to activate it.

The functionality of breakpoints is changed. They no longer break programs but serve as a point to fast-forward (or backward) the environment visualiser.

When the program is run for the first time in the environment visualiser, the evaluator first runs the program all the way to the end and counts the number of steps. Breakpoints are also recorded as breakpoint steps.

## Changes
- The explicit control evaluator in `src/ec-evaluator` is modified to count the number of steps.
- New variables have been added into the context runtime to track the number of steps.
- Tests under `src/__tests__/inspect.ts` are skipped because of the new implementation of breakpoints.

## Future Work
1. Using a more efficient and smarter way of getting the environment state. The current implementation reruns the program whenever the slider is shifted.
2. Display the agenda and stash stacks together with the environment visualiser.
3. Refactor the codebase to remove suspended states caused by breakpoints. Because of the new environment visualiser, the program only records breakpoints when we encounter them and allows the program to finish even if breakpoints are present.