### PR TITLE
Fix incorrect `function.name` for aliased imports

### DIFF
--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -195,7 +195,9 @@ function evaluateImports(
           }
 
           declareIdentifier(context, spec.local.name, node, environment)
-          defineVariable(context, spec.local.name, functions[spec.imported.name], true, node)
+          const importedObj = functions[spec.imported.name]
+          Object.defineProperty(importedObj, 'name', { value: spec.local.name })
+          defineVariable(context, spec.local.name, importedObj, true, node)
         }
       }
     })

--- a/src/runner/sourceRunner.ts
+++ b/src/runner/sourceRunner.ts
@@ -284,7 +284,7 @@ export async function sourceRunner(
     return runNative(program, context, theOptions)
   }
 
-  return runInterpreter(program!, context, theOptions)
+  return runInterpreter(program, context, theOptions)
 }
 
 export async function sourceFilesRunner(


### PR DESCRIPTION
Uses `Object.defineProperty` to set the correct `function.name` value for aliased imports in:

* ec-evaluator
* transpiler

Did not do so for `interpreter/interpreter.ts` due to the deprecation note in #1476.

### How to test

Consider the following program:

```js
import { play as asdf } from 'sound';

asdf("test");
```

Previously, this will result in the following error:

```
Error: play is expecting sound, but encountered test
```

Now, it will result in:

```
Error: asdf is expecting sound, but encountered test
```

---

Tested with:

* Source §1/2/3/4
* Source §1/2/3/4 Native
* Source §1/2/3/4 Typed
* Source §1/2 Lazy
* Source §4 Explicit-Control
* Full JS