### PR TITLE
Fix env viz - program environment not reflecting values that are imported from modules

### DIFF
--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -138,7 +138,6 @@ function evaluateImports(
   loadTabs: boolean,
   checkImports: boolean
 ) {
-
   try {
     const moduleName = node.source.value
     if (typeof moduleName !== 'string') {


### PR DESCRIPTION
Fixes #1434

Import modules are now handled whenever an 'ImportDeclaration' node is encountered rather than handling all of them together before the other nodes