### PR TITLE
Bump version to match NPM registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-slang",
-  "version": "1.0.20",
+  "version": "1.0.23",
   "license": "Apache-2.0",
   "description": "Javascript-based implementations of Source, written in Typescript",
   "keywords": [


### PR DESCRIPTION
This does not actually signify a new release, but is merely a hotfix to ensure the version number matches the one in NPM registry.

See https://github.com/source-academy/js-slang/issues/1414 for more info.

Part of #1414. After this, we will try to ban publishing to NPM directly, and instead set up a GitHub Action to publish to NPM every time the version number is changed on `package.json`. That way, no separate PRs are required just to bump the version, and instead, the authors of the PRs that make changes can bump the version directly and it will automatically (and perhaps optionally) publish a new version on NPM when merged to `master`.