### PR TITLE
Fix env viz import issues

### DIFF
--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -218,7 +218,6 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
 
   let command = agenda.peek()
 
-
   // First node will be a Program
   context.runtime.nodes.unshift(command as es.Program)
 
@@ -297,7 +296,6 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       pushEnvironment(context, environment)
       evaluateImports(command as unknown as es.Program, context, true, true)
       declareFunctionsAndVariables(context, command, environment)
-
     }
 
     if (command.body.length == 1) {

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -222,10 +222,6 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
   context.runtime.nodes.unshift(command as es.Program)
 
   while (command) {
-    let isImportDeclaration = false
-    if (isNode(command) && command.type === 'ImportDeclaration') {
-      isImportDeclaration = true
-    }
     // Return to capture a snapshot of the agenda and stash after the target step count is reached
     if (!isPrelude && steps === context.runtime.envSteps) {
       return stash.peek()
@@ -262,10 +258,8 @@ function runECEMachine(context: Context, agenda: Agenda, stash: Stash, isPrelude
       stash.push(undefined)
     }
     command = agenda.peek()
-    // If command is an ImportDeclaration, don't add unnecessary step
-    if (!isImportDeclaration) {
-      steps += 1
-    }
+
+    steps += 1
   }
 
   if (!isPrelude) {
@@ -291,7 +285,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     isPrelude: boolean
   ) {
     // Create and push the environment only if it is non empty.
-    if (hasDeclarations(command) || hasImportDeclarations(command as unknown as es.Program)) {
+    if (hasDeclarations(command) || hasImportDeclarations(command)) {
       const environment = createBlockEnvironment(context, 'programEnvironment')
       pushEnvironment(context, environment)
       evaluateImports(command as unknown as es.Program, context, true, true)

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -320,6 +320,15 @@ export function hasDeclarations(node: es.BlockStatement): boolean {
   return false
 }
 
+export function hasImportDeclarations(node: es.Program): boolean {
+  for (const statement of node.body) {
+    if (statement.type === 'ImportDeclaration' ) {
+      return true
+    }
+  }
+  return false
+}
+
 export function defineVariable(
   context: Context,
   name: string,

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -183,6 +183,7 @@ export const valueProducing = (command: es.Node): boolean => {
     type !== 'ContinueStatement' &&
     type !== 'BreakStatement' &&
     type !== 'ReturnStatement' &&
+    type !== 'ImportDeclaration' &&
     (type !== 'BlockStatement' || command.body.some(valueProducing))
   )
 }

--- a/src/ec-evaluator/utils.ts
+++ b/src/ec-evaluator/utils.ts
@@ -322,7 +322,7 @@ export function hasDeclarations(node: es.BlockStatement): boolean {
 
 export function hasImportDeclarations(node: es.Program): boolean {
   for (const statement of node.body) {
-    if (statement.type === 'ImportDeclaration' ) {
+    if (statement.type === 'ImportDeclaration') {
       return true
     }
   }


### PR DESCRIPTION
ImportDeclarations are now handled in the Program evaluator in cmdEvaluators so that all toplevel names are shown right away in the program environment - Fixes #1450
ImportDeclarations are now non value producing - Fixes #1448 (POP issue)
<img width="1423" alt="Screenshot 2023-07-21 at 7 46 53 PM" src="https://github.com/source-academy/js-slang/assets/77202894/8c848d02-2c4d-4d30-ba25-639c1cb7a2da">

Added a condition in runECEMachine to check if the command is an ImportDeclaration, then the current step is not incremented - Fixes #1448  (redundant steps issue but this feels quite hackish? )
<img width="1381" alt="Screenshot 2023-07-21 at 7 47 13 PM" src="https://github.com/source-academy/js-slang/assets/77202894/c2296389-1f71-4148-b5d4-7d99e0352d83">

