### PR TITLE
Bump version to v1.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-slang",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "Apache-2.0",
   "description": "Javascript-based implementations of Source, written in Typescript",
   "keywords": [


### PR DESCRIPTION
Changelog: https://github.com/source-academy/js-slang/compare/d04dd404d0552b620d8c52eb5c4b066234deb21e...b152558ffffde15788b5e6b0a2fe2b757485448e

Also serves to test our new CI pipeline for deploying to NPM automatically.