### PR TITLE
Fix for scm-slang conditionals

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -2,8 +2,8 @@
 
 import { GLOBAL, JSSLANG_PROPERTIES } from './constants'
 import * as gpu_lib from './gpu/lib'
-import * as scheme_libs from './scm-slang/src/stdlib/source-scheme-library'
 import { AsyncScheduler } from './schedulers'
+import * as scheme_libs from './scm-slang/src/stdlib/source-scheme-library'
 import { lazyListPrelude } from './stdlib/lazyList.prelude'
 import * as list from './stdlib/list'
 import { list_to_vector } from './stdlib/list'
@@ -554,6 +554,11 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
 
         // Scheme procedures
         defineBuiltin(context, 'procedure$63$(val)', scheme_libs.procedureQ)
+
+        // Special values
+        defineBuiltin(context, 'undefined', undefined)
+        defineBuiltin(context, 'NaN', NaN)
+        defineBuiltin(context, 'Infinity', Infinity)
 
         break
       default:


### PR DESCRIPTION
Resolves a bug which rendered scheme conditional syntax unevaluable

![image_2023-04-14_00-47-56](https://user-images.githubusercontent.com/72686534/231829368-f1731446-647d-4130-bb56-25f1fedae252.png)

This code does not compile, as scheme conditionals without a "catch-all" else clause may return undefined as a value. This commit exposes undefined, NaN and Infinity as builtin values so that they can be defined and used by both the parser and end users.