### PR TITLE
Fix: not displaying runtime errors in stepper

### DIFF
--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -85,6 +85,9 @@ function runSubstitution(
   options: IOptions
 ): Promise<Result> {
   const steps = getEvaluationSteps(program, context, options.stepLimit)
+  if (context.errors.length > 0) {
+    return resolvedErrorPromise
+  }
   const redexedSteps: IStepperPropContents[] = []
   for (const step of steps) {
     const redex = getRedex(step[0], step[1])


### PR DESCRIPTION
## Description
Address the issue where the stepper is not generating any runtime errors.