### PR TITLE
Fix nullary functions on the CSE machine

### DIFF
--- a/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator.ts.snap
+++ b/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator.ts.snap
@@ -45,6 +45,44 @@ foo();",
 }
 `;
 
+exports[`Nullary functions properly restore environment 1: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "function f() {
+  function g(t) {
+      return 0;
+  }
+  return g;
+}
+const h = f();
+h(100);",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 0,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
+exports[`Nullary functions properly restore environment 2: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "function f() {
+  const a = 1;
+  return a;
+}
+const a = f();
+a;",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 1,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`Simple tail call returns work: expectResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/ec-evaluator/__tests__/ec-evaluator.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator.ts
@@ -374,3 +374,33 @@ test('Conditional statements are value producing always', () => {
     optionEC3
   ).toMatchInlineSnapshot(`120`)
 })
+
+test('Nullary functions properly restore environment 1', () => {
+  return expectResult(
+    stripIndent`
+    function f() {
+      function g(t) {
+          return 0;
+      }
+      return g;
+    }
+    const h = f();
+    h(100);
+    `,
+    optionEC3
+  ).toMatchInlineSnapshot(`0`)
+})
+
+test('Nullary functions properly restore environment 2', () => {
+  return expectResult(
+    stripIndent`
+    function f() {
+      const a = 1;
+      return a;
+    }
+    const a = f();
+    a;
+    `,
+    optionEC3
+  ).toMatchInlineSnapshot(`1`)
+})

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -145,7 +145,6 @@ export function evaluate(program: es.Program, context: Context, options: IOption
       options.isPrelude
     )
   } catch (error) {
-    // console.error('ecerror:', error)
     return new ECError(error)
   } finally {
     context.runtime.isRunning = false
@@ -200,7 +199,6 @@ function evaluateImports(
       }
     })
   } catch (error) {
-    // console.log(error)
     handleRuntimeError(context, error)
   }
 }
@@ -816,7 +814,6 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       if (
         next &&
         !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) &&
-        args.length !== 0 &&
         agenda.some(isNode)
       ) {
         agenda.push(instr.envInstr(currentEnvironment(context), command.srcNode))


### PR DESCRIPTION
This pull request closes https://github.com/source-academy/js-slang/issues/1493.

Made a simple change to remove the check for function arguments when pushing environment instructions during application calls. The machine now always restores the original environment after function applications.

Also added 2 tests to the test suite to test if nullary functions properly restore their environments. These 2 code snippets fail on the current live version of Source Academy:

```
function f() {
    function g(t) {
        return 0;
    }
    return g;
}
const h = f();
h(100);
```

```
function f() {
  const a = 1;
  return a;
}
const a = f();
a;
```