### PR TITLE
Add simplifications to explicit control evaluator

### DIFF
--- a/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
@@ -151,7 +151,7 @@ test('Infinite recursion with a block bodied function', () => {
     function i(n) {
       return n === 0 ? 0 : 1 + i(n-1);
     }
-    i(25000);
+    i(30000);
   `,
     optionEC4
   ).toEqual(expect.stringMatching(/Maximum call stack size exceeded\n *(i\(\d*\)[^i]{2,4}){3}/))
@@ -166,7 +166,7 @@ test('Infinite recursion with function calls in argument', () => {
     function r() {
       return 1;
     }
-    i(25000, 1);
+    i(30000, 1);
   `,
     optionEC4
   ).toEqual(
@@ -937,7 +937,7 @@ test('Check that stack is at most 10k in size', () => {
         return 1 + f(x-1);
       }
     }
-    f(25000);
+    f(30000);
   `,
     optionEC
   ).toEqual(expect.stringMatching(/Maximum call stack size exceeded\n([^f]*f){3}/))

--- a/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
@@ -151,7 +151,7 @@ test('Infinite recursion with a block bodied function', () => {
     function i(n) {
       return n === 0 ? 0 : 1 + i(n-1);
     }
-    i(20000);
+    i(25000);
   `,
     optionEC4
   ).toEqual(expect.stringMatching(/Maximum call stack size exceeded\n *(i\(\d*\)[^i]{2,4}){3}/))
@@ -166,7 +166,7 @@ test('Infinite recursion with function calls in argument', () => {
     function r() {
       return 1;
     }
-    i(20000, 1);
+    i(25000, 1);
   `,
     optionEC4
   ).toEqual(
@@ -937,7 +937,7 @@ test('Check that stack is at most 10k in size', () => {
         return 1 + f(x-1);
       }
     }
-    f(20000);
+    f(25000);
   `,
     optionEC
   ).toEqual(expect.stringMatching(/Maximum call stack size exceeded\n([^f]*f){3}/))

--- a/src/ec-evaluator/types.ts
+++ b/src/ec-evaluator/types.ts
@@ -1,8 +1,6 @@
 import * as es from 'estree'
 
-import { Context } from '..'
 import { Environment } from '../types'
-import { Agenda, Stash } from './interpreter'
 
 export enum InstrType {
   RESET = 'Reset',
@@ -86,14 +84,6 @@ export type Instr =
   | ArrLitInstr
 
 export type AgendaItem = es.Node | Instr
-
-export type CmdEvaluator = (
-  command: AgendaItem,
-  context: Context,
-  agenda: Agenda,
-  stash: Stash,
-  isPrelude: boolean
-) => void
 
 // Special class that cannot be found on the stash so is safe to be used
 // as an indicator of a breakpoint from running the ECE machine

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -19,6 +19,7 @@ interface IStack<T> {
   pop(): T | undefined
   peek(): T | undefined
   size(): number
+  getStack(): T[]
 }
 
 export class Stack<T> implements IStack<T> {
@@ -48,11 +49,9 @@ export class Stack<T> implements IStack<T> {
     return this.storage.length
   }
 
-  public mapStack(mapper: (t: T) => any, num?: number): T[] {
-    if (num && num <= this.storage.length) {
-      return this.storage.slice(this.storage.length - num).map(mapper)
-    }
-    return [...this.storage].map(mapper)
+  public getStack(): T[] {
+    // return a copy of the stack's contents
+    return [...this.storage]
   }
 }
 

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -126,10 +126,16 @@ export const handleSequence = (seq: es.Statement[]): AgendaItem[] => {
   let valueProduced = false
   for (const command of seq) {
     if (valueProducing(command)) {
-      valueProduced ? result.push(instr.popInstr(command)) : (valueProduced = true)
+      // Value producing statements have an extra pop instruction
+      if (valueProduced) {
+        result.push(instr.popInstr(command))
+      } else {
+        valueProduced = true
+      }
     }
     result.push(command)
   }
+  // Push statements in reverse order
   return result.reverse()
 }
 

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -19,6 +19,7 @@ interface IStack<T> {
   pop(): T | undefined
   peek(): T | undefined
   size(): number
+  isEmpty(): boolean
   getStack(): T[]
 }
 
@@ -39,7 +40,7 @@ export class Stack<T> implements IStack<T> {
   }
 
   public peek(): T | undefined {
-    if (this.size() === 0) {
+    if (this.isEmpty()) {
       return undefined
     }
     return this.storage[this.size() - 1]
@@ -47,6 +48,10 @@ export class Stack<T> implements IStack<T> {
 
   public size(): number {
     return this.storage.length
+  }
+
+  public isEmpty(): boolean {
+    return this.size() == 0
   }
 
   public getStack(): T[] {

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -274,23 +274,19 @@ export function declareFunctionsAndVariables(
   node: es.BlockStatement,
   environment: Environment
 ) {
-  let hasDeclarations: boolean = false
   for (const statement of node.body) {
     switch (statement.type) {
       case 'VariableDeclaration':
         declareVariables(context, statement, environment)
-        hasDeclarations = true
         break
       case 'FunctionDeclaration':
         declareIdentifier(context, (statement.id as es.Identifier).name, statement, environment)
-        hasDeclarations = true
         break
     }
   }
-  return hasDeclarations
 }
 
-function hasDeclarations(node: es.BlockStatement): boolean {
+export function hasDeclarations(node: es.BlockStatement): boolean {
   for (const statement of node.body) {
     if (statement.type === 'VariableDeclaration' || statement.type === 'FunctionDeclaration') {
       return true

--- a/src/interpreter/closure.ts
+++ b/src/interpreter/closure.ts
@@ -3,6 +3,7 @@ import { generate } from 'astring'
 import * as es from 'estree'
 import { uniqueId } from 'lodash'
 
+import { hasReturnStatement, isBlockStatement } from '../ec-evaluator/utils'
 import { Context, Environment, Value } from '../types'
 import {
   blockArrowFunction,
@@ -58,12 +59,9 @@ export default class Closure extends Callable {
     dummyReturn?: boolean,
     predefined?: boolean
   ) {
-    function isExpressionBody(body: es.BlockStatement | es.Expression): body is es.Expression {
-      return body.type !== 'BlockStatement'
-    }
-    const functionBody: es.BlockStatement = isExpressionBody(node.body)
+    const functionBody: es.BlockStatement = !isBlockStatement(node.body)
       ? blockStatement([returnStatement(node.body, node.body.loc)], node.body.loc)
-      : dummyReturn
+      : dummyReturn && !hasReturnStatement(node.body)
       ? blockStatement(
           [
             ...node.body.body,

--- a/src/interpreter/closure.ts
+++ b/src/interpreter/closure.ts
@@ -6,6 +6,7 @@ import { uniqueId } from 'lodash'
 import { Context, Environment, Value } from '../types'
 import {
   blockArrowFunction,
+  blockStatement,
   callExpression,
   identifier,
   returnStatement
@@ -60,12 +61,16 @@ export default class Closure extends Callable {
     function isExpressionBody(body: es.BlockStatement | es.Expression): body is es.Expression {
       return body.type !== 'BlockStatement'
     }
-    const functionBody: es.Statement[] | es.Expression | es.BlockStatement = isExpressionBody(
-      node.body
-    )
-      ? [returnStatement(node.body, node.body.loc)]
+    const functionBody: es.BlockStatement = isExpressionBody(node.body)
+      ? blockStatement([returnStatement(node.body, node.body.loc)], node.body.loc)
       : dummyReturn
-      ? [...node.body.body, returnStatement(identifier('undefined', node.body.loc), node.body.loc)]
+      ? blockStatement(
+          [
+            ...node.body.body,
+            returnStatement(identifier('undefined', node.body.loc), node.body.loc)
+          ],
+          node.body.loc
+        )
       : node.body
 
     const closure = new Closure(


### PR DESCRIPTION
# Simplifications of the explicit control evaluator

## Description
This pull request presents simplifications to the explicit control evaluator.

## Changes
- Top-level `push undefined if needed` instructions are not pushed anymore, but `undefined` is pushed immediately to the stash. Addresses https://github.com/source-academy/frontend/issues/2536
- `ENVIRONMENT` instruction will not be created by block statements if there is another `ENVIRONMENT` instruction already on the agenda. There might be more cases where the `ENVIRONMENT` instruction is unnecessary. Addresses https://github.com/source-academy/frontend/issues/2538
- Expression statements will be fast forward (so the next step would not just remove `;`). Programs with only one statement will also be fast forwarded. Addresses https://github.com/source-academy/frontend/issues/2535
- Issues involving inconsistent steps fixed. Addresses https://github.com/source-academy/frontend/issues/2539
- Redundant `ENVIRONMENT` instructions removed for nullary functions and function bodies with no declarations. Addresses https://github.com/source-academy/frontend/issues/2542
- Interpreter now only adds `return undefined` to function bodies when needed.