### PR TITLE
Use POSIX paths on Windows systems

### DIFF
--- a/src/localImports/preprocessor.ts
+++ b/src/localImports/preprocessor.ts
@@ -1,5 +1,5 @@
 import es from 'estree'
-import * as path from 'path'
+import * as posixPath from 'path/posix'
 
 import { CannotFindModuleError, CircularImportError } from '../errors/localImportErrors'
 import { parse } from '../parser/parser'
@@ -39,11 +39,11 @@ export const getImportedLocalModulePaths = (
   program: es.Program,
   currentFilePath: string
 ): Set<string> => {
-  if (!path.isAbsolute(currentFilePath)) {
+  if (!posixPath.isAbsolute(currentFilePath)) {
     throw new Error(`Current file path '${currentFilePath}' is not absolute.`)
   }
 
-  const baseFilePath = path.resolve(currentFilePath, '..')
+  const baseFilePath = posixPath.resolve(currentFilePath, '..')
   const importedLocalModuleNames: Set<string> = new Set()
   const importDeclarations = program.body.filter(isImportDeclaration)
   importDeclarations.forEach((importDeclaration: es.ImportDeclaration): void => {
@@ -52,7 +52,7 @@ export const getImportedLocalModulePaths = (
       throw new Error('Module names must be strings.')
     }
     if (!isSourceModule(modulePath)) {
-      const absoluteModulePath = path.resolve(baseFilePath, modulePath)
+      const absoluteModulePath = posixPath.resolve(baseFilePath, modulePath)
       importedLocalModuleNames.add(absoluteModulePath)
     }
   })
@@ -192,7 +192,7 @@ const preprocessFileImports = (
   // We want to operate on the entrypoint program to get the eventual
   // preprocessed program.
   const entrypointProgram = programs[entrypointFilePath]
-  const entrypointDirPath = path.resolve(entrypointFilePath, '..')
+  const entrypointDirPath = posixPath.resolve(entrypointFilePath, '..')
 
   // Create variables to hold the imported statements.
   const entrypointProgramModuleDeclarations = entrypointProgram.body.filter(isModuleDeclaration)

--- a/src/localImports/transformers/transformProgramToFunctionDeclaration.ts
+++ b/src/localImports/transformers/transformProgramToFunctionDeclaration.ts
@@ -1,5 +1,5 @@
 import es from 'estree'
-import * as path from 'path'
+import * as posixPath from 'path/posix'
 
 import { defaultExportLookupName } from '../../stdlib/localImport.prelude'
 import {
@@ -50,7 +50,7 @@ export const getInvokedFunctionResultVariableNameToImportSpecifiersMap = (
     // current file path to get the absolute file path of the file to
     // be imported. Since the absolute file path is guaranteed to be
     // unique, it is also the canonical file path.
-    const importFilePath = path.resolve(currentDirPath, importSource)
+    const importFilePath = posixPath.resolve(currentDirPath, importSource)
     // Even though we limit the chars that can appear in Source file
     // paths, some chars in file paths (such as '/') cannot be used
     // in function names. As such, we substitute illegal chars with
@@ -287,7 +287,7 @@ export const transformProgramToFunctionDeclaration = (
   currentFilePath: string
 ): es.FunctionDeclaration => {
   const moduleDeclarations = program.body.filter(isModuleDeclaration)
-  const currentDirPath = path.resolve(currentFilePath, '..')
+  const currentDirPath = posixPath.resolve(currentFilePath, '..')
 
   // Create variables to hold the imported statements.
   const invokedFunctionResultVariableNameToImportSpecifiersMap =


### PR DESCRIPTION
## Context

> The default operation of the `node:path` module varies based on the operating system on which a Node.js application is running. Specifically, when running on a Windows operating system, the `node:path` module will assume that Windows-style paths are being used.
>
> -- https://nodejs.org/api/path.html#windows-vs-posix

While the above behaviour is useful when it comes to manipulating files on the host operating system (OS)'s filesystem, we want the preprocessor to make use of POSIX file paths because BrowserFS in the frontend is a POSIX filesystem.

Note that it is technically not wrong to make use of Windows file paths in the preprocessor, but this would introduce additional complexity into the tests (because they would need to handle file paths in both systems) as well as other parts of the preprocessor (because the Windows drive letter contains characters which are not valid JavaScript names). In fact, if js-slang were to support running multiple-file programs on the host OS in the future, this behaviour might even be necessary. However until that is the case, we should apply the [YAGNI principle](https://martinfowler.com/bliki/Yagni.html) to keep things simple.

## Changes

* Make use of the POSIX specific implementations of the `path` methods regardless of OS by importing from [`node:path/posix`](https://nodejs.org/api/path.html#pathposix)

## How to Test

There should be no change in behaviour on POSIX OSes. I will need someone using Windows to verify that the preprocessor tests all pass.