### PR TITLE
Add documentation for AUXILIARY functions

### DIFF
--- a/docs/lib/auxiliary.js
+++ b/docs/lib/auxiliary.js
@@ -1,0 +1,25 @@
+/**
+ * Searches for the specified name in the data structure of exported names.
+ * The data structure is a pair where the head element is the default export
+ * and the tail element is a list of pairs where each pair is a mapping from
+ * the exported name to the value being exported. If the lookup name is
+ * "default", the default export is returned instead of a named export. If
+ * the name does not exist, <code>undefined</code> is returned.
+ *
+ * @param {pair} exports - The data structure of exported values
+ * @param {string} lookup_name - Name to import
+ * @returns {value} The value corresponding to the imported name
+ */
+function __access_export__(exports, lookup_name) {}
+
+/**
+ * Searches for the specified name in the data structure of exported names.
+ * The data structure is a list of pairs where each pair is a mapping from
+ * the exported name to the value being exported. If the name does not exist,
+ * <code>undefined</code> is returned.
+ *
+ * @param {list} named_exports - The data structure of exported names
+ * @param {string} lookup_name - Name to import
+ * @returns {value} The value corresponding to the imported name
+ */
+function __access_named_export__(named_exports, lookup_name) {}

--- a/docs/md/README_2.md
+++ b/docs/md/README_2.md
@@ -10,6 +10,9 @@ order. Click on a name to see how it is defined and used. They come in
 these groups:
   <ul>
     <li>
+      <a href="../AUXILIARY/">AUXILIARY</a>: Auxiliary constants and functions
+    </li>
+    <li>
       <a href="../MISC/">MISC</a>: Miscellaneous constants and functions
     </li>
     <li>

--- a/docs/md/README_3.md
+++ b/docs/md/README_3.md
@@ -9,6 +9,9 @@ On the right, you see all predeclared names of Source §3, in alphabetical
 order. Click on a name to see how it is defined and used. They come in these groups:
   <ul>
     <li>
+      <a href="../AUXILIARY/index.html">AUXILIARY</a>: Auxiliary constants and functions
+    </li>
+    <li>
       <a href="../MISC/index.html">MISC</a>: Miscellaneous constants and functions
     </li>
     <li>

--- a/docs/md/README_3_CONCURRENT.md
+++ b/docs/md/README_3_CONCURRENT.md
@@ -9,6 +9,9 @@ On the right, you see all predeclared names of Source §3 Concurrent, in alphabe
 order. Click on a name to see how it is defined and used. They come in these groups:
   <ul>
     <li>
+      <a href="../AUXILIARY/index.html">AUXILIARY</a>: Auxiliary constants and functions
+    </li>
+    <li>
       <a href="../MISC/index.html">MISC</a>: Miscellaneous constants and functions
     </li>
     <li>

--- a/docs/md/README_3_NON-DET.md
+++ b/docs/md/README_3_NON-DET.md
@@ -14,6 +14,9 @@ On the right, you see all predeclared names of Source §3 Non-Det, in alphabetic
 order. Click on a name to see how it is defined and used. They come in these groups:
   <ul>
     <li>
+      <a href="../AUXILIARY/index.html">AUXILIARY</a>: Auxiliary constants and functions
+    </li>
+    <li>
       <a href="../MISC/index.html">MISC</a>: Miscellaneous constants and functions
     </li>
     <li>

--- a/docs/md/README_4.md
+++ b/docs/md/README_4.md
@@ -9,6 +9,9 @@ On the right, you see all predeclared names of Source §4, in alphabetical
 order. Click on a name to see how it is defined and used. They come in these groups:
   <ul>
     <li>
+      <a href="../AUXILIARY/index.html">AUXILIARY</a>: Auxiliary constants and functions
+    </li>
+    <li>
       <a href="../MISC/index.html">MISC</a>: Miscellaneous constants and functions
     </li>
     <li>

--- a/docs/md/README_4_GPU.md
+++ b/docs/md/README_4_GPU.md
@@ -7,6 +7,9 @@ On the right, you see all predeclared names of Source §4, in alphabetical
 order. Click on a name to see how it is defined and used. They come in these groups:
   <ul>
     <li>
+      <a href="../AUXILIARY/index.html">AUXILIARY</a>: Auxiliary constants and functions
+    </li>
+    <li>
       <a href="../MISC/index.html">MISC</a>: Miscellaneous constants and functions
     </li>
     <li>

--- a/docs/md/README_AUXILIARY.md
+++ b/docs/md/README_AUXILIARY.md
@@ -1,0 +1,4 @@
+On the right, you see all predeclared names of AUXILIARY, in alphabetical order.
+Click on a name to see how it is defined and used.
+
+Unlike <a href="../MISC/">MISC</a>, the names declared in AUXILIARY are not meant to be directly called, although they can be.

--- a/scripts/jsdoc.sh
+++ b/scripts/jsdoc.sh
@@ -72,6 +72,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_2.md \
 	     -d ${DST}/"source_2"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
 	     ${LIB}/list.js
@@ -82,6 +83,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_2_LAZY.md \
 	     -d ${DST}/"source_2_lazy"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
 	     ${LIB}/list.js
@@ -92,6 +94,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_2_TYPED.md \
 	     -d ${DST}/"source_2_typed"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
 	     ${LIB}/list.js
@@ -102,6 +105,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_3.md \
 	     -d ${DST}/"source_3"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
              ${LIB}/list.js \
@@ -115,6 +119,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_3_CONCURRENT.md \
 	     -d ${DST}/"source_3_concurrent"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
              ${LIB}/list.js \
@@ -129,6 +134,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_3_NON-DET.md \
 	     -d ${DST}/"source_3_non-det"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
          ${LIB}/list.js \
@@ -143,6 +149,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_3_TYPED.md \
 	     -d ${DST}/"source_3_typed"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
          ${LIB}/list.js \
@@ -156,6 +163,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_4.md \
 	     -d ${DST}/"source_4"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
 	     ${LIB}/list.js \
@@ -170,6 +178,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_4_GPU.md \
 	     -d ${DST}/"source_4_gpu"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
 		 ${LIB}/list.js \
@@ -183,6 +192,7 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -R ${MD}/README_4_TYPED.md \
 	     -d ${DST}/"source_4_typed"/ \
+	     ${LIB}/auxiliary.js \
 	     ${LIB}/misc.js \
 	     ${LIB}/math.js \
 	     ${LIB}/list.js \
@@ -190,7 +200,15 @@ run() {
 	     ${LIB}/array.js \
 	     ${LIB}/pairmutator.js \
 	     ${LIB}/mce.js
-    
+
+    # AUXILIARY
+
+    ${JSDOC} -r -t ${TMPL} \
+       -c docs/jsdoc/conf.json \
+       -R ${MD}/README_AUXILIARY.md \
+       -d ${DST}/AUXILIARY/ \
+       ${LIB}/auxiliary.js
+
     # MISC
     
     ${JSDOC} -r -t ${TMPL} \
@@ -302,8 +320,8 @@ run() {
 	     -c docs/jsdoc/conf.json \
 	     -d "${DST}/PIXNFLIX/" \
 	     -R ${MD}/PIXNFLIX_README.md \
-	     ${LIB}/video_lib.js 
-    
+	     ${LIB}/video_lib.js
+
    # GAME
     
     ${JSDOC} -r -t ${TMPL} \


### PR DESCRIPTION
AUXILIARY functions are like MISC functions, except they are not intended to be directly called by the user (although they can be). Currently, there are two such functions, `__access_export__` and `__access_named_export__`, which are used for local modules.