### PR TITLE
Deprecate set-output in workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install -y texlive texlive-fonts-extra texlive-lang-cjk latexmk
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: yarn-cache
         with:


### PR DESCRIPTION
As the usage of `::set-output` has already been [deprecated by Github on 11 October 2022](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), they should be migrated to the new format using `$GITHUB_OUTPUT`.

Fixes #1481.