### PR TITLE
fix: `not declared` errors in source native variant REPL

### DIFF
--- a/src/runner/fullJSRunner.ts
+++ b/src/runner/fullJSRunner.ts
@@ -9,10 +9,15 @@ import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { hoistAndMergeImports } from '../localImports/transformers/hoistAndMergeImports'
 import { getRequireProvider, RequireProvider } from '../modules/requireProvider'
 import { parse } from '../parser/parser'
-import { evallerReplacer, getBuiltins, transpile } from '../transpiler/transpiler'
+import {
+  evallerReplacer,
+  getBuiltins,
+  getGloballyDeclaredIdentifiers,
+  transpile
+} from '../transpiler/transpiler'
 import type { Context, NativeStorage } from '../types'
 import * as create from '../utils/astCreator'
-import { getIdentifiersInProgram } from '../utils/uniqueIds'
+import { getFunctionDeclarationNamesInProgram } from '../utils/uniqueIds'
 import { toSourceError } from './errors'
 import { appendModulesToContext, resolvedErrorPromise } from './utils'
 
@@ -70,7 +75,10 @@ export async function fullJSRunner(
     ...preludeAndBuiltins,
     evallerReplacer(create.identifier(NATIVE_STORAGE_ID), new Set())
   ])
-  getIdentifiersInProgram(preEvalProgram).forEach(id =>
+  getFunctionDeclarationNamesInProgram(preEvalProgram).forEach(id =>
+    context.nativeStorage.previousProgramsIdentifiers.add(id)
+  )
+  getGloballyDeclaredIdentifiers(preEvalProgram).forEach(id =>
     context.nativeStorage.previousProgramsIdentifiers.add(id)
   )
   const preEvalCode: string = generate(preEvalProgram)

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -12,6 +12,7 @@ import { ModuleDocumentation } from '../modules/moduleTypes'
 import { AllowedDeclarations, Chapter, Context, NativeStorage, Variant } from '../types'
 import * as create from '../utils/astCreator'
 import {
+  getFunctionDeclarationNamesInProgram,
   getIdentifiersInNativeStorage,
   getIdentifiersInProgram,
   getUniqueId
@@ -678,6 +679,9 @@ function transpileToFullJS(
     globalIds.native
   )
 
+  getFunctionDeclarationNamesInProgram(program).forEach(id =>
+    context.nativeStorage.previousProgramsIdentifiers.add(id)
+  )
   getGloballyDeclaredIdentifiers(program).forEach(id =>
     context.nativeStorage.previousProgramsIdentifiers.add(id)
   )


### PR DESCRIPTION
Fixes #1477

## Description

When using the REPL with the Source Native variant, `UndefinedVariable` errors will be raised when trying to reference previously declared functions in the REPL.

This happens when a user first runs a program in the editor (via the "play" button) and subsequently tries to access the functions/variables in the REPL.

## The Cause

### `UndefinedVariable` Errors

The bug is due to the function and variable identifiers not being properly kept tracked of during the transpilation stage of a Source Native program. 

Declared functions and variables in a program are not added to the context (in `context.nativeStorage`) when executing a program. Hence, upon accessing previously declared functions/variables, an `UndefinedVariable` error will be raised as those declarations have been lost.

The fix would be add those declarations during the transpilation stage of a Source Native program:

https://github.com/source-academy/js-slang/blob/bf698f108b4f493040d829b0c2fa212f3b7b7a18/src/transpiler/transpiler.ts#L682-L687

## Why does `f;` not result in a `UndefinedVariable` error?

The bug is due to the use of `getIdentifiersInProgram` during the pre-evaluation stage of the `FullJSRunner`:

https://github.com/source-academy/js-slang/blob/afcff0d983b25788dbf972b69aa9912db0688a0f/src/runner/fullJSRunner.ts#L73-L75

The snippet above adds **all** identifiers in the program, which includes identifiers of arguments in a function declaration, into the program context.

It turns out some of the arguments we have in our `stdlib` functions are named `f`:

https://github.com/source-academy/js-slang/blob/bf698f108b4f493040d829b0c2fa212f3b7b7a18/src/stdlib/list.prelude.ts#L44-L51

**`f` works in Source Native 2-4 since the `list` is introduced in those chapters and not in Source Native 1.**

> The fix for this is the same for the error above. Instead of using `getIdentifiersInProgram` we specifically pick out function and variable declarations using `getFunctionDeclarationNamesInProgram` and `getGloballyDeclaredIdentifiers`
