### PR TITLE
CSE Machine: implement variable declaration check

### DIFF
--- a/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator-errors.ts.snap
+++ b/src/ec-evaluator/__tests__/__snapshots__/ec-evaluator-errors.ts.snap
@@ -1042,3 +1042,21 @@ Object {
   "visualiseListResult": Array [],
 }
 `;
+
+exports[`Undefined variables are caught even when unreached: expectParsedError 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "const a = 1;
+if (false) {
+  im_undefined;
+} else {
+  a;
+}",
+  "displayResult": Array [],
+  "numErrors": 1,
+  "parsedErrors": "Line 3: Name im_undefined not declared.",
+  "result": undefined,
+  "resultStatus": "error",
+  "visualiseListResult": Array [],
+}
+`;

--- a/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
+++ b/src/ec-evaluator/__tests__/ec-evaluator-errors.ts
@@ -51,6 +51,21 @@ test('Undefined variable error is thrown - verbose', () => {
           `)
 })
 
+const undefinedUnreachedVariable = stripIndent`
+const a = 1;
+if (false) {
+  im_undefined;
+} else {
+  a;
+}
+`
+
+test('Undefined variables are caught even when unreached', () => {
+  return expectParsedError(undefinedUnreachedVariable, optionEC).toMatchInlineSnapshot(
+    `"Line 3: Name im_undefined not declared."`
+  )
+})
+
 test('Undefined variable error message differs from verbose version', () => {
   return expectDifferentParsedErrors(undefinedVariable, undefinedVariableVerbose, optionEC).toBe(
     undefined

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -134,12 +134,16 @@ export class Stash extends Stack<Value> {
  */
 export function evaluate(program: es.Program, context: Context, options: IOptions): Value {
   try {
+    checkProgramForUndefinedVariables(program, context)
+  } catch (error) {
+    context.errors.push(error)
+    return new ECError(error)
+  }
+
+  try {
     context.runtime.isRunning = true
     context.runtime.agenda = new Agenda(program)
     context.runtime.stash = new Stash()
-
-    checkProgramForUndefinedVariables(program, context)
-
     return runECEMachine(
       context,
       context.runtime.agenda,

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -17,7 +17,6 @@ import Closure from '../interpreter/closure'
 import { UndefinedImportError } from '../modules/errors'
 import { initModuleContext, loadModuleBundle } from '../modules/moduleLoader'
 import { ImportTransformOptions } from '../modules/moduleTypes'
-import { parse } from '../parser/parser'
 import { checkEditorBreakpoints } from '../stdlib/inspector'
 import { checkProgramForUndefinedVariables } from '../transpiler/transpiler'
 import { Context, ContiguousArrayElements, Result, Value } from '../types'
@@ -26,13 +25,6 @@ import { filterImportDeclarations } from '../utils/ast/helpers'
 import * as ast from '../utils/astCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
-import {
-  getFunctionDeclarationNamesInProgram,
-  getIdentifiersInNativeStorage,
-  getIdentifiersInProgram,
-  getUniqueId
-} from '../utils/uniqueIds'
-import { ancestor } from '../utils/walkers'
 import * as instr from './instrCreator'
 import {
   AgendaItem,

--- a/src/ec-evaluator/interpreter.ts
+++ b/src/ec-evaluator/interpreter.ts
@@ -69,6 +69,9 @@ import {
   Stack,
   valueProducing
 } from './utils'
+import { parse } from '../parser/parser'
+import { ancestor } from '../utils/walkers'
+import { getIdentifiersInProgram, getIdentifiersInNativeStorage, getFunctionDeclarationNamesInProgram, getUniqueId } from '../utils/uniqueIds'
 
 type CmdEvaluator = (
   command: AgendaItem,
@@ -123,6 +126,136 @@ export class Stash extends Stack<Value> {
   }
 }
 
+const globalIdNames = [
+  'native',
+  'callIfFuncAndRightArgs',
+  'boolOrErr',
+  'wrap',
+  'wrapSourceModule',
+  'unaryOp',
+  'binaryOp',
+  'throwIfTimeout',
+  'setProp',
+  'getProp',
+  'builtins'
+] as const
+type NativeIds = Record<typeof globalIdNames[number], es.Identifier>
+
+function getNativeIds(program: es.Program, usedIdentifiers: Set<string>): NativeIds {
+  const globalIds = {}
+  for (const identifier of globalIdNames) {
+    globalIds[identifier] = ast.identifier(getUniqueId(usedIdentifiers, identifier))
+  }
+  return globalIds as NativeIds
+}
+
+/**
+ * Function that checks a program, prior to running, for any undefined variables. Copied from src/stepper/stepper.ts.
+ * TODO: put this function in src/utils
+ */
+function checkForUndefinedVariables(program: es.Program, context: Context) {
+  const usedIdentifiers = new Set<string>([
+    ...getIdentifiersInProgram(program),
+    ...getIdentifiersInNativeStorage(context.nativeStorage)
+  ])
+  const globalIds = getNativeIds(program, usedIdentifiers)
+
+  const preludes = context.prelude
+    ? getFunctionDeclarationNamesInProgram(parse(context.prelude, context)!)
+    : new Set<String>()
+  const builtins = context.nativeStorage.builtins
+  const identifiersIntroducedByNode = new Map<es.Node, Set<string>>()
+  function processBlock(node: es.Program | es.BlockStatement) {
+    const identifiers = new Set<string>()
+    for (const statement of node.body) {
+      if (statement.type === 'VariableDeclaration') {
+        identifiers.add((statement.declarations[0].id as es.Identifier).name)
+      } else if (statement.type === 'FunctionDeclaration') {
+        if (statement.id === null) {
+          throw new Error(
+            'Encountered a FunctionDeclaration node without an identifier. This should have been caught when parsing.'
+          )
+        }
+        identifiers.add(statement.id.name)
+      } else if (statement.type === 'ImportDeclaration') {
+        for (const specifier of statement.specifiers) {
+          identifiers.add(specifier.local.name)
+        }
+      }
+    }
+    identifiersIntroducedByNode.set(node, identifiers)
+  }
+  function processFunction(
+    node: es.FunctionDeclaration | es.ArrowFunctionExpression,
+    _ancestors: es.Node[]
+  ) {
+    identifiersIntroducedByNode.set(
+      node,
+      new Set(
+        node.params.map(id =>
+          id.type === 'Identifier'
+            ? id.name
+            : ((id as es.RestElement).argument as es.Identifier).name
+        )
+      )
+    )
+  }
+  const identifiersToAncestors = new Map<es.Identifier, es.Node[]>()
+  ancestor(program, {
+    Program: processBlock,
+    BlockStatement: processBlock,
+    FunctionDeclaration: processFunction,
+    ArrowFunctionExpression: processFunction,
+    ForStatement(forStatement: es.ForStatement, ancestors: es.Node[]) {
+      const init = forStatement.init!
+      if (init.type === 'VariableDeclaration') {
+        identifiersIntroducedByNode.set(
+          forStatement,
+          new Set([(init.declarations[0].id as es.Identifier).name])
+        )
+      }
+    },
+    Identifier(identifier: es.Identifier, ancestors: es.Node[]) {
+      identifiersToAncestors.set(identifier, [...ancestors])
+    },
+    Pattern(node: es.Pattern, ancestors: es.Node[]) {
+      if (node.type === 'Identifier') {
+        identifiersToAncestors.set(node, [...ancestors])
+      } else if (node.type === 'MemberExpression') {
+        if (node.object.type === 'Identifier') {
+          identifiersToAncestors.set(node.object, [...ancestors])
+        }
+      }
+    }
+  })
+  const nativeInternalNames = new Set(Object.values(globalIds).map(({ name }) => name))
+
+  for (const [identifier, ancestors] of identifiersToAncestors) {
+    const name = identifier.name
+    const isCurrentlyDeclared = ancestors.some(a => identifiersIntroducedByNode.get(a)?.has(name))
+    if (isCurrentlyDeclared) {
+      continue
+    }
+    const isPreviouslyDeclared = context.nativeStorage.previousProgramsIdentifiers.has(name)
+    if (isPreviouslyDeclared) {
+      continue
+    }
+    const isBuiltin = builtins.has(name)
+    if (isBuiltin) {
+      continue
+    }
+    const isPrelude = preludes.has(name)
+    if (isPrelude) {
+      continue
+    }
+    const isNativeId = nativeInternalNames.has(name)
+    if (!isNativeId) {
+      throw new errors.UndefinedVariable(name, identifier)
+    }
+  }
+}
+
+
 /**
  * Function to be called when a program is to be interpreted using
  * the explicit control evaluator.
@@ -136,6 +269,9 @@ export function evaluate(program: es.Program, context: Context, options: IOption
     context.runtime.isRunning = true
     context.runtime.agenda = new Agenda(program)
     context.runtime.stash = new Stash()
+
+    checkForUndefinedVariables(program, context)
+
     return runECEMachine(
       context,
       context.runtime.agenda,

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -29,13 +29,6 @@ import {
 } from '../utils/dummyAstCreator'
 import { evaluateBinaryExpression, evaluateUnaryExpression } from '../utils/operators'
 import * as rttc from '../utils/rttc'
-import {
-  getFunctionDeclarationNamesInProgram,
-  getIdentifiersInNativeStorage,
-  getIdentifiersInProgram,
-  getUniqueId
-} from '../utils/uniqueIds'
-import { ancestor } from '../utils/walkers'
 import { nodeToValue, objectToString, valueToExpression } from './converter'
 import * as builtin from './lib'
 import {

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -7,6 +7,7 @@ import { UndefinedImportError } from '../modules/errors'
 import { initModuleContextAsync, loadModuleBundleAsync } from '../modules/moduleLoaderAsync'
 import type { ImportTransformOptions } from '../modules/moduleTypes'
 import { parse } from '../parser/parser'
+import { checkProgramForUndefinedVariables } from '../transpiler/transpiler'
 import {
   BlockExpression,
   Context,
@@ -3206,131 +3207,6 @@ async function evaluateImports(
   program.body = otherNodes
 }
 
-const globalIdNames = [
-  'native',
-  'callIfFuncAndRightArgs',
-  'boolOrErr',
-  'wrap',
-  'wrapSourceModule',
-  'unaryOp',
-  'binaryOp',
-  'throwIfTimeout',
-  'setProp',
-  'getProp',
-  'builtins'
-] as const
-type NativeIds = Record<typeof globalIdNames[number], es.Identifier>
-
-function getNativeIds(program: es.Program, usedIdentifiers: Set<string>): NativeIds {
-  const globalIds = {}
-  for (const identifier of globalIdNames) {
-    globalIds[identifier] = ast.identifier(getUniqueId(usedIdentifiers, identifier))
-  }
-  return globalIds as NativeIds
-}
-
-function checkForUndefinedVariables(program: es.Program, context: Context) {
-  const usedIdentifiers = new Set<string>([
-    ...getIdentifiersInProgram(program),
-    ...getIdentifiersInNativeStorage(context.nativeStorage)
-  ])
-  const globalIds = getNativeIds(program, usedIdentifiers)
-
-  const preludes = context.prelude
-    ? getFunctionDeclarationNamesInProgram(parse(context.prelude, context)!)
-    : new Set<String>()
-  const builtins = context.nativeStorage.builtins
-  const identifiersIntroducedByNode = new Map<es.Node, Set<string>>()
-  function processBlock(node: es.Program | es.BlockStatement) {
-    const identifiers = new Set<string>()
-    for (const statement of node.body) {
-      if (statement.type === 'VariableDeclaration') {
-        identifiers.add((statement.declarations[0].id as es.Identifier).name)
-      } else if (statement.type === 'FunctionDeclaration') {
-        if (statement.id === null) {
-          throw new Error(
-            'Encountered a FunctionDeclaration node without an identifier. This should have been caught when parsing.'
-          )
-        }
-        identifiers.add(statement.id.name)
-      } else if (statement.type === 'ImportDeclaration') {
-        for (const specifier of statement.specifiers) {
-          identifiers.add(specifier.local.name)
-        }
-      }
-    }
-    identifiersIntroducedByNode.set(node, identifiers)
-  }
-  function processFunction(
-    node: es.FunctionDeclaration | es.ArrowFunctionExpression,
-    _ancestors: es.Node[]
-  ) {
-    identifiersIntroducedByNode.set(
-      node,
-      new Set(
-        node.params.map(id =>
-          id.type === 'Identifier'
-            ? id.name
-            : ((id as es.RestElement).argument as es.Identifier).name
-        )
-      )
-    )
-  }
-  const identifiersToAncestors = new Map<es.Identifier, es.Node[]>()
-  ancestor(program, {
-    Program: processBlock,
-    BlockStatement: processBlock,
-    FunctionDeclaration: processFunction,
-    ArrowFunctionExpression: processFunction,
-    ForStatement(forStatement: es.ForStatement, ancestors: es.Node[]) {
-      const init = forStatement.init!
-      if (init.type === 'VariableDeclaration') {
-        identifiersIntroducedByNode.set(
-          forStatement,
-          new Set([(init.declarations[0].id as es.Identifier).name])
-        )
-      }
-    },
-    Identifier(identifier: es.Identifier, ancestors: es.Node[]) {
-      identifiersToAncestors.set(identifier, [...ancestors])
-    },
-    Pattern(node: es.Pattern, ancestors: es.Node[]) {
-      if (node.type === 'Identifier') {
-        identifiersToAncestors.set(node, [...ancestors])
-      } else if (node.type === 'MemberExpression') {
-        if (node.object.type === 'Identifier') {
-          identifiersToAncestors.set(node.object, [...ancestors])
-        }
-      }
-    }
-  })
-  const nativeInternalNames = new Set(Object.values(globalIds).map(({ name }) => name))
-
-  for (const [identifier, ancestors] of identifiersToAncestors) {
-    const name = identifier.name
-    const isCurrentlyDeclared = ancestors.some(a => identifiersIntroducedByNode.get(a)?.has(name))
-    if (isCurrentlyDeclared) {
-      continue
-    }
-    const isPreviouslyDeclared = context.nativeStorage.previousProgramsIdentifiers.has(name)
-    if (isPreviouslyDeclared) {
-      continue
-    }
-    const isBuiltin = builtins.has(name)
-    if (isBuiltin) {
-      continue
-    }
-    const isPrelude = preludes.has(name)
-    if (isPrelude) {
-      continue
-    }
-    const isNativeId = nativeInternalNames.has(name)
-    if (!isNativeId) {
-      throw new errors.UndefinedVariable(name, identifier)
-    }
-  }
-}
-
 // the context here is for builtins
 export async function getEvaluationSteps(
   program: es.Program,
@@ -3339,7 +3215,7 @@ export async function getEvaluationSteps(
 ): Promise<[es.Program, string[][], string][]> {
   const steps: [es.Program, string[][], string][] = []
   try {
-    checkForUndefinedVariables(program, context)
+    checkProgramForUndefinedVariables(program, context)
     const limit = stepLimit === undefined ? 1000 : stepLimit % 2 === 0 ? stepLimit : stepLimit + 1
     await evaluateImports(program, context, importOptions)
     // starts with substituting predefined constants

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -551,7 +551,7 @@ export function checkProgramForUndefinedVariables(program: es.Program, context: 
     if (isPrelude) {
       continue
     }
-    const isInEnv = (name in env)
+    const isInEnv = name in env
     if (isInEnv) {
       continue
     }

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -452,6 +452,19 @@ export function checkForUndefinedVariables(
   }
 }
 
+export function checkProgramForUndefinedVariables(
+  program: es.Program,
+  context: Context
+) {
+  const usedIdentifiers = new Set<string>([
+    ...getIdentifiersInProgram(program),
+    ...getIdentifiersInNativeStorage(context.nativeStorage)
+  ])
+  const globalIds = getNativeIds(program, usedIdentifiers)
+
+  checkForUndefinedVariables(program, context.nativeStorage, globalIds, false)
+}
+
 function transformSomeExpressionsToCheckIfBoolean(program: es.Program, globalIds: NativeIds) {
   function transform(
     node:

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -15,6 +15,7 @@ import {
   memoizedGetModuleManifestAsync
 } from '../modules/moduleLoaderAsync'
 import type { ImportTransformOptions } from '../modules/moduleTypes'
+import { parse } from '../parser/parser'
 import {
   AllowedDeclarations,
   Chapter,
@@ -459,9 +460,101 @@ export function checkProgramForUndefinedVariables(program: es.Program, context: 
   ])
   const globalIds = getNativeIds(program, usedIdentifiers)
 
-  checkForUndefinedVariables(program, context.nativeStorage, globalIds, false)
-}
+  const preludes = context.prelude
+    ? getFunctionDeclarationNamesInProgram(parse(context.prelude, context)!)
+    : new Set<String>()
 
+  const builtins = context.nativeStorage.builtins
+  const identifiersIntroducedByNode = new Map<es.Node, Set<string>>()
+  function processBlock(node: es.Program | es.BlockStatement) {
+    const identifiers = new Set<string>()
+    for (const statement of node.body) {
+      if (statement.type === 'VariableDeclaration') {
+        identifiers.add((statement.declarations[0].id as es.Identifier).name)
+      } else if (statement.type === 'FunctionDeclaration') {
+        if (statement.id === null) {
+          throw new Error(
+            'Encountered a FunctionDeclaration node without an identifier. This should have been caught when parsing.'
+          )
+        }
+        identifiers.add(statement.id.name)
+      } else if (statement.type === 'ImportDeclaration') {
+        for (const specifier of statement.specifiers) {
+          identifiers.add(specifier.local.name)
+        }
+      }
+    }
+    identifiersIntroducedByNode.set(node, identifiers)
+  }
+  function processFunction(
+    node: es.FunctionDeclaration | es.ArrowFunctionExpression,
+    _ancestors: es.Node[]
+  ) {
+    identifiersIntroducedByNode.set(
+      node,
+      new Set(
+        node.params.map(id =>
+          id.type === 'Identifier'
+            ? id.name
+            : ((id as es.RestElement).argument as es.Identifier).name
+        )
+      )
+    )
+  }
+  const identifiersToAncestors = new Map<es.Identifier, es.Node[]>()
+  ancestor(program, {
+    Program: processBlock,
+    BlockStatement: processBlock,
+    FunctionDeclaration: processFunction,
+    ArrowFunctionExpression: processFunction,
+    ForStatement(forStatement: es.ForStatement, ancestors: es.Node[]) {
+      const init = forStatement.init!
+      if (init.type === 'VariableDeclaration') {
+        identifiersIntroducedByNode.set(
+          forStatement,
+          new Set([(init.declarations[0].id as es.Identifier).name])
+        )
+      }
+    },
+    Identifier(identifier: es.Identifier, ancestors: es.Node[]) {
+      identifiersToAncestors.set(identifier, [...ancestors])
+    },
+    Pattern(node: es.Pattern, ancestors: es.Node[]) {
+      if (node.type === 'Identifier') {
+        identifiersToAncestors.set(node, [...ancestors])
+      } else if (node.type === 'MemberExpression') {
+        if (node.object.type === 'Identifier') {
+          identifiersToAncestors.set(node.object, [...ancestors])
+        }
+      }
+    }
+  })
+  const nativeInternalNames = new Set(Object.values(globalIds).map(({ name }) => name))
+
+  for (const [identifier, ancestors] of identifiersToAncestors) {
+    const name = identifier.name
+    const isCurrentlyDeclared = ancestors.some(a => identifiersIntroducedByNode.get(a)?.has(name))
+    if (isCurrentlyDeclared) {
+      continue
+    }
+    const isPreviouslyDeclared = context.nativeStorage.previousProgramsIdentifiers.has(name)
+    if (isPreviouslyDeclared) {
+      continue
+    }
+    const isBuiltin = builtins.has(name)
+    if (isBuiltin) {
+      continue
+    }
+    const isPrelude = preludes.has(name)
+    if (isPrelude) {
+      continue
+    }
+    const isNativeId = nativeInternalNames.has(name)
+    if (!isNativeId) {
+      throw new UndefinedVariable(name, identifier)
+    }
+  }
+}
 function transformSomeExpressionsToCheckIfBoolean(program: es.Program, globalIds: NativeIds) {
   function transform(
     node:

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -465,6 +465,8 @@ export function checkProgramForUndefinedVariables(program: es.Program, context: 
     : new Set<String>()
 
   const builtins = context.nativeStorage.builtins
+  const env = context.runtime.environments[0].head
+
   const identifiersIntroducedByNode = new Map<es.Node, Set<string>>()
   function processBlock(node: es.Program | es.BlockStatement) {
     const identifiers = new Set<string>()
@@ -547,6 +549,10 @@ export function checkProgramForUndefinedVariables(program: es.Program, context: 
     }
     const isPrelude = preludes.has(name)
     if (isPrelude) {
+      continue
+    }
+    const isInEnv = (name in env)
+    if (isInEnv) {
       continue
     }
     const isNativeId = nativeInternalNames.has(name)

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -452,10 +452,7 @@ export function checkForUndefinedVariables(
   }
 }
 
-export function checkProgramForUndefinedVariables(
-  program: es.Program,
-  context: Context
-) {
+export function checkProgramForUndefinedVariables(program: es.Program, context: Context) {
   const usedIdentifiers = new Set<string>([
     ...getIdentifiersInProgram(program),
     ...getIdentifiersInNativeStorage(context.nativeStorage)


### PR DESCRIPTION
# Description:
In the stepper and transpiler, the function `checkForUndefinedVariables` ensures that all variables used in the program are declared before the program is run. The CSE machine does not include this check, meaning that some programs containing undeclared variables run normally if such variables are never accessed. This PR implements a version of  `checkForUndefinedVariables` for the CSE machine, which the stepper can also utilize.

# Changes:

- [X] implement  `checkProgramForUndefinedVariables` for the stepper and CSE machine