### PR TITLE
Add proof-of-concept for handling module types in Source Typed

### DIFF
--- a/src/errors/typeErrors.ts
+++ b/src/errors/typeErrors.ts
@@ -727,3 +727,26 @@ export class DuplicateTypeAliasError implements SourceError {
     return this.explain()
   }
 }
+
+export class NameNotFoundInModuleError implements SourceError {
+  public type = ErrorType.TYPE
+  public severity = ErrorSeverity.ERROR
+
+  constructor(
+    public node: tsEs.ImportDeclaration,
+    public moduleName: string,
+    public name: string
+  ) {}
+
+  get location() {
+    return this.node.loc ?? UNKNOWN_LOCATION
+  }
+
+  public explain() {
+    return `Module '${this.moduleName}' has no exported member '${this.name}'.`
+  }
+
+  public elaborate() {
+    return this.explain()
+  }
+}

--- a/src/typeChecker/runeTypes.ts
+++ b/src/typeChecker/runeTypes.ts
@@ -1,0 +1,129 @@
+export const runeTypeDeclarations = {
+  prelude: `type Rune = 'Rune';
+  type AnimatedRune = 'AnimatedRune';`,
+  blank: `const blank: Rune = 'Rune';`,
+  circle: `const circle: Rune = 'Rune';`,
+  corner: `const corner: Rune = 'Rune';`,
+  heart: `const heart: Rune = 'Rune';`,
+  nova: `const nova: Rune = 'Rune';`,
+  pentagram: `const pentagram: Rune = 'Rune';`,
+  rcross: `const rcross: Rune = 'Rune';`,
+  ribbon: `const ribbon: Rune = 'Rune';`,
+  sail: `const sail: Rune = 'Rune';`,
+  square: `const square: Rune = 'Rune';`,
+  triangle: `const triangle: Rune = 'Rune';`,
+  black: `function black(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  blue: `function blue(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  brown: `function brown(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  color: `function color(rune: Rune, r: number, g: number, b: number): Rune {
+    return 'Rune';
+  }`,
+  green: `function green(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  indigo: `function indigo(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  orange: `function orange(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  pink: `function pink(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  purple: `function purple(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  random_color: `function random_color(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  red: `function red(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  white: `function white(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  yellow: `function yellow(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  anaglyph: `function anaglyph(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  animate_anaglyph: `animate_anaglyph(duration: number, fps: number, func: RuneAnimation): AnimatedRune {
+    return 'AnimatedRune';
+  }`,
+  animate_rune: `function animate_rune(duration: number, fps: number, func: RuneAnimation): AnimatedRune {
+    return 'AnimatedRune';
+  }`,
+  beside: `function beside(rune1: Rune, rune2: Rune): Rune {
+    return 'Rune';
+  }`,
+  beside_frac: `function beside_frac(frac: number, rune1: Rune, rune2: Rune): Rune {
+    return 'Rune';
+  }`,
+  flip_horiz: `function flip_horiz(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  flip_vert: `function flip_vert(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  from_url: `function from_url(imageUrl: string): Rune {
+    return 'Rune';
+  }`,
+  hollusion: `function hollusion(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  hollusion_magnitude: `function hollusion_magnitude(rune: Rune, magnitude: number): Rune {
+    return 'Rune';
+  }`,
+  make_cross: `function make_cross(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  overlay: `function overlay(rune1: Rune, rune2: Rune): Rune {
+    return 'Rune';
+  }`,
+  overlay_frac: `function overlay_frac(frac: number, rune1: Rune, rune2: Rune): Rune {
+    return 'Rune';
+  }`,
+  quarter_turn_left: `function quarter_turn_left(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  quarter_turn_right: `function quarter_turn_right(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  repeat_pattern: `function repeat_pattern(n: number, pattern: ((a: Rune) => Rune), initial: Rune): Rune {
+    return 'Rune';
+  }`,
+  rotate: `function rotate(rad: number, rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  scale: `function scale(ratio: number, rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  scale_independent: `function scale_independent(ratio_x: number, ratio_y: number, rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  show: `function show(rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  stack: `function stack(rune1: Rune, rune2: Rune): Rune {
+    return 'Rune';
+  }`,
+  stack_frac: `function stack_frac(frac: number, rune1: Rune, rune2: Rune): Rune {
+    return 'Rune';
+  }`,
+  stackn: `function stackn(n: number, rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  translate: `function translate(x: number, y: number, rune: Rune): Rune {
+    return 'Rune';
+  }`,
+  turn_upside_down: `function turn_upside_down(rune: Rune): Rune {
+    return 'Rune';
+  }`
+}

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -387,7 +387,8 @@ function typeCheckAndReturnType(node: tsEs.Node): Type {
           return tStream(elementType)
         }
       }
-      const calleeType = typeCheckAndReturnType(callee)
+      // Copy of callee type is made so that the type saved in the type environment does not change
+      const calleeType = cloneDeep(typeCheckAndReturnType(callee))
       if (calleeType.kind !== 'function') {
         if (calleeType.kind !== 'primitive' || calleeType.name !== 'any') {
           context.errors.push(new TypeNotCallableError(node, formatTypeString(calleeType)))
@@ -857,7 +858,9 @@ function getTypeVariableMappings(
   expectedType: Type
 ): [string, Type][] {
   // If type variable mapping is found, terminate early
-  if (expectedType.kind === 'variable') {
+  // note that the expected type is only a type variable
+  // if there is no type alias with the same name already saved in the type env
+  if (expectedType.kind === 'variable' && !lookupTypeAlias(expectedType.name, env)) {
     return [[expectedType.name, actualType]]
   }
   // If actual type is a type reference, expand type first

--- a/src/typeChecker/typeErrorChecker.ts
+++ b/src/typeChecker/typeErrorChecker.ts
@@ -604,6 +604,8 @@ function handleImportDeclarations(node: tsEs.Program) {
       const importedType = moduleTypesTextMap[importedName]
       if (!importedType) {
         context.errors.push(new NameNotFoundInModuleError(stmt, moduleName, importedName))
+        // Set imported name to be of type any to prevent further typecheck errors
+        setType(importedName, tAny, env)
         return
       }
 


### PR DESCRIPTION
Part of #1399

This PR adds a basic implementation of module type handling in Source Typed, using the `rune` module as an example. Source Typed is now able to properly handle types for runes, as well as throw errors when attempting to import a name that does not exist in the module.

Summary of implementation:
- A map of names available in the runes module to their respective type information is created (see `runeTypes.ts`). The map also contains an extra `prelude` attribute, which contains the types shared by variables and functions in the module (in this case, `Rune` and `AnimatedRune`). The type information in the map are in the form of Source Typed code strings (constant/function/type alias declarations) which can be evaluated by the Source Typed type checker. To hide the actual implementation of the module, the code in the map are placeholder code that only serves to save the correct types in the type environment when the code is evaluated. The types for the variables/functions are retrieved from the [rune module documentation](https://source-academy.github.io/modules/documentation/modules/rune.html).
- When encountering import statements that import from the `rune` module, the Source Typed type checker will fetch the prelude code + code for the names imported for that module, and evaluate the code as a program string. Following evaluation, the correct types for the module names will be saved in the type environment for use in the rest of the program.

Sample screenshots:
<img width="910" alt="Screenshot 2023-08-12 at 14 37 58" src="https://github.com/source-academy/js-slang/assets/54243224/286817e8-dbe5-4ace-9f5b-eb6983cdcab8">
<img width="840" alt="Screenshot 2023-08-12 at 14 36 56" src="https://github.com/source-academy/js-slang/assets/54243224/5be72182-c86c-46a9-a3dc-53bf03aaa56a">

To test this PR, link local js-slang to local frontend and write runes module code in any of the Source Typed chapters. Some unit tests have also been written.

To expand this proof-of-concept to an implementation that is extensible to all modules, the following needs to be done:
- The map of module names to types (`runeTypes.ts`) should be shifted to the modules repo. All future module type maps should be written in the modules repo instead and made available for fetching (e.g. as JSON files).
- The `TODO: Add logic for fetching module type declarations map from modules repo` code should be replaced with logic that fetches the module maps from the module repo as and when needed.

When writing module type maps, note the following:
- The map must contain a `prelude` attribute that contains code for the types shared by variables and functions in the module. If there are no shared types, an empty string should be provided.
- Code in the map should be placeholder code that hides the actual module implementation and only provides the correct types needed.
- The module map must contain all names in the module, else the `NameNotFoundInModule` error will be thrown for names that are not in the module map.
- Types in the map must be consistent with the [modules documentation](https://source-academy.github.io/modules/documentation/modules.html).

Limitations in the current approach:
- Since the placeholder value for runes is the string `'Rune'`, type errors will not be thrown if attempting to assign type `string` to the rune. This is an unfortunate result of hiding the module implementation using Source primitive values. One possible solution would be to add special placeholder type for modules, however this will likely require more extensive changes to Source Typed, and is currently out of scope for this PR.