### PR TITLE
Fix evaluation error when no evaluation code is provided

### DIFF
--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -2095,6 +2095,8 @@ false ? 1 : 100 * factorial(100 - 1);
 "
 `;
 
+exports[`Evaluation of empty code and imports Evaluate empty program 1`] = `""`;
+
 exports[`Infinite recursion 1`] = `
 "function f() {
   return f();

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -1468,6 +1468,16 @@ describe(`#1342: Test the fix of #1341: Stepper limit off by one`, () => {
   })
 })
 
+describe(`Evaluation of empty code and imports`, () => {
+  test('Evaluate empty program', () => {
+    const code = ``
+    const program = parse(code, mockContext())!
+    const steps = getEvaluationSteps(program, mockContext(), 1000)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('')
+  })
+})
+
 // describe(`#1223: Stepper: Import statements cause errors`, () => {
 //   test('import a module and invoke its functions', () => {
 //     const code = `

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -3250,7 +3250,7 @@ export function getEvaluationSteps(
       reducedWithPath = reduceMain(reducedWithPath[0], context)
       i += 2
     }
-    if (!limitExceeded) {
+    if (!limitExceeded && steps.length > 0) {
       steps[steps.length - 1][2] = 'Evaluation complete'
     }
     return steps

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -3253,6 +3253,9 @@ export function getEvaluationSteps(
     if (!limitExceeded && steps.length > 0) {
       steps[steps.length - 1][2] = 'Evaluation complete'
     }
+    if (steps.length === 0) {
+      steps.push([reducedWithPath[0] as es.Program, [], 'Nothing to evaluate'])
+    }
     return steps
   } catch (error) {
     context.errors.push(error)


### PR DESCRIPTION
## Description

This PR aims to resolve a bug where if there is no code to be evaluated in the playground stepper, an error will be thrown in the page (see attached image below:)

![Screenshot 2023-08-23 at 11-49-10 Source Academy](https://github.com/source-academy/js-slang/assets/26355099/6ab29988-0618-4a78-8984-fc63d86fba4d)

The bug can be replicated by simply executing empty code in the playground stepper, or when modules are imported but no code has been provided, e.g.
```
import { heart } from "rune";
```

The first commit attempts to resolve the problem, but no useful information is provided back to the user (looks as if nothing has occurred) (maybe this could be detected and implemented via the frontend?), and thus the second commit will return an evaluation response with a message to signal that nothing has been evaluated (see images below):

<details>
<summary>New behaviour when nothing is evaluated (click to expand)</summary>

![Screenshot 2023-08-23 at 11-47-49 Source Academy](https://github.com/source-academy/js-slang/assets/26355099/7fcf22c6-0e8c-477d-839f-2d9d0675672a)

![Screenshot 2023-08-23 at 11-47-37 Source Academy](https://github.com/source-academy/js-slang/assets/26355099/ab1ae9ff-fef1-413a-9209-d389b870bac8)
</details>

If the second commit/user interaction feedback is not required (e.g. implemented in frontend), feel free to let me know and I will remove the commit from this PR.

## Testing
These changes have been tested locally, and no longer produces the error as shown above in the first image.