### PR TITLE
Fix file path in error message when module cannot be found

### DIFF
--- a/src/localImports/__tests__/preprocessor.ts
+++ b/src/localImports/__tests__/preprocessor.ts
@@ -104,7 +104,7 @@ describe('preprocessFileImports', () => {
     expect(stripLocationInfo(actualProgram)).toEqual(stripLocationInfo(expectedProgram))
   }
 
-  it('returns undefined if the entrypoint file does not exist', () => {
+  it('returns undefined & adds CannotFindModuleError to context if the entrypoint file does not exist', () => {
     const files: Record<string, string> = {
       '/a.js': '1 + 2;'
     }
@@ -115,7 +115,7 @@ describe('preprocessFileImports', () => {
     )
   })
 
-  it('returns undefined if an imported file does not exist', () => {
+  it('returns undefined & adds CannotFindModuleError to context if an imported file does not exist', () => {
     const files: Record<string, string> = {
       '/a.js': `import { x } from './non-existent-file.js';`
     }

--- a/src/localImports/__tests__/preprocessor.ts
+++ b/src/localImports/__tests__/preprocessor.ts
@@ -110,6 +110,20 @@ describe('preprocessFileImports', () => {
     }
     const actualProgram = preprocessFileImports(files, '/non-existent-file.js', actualContext)
     expect(actualProgram).toBeUndefined()
+    expect(parseError(actualContext.errors)).toMatchInlineSnapshot(
+      `"Cannot find module '/non-existent-file.js'."`
+    )
+  })
+
+  it('returns undefined if an imported file does not exist', () => {
+    const files: Record<string, string> = {
+      '/a.js': `import { x } from './non-existent-file.js';`
+    }
+    const actualProgram = preprocessFileImports(files, '/a.js', actualContext)
+    expect(actualProgram).toBeUndefined()
+    expect(parseError(actualContext.errors)).toMatchInlineSnapshot(
+      `"Cannot find module '/non-existent-file.js'."`
+    )
   })
 
   it('returns the same AST if the entrypoint file does not contain import/export statements', () => {

--- a/src/localImports/preprocessor.ts
+++ b/src/localImports/preprocessor.ts
@@ -77,7 +77,7 @@ const parseProgramsAndConstructImportGraph = (
   const parseFile = (currentFilePath: string): void => {
     const code = files[currentFilePath]
     if (code === undefined) {
-      context.errors.push(new CannotFindModuleError(entrypointFilePath))
+      context.errors.push(new CannotFindModuleError(currentFilePath))
       return
     }
 


### PR DESCRIPTION
Should be passing in the current file path and not the entrypoint file path.