### PR TITLE
CSE Machine: `hasXStatement` fixes

### DIFF
--- a/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
@@ -42,11 +42,15 @@ Object {
       i = i + 1;
       if (i === 1) {
         i = 1;
+        i = 1;
       } else if (i === 2) {
+        i = 2;
         continue;
       } else if (i === 3) {
+        i = 3;
         return i;
       } else if (i === 4) {
+        i = 4;
         break;
       }
   }

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
@@ -33,6 +33,30 @@ c;",
 }
 `;
 
+exports[`Breaks and continues are detected properly inside loops: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "let i = 0;
+while(i < 10) {
+    i = i + 1;
+    if (i === 1) {
+        break;
+    } else if (i === 2) {
+        i = i + 1;
+    } else {
+        continue;
+    }
+}
+i;",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 1,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`Conditional statements are value producing always: expectResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
@@ -33,25 +33,30 @@ c;",
 }
 `;
 
-exports[`Breaks and continues are detected properly inside loops: expectResult 1`] = `
+exports[`Breaks, continues and returns are detected properly inside loops: expectResult 1`] = `
 Object {
   "alertResult": Array [],
-  "code": "let i = 0;
-while(i < 10) {
-    i = i + 1;
-    if (i === 1) {
-        break;
-    } else if (i === 2) {
-        i = i + 1;
-    } else {
+  "code": "function f() {
+  let i = 0;
+  while(i < 10) {
+      i = i + 1;
+      if (i === 1) {
+        i = 1;
+      } else if (i === 2) {
         continue;
-    }
+      } else if (i === 3) {
+        return i;
+      } else if (i === 4) {
+        break;
+      }
+  }
+  return i;
 }
-i;",
+f();",
   "displayResult": Array [],
   "numErrors": 0,
   "parsedErrors": "",
-  "result": 1,
+  "result": 3,
   "resultStatus": "finished",
   "visualiseListResult": Array [],
 }

--- a/src/cse-machine/__tests__/cse-machine.ts
+++ b/src/cse-machine/__tests__/cse-machine.ts
@@ -431,3 +431,23 @@ test('Array literals are unpacked in the correct order', () => {
     optionEC3
   ).toMatchInlineSnapshot(`123`)
 })
+
+test('Breaks and continues are detected properly inside loops', () => {
+  return expectResult(
+    stripIndent`
+    let i = 0;
+    while(i < 10) {
+        i = i + 1;
+        if (i === 1) {
+            break;
+        } else if (i === 2) {
+            i = i + 1;
+        } else {
+            continue;
+        }
+    }
+    i;
+    `,
+    optionEC3
+  ).toMatchInlineSnapshot(`1`)
+})

--- a/src/cse-machine/__tests__/cse-machine.ts
+++ b/src/cse-machine/__tests__/cse-machine.ts
@@ -441,11 +441,15 @@ test('Breaks, continues and returns are detected properly inside loops', () => {
           i = i + 1;
           if (i === 1) {
             i = 1;
+            i = 1;
           } else if (i === 2) {
+            i = 2;
             continue;
           } else if (i === 3) {
+            i = 3;
             return i;
           } else if (i === 4) {
+            i = 4;
             break;
           }
       }

--- a/src/cse-machine/__tests__/cse-machine.ts
+++ b/src/cse-machine/__tests__/cse-machine.ts
@@ -432,22 +432,27 @@ test('Array literals are unpacked in the correct order', () => {
   ).toMatchInlineSnapshot(`123`)
 })
 
-test('Breaks and continues are detected properly inside loops', () => {
+test('Breaks, continues and returns are detected properly inside loops', () => {
   return expectResult(
     stripIndent`
-    let i = 0;
-    while(i < 10) {
-        i = i + 1;
-        if (i === 1) {
-            break;
-        } else if (i === 2) {
-            i = i + 1;
-        } else {
+    function f() {
+      let i = 0;
+      while(i < 10) {
+          i = i + 1;
+          if (i === 1) {
+            i = 1;
+          } else if (i === 2) {
             continue;
-        }
+          } else if (i === 3) {
+            return i;
+          } else if (i === 4) {
+            break;
+          }
+      }
+      return i;
     }
-    i;
+    f();
     `,
     optionEC3
-  ).toMatchInlineSnapshot(`1`)
+  ).toMatchInlineSnapshot(`3`)
 })

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -508,9 +508,9 @@ export const hasReturnStatementIf = (statement: es.IfStatement): boolean => {
   // Parser enforces that if/else have braces (block statement)
   hasReturn = hasReturn || hasReturnStatement(statement.consequent as es.BlockStatement)
   if (statement.alternate) {
-    if (statement.alternate.type === 'IfStatement') {
+    if (isIfStatement(statement.alternate)) {
       hasReturn = hasReturn || hasReturnStatementIf(statement.alternate as es.IfStatement)
-    } else if (statement.alternate.type === 'BlockStatement') {
+    } else if (isBlockStatement(statement.alternate)) {
       hasReturn = hasReturn || hasReturnStatement(statement.alternate as es.BlockStatement)
     }
   }
@@ -520,15 +520,15 @@ export const hasReturnStatementIf = (statement: es.IfStatement): boolean => {
 export const hasReturnStatement = (block: es.BlockStatement): boolean => {
   let hasReturn = false
   for (const statement of block.body) {
-    if (statement.type === 'ReturnStatement') {
+    if (isReturnStatement(statement)) {
       hasReturn = true
-    } else if (statement.type === 'IfStatement') {
+    } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
       hasReturn = hasReturn || hasReturnStatement(statement.consequent as es.BlockStatement)
       if (statement.alternate) {
-        if (statement.alternate.type === 'IfStatement') {
+        if (isIfStatement(statement.alternate)) {
           hasReturn = hasReturn || hasReturnStatementIf(statement.alternate as es.IfStatement)
-        } else if (statement.alternate.type === 'BlockStatement') {
+        } else if (isBlockStatement(statement.alternate)) {
           hasReturn = hasReturn || hasReturnStatement(statement.alternate as es.BlockStatement)
         }
       }
@@ -546,9 +546,9 @@ export const hasBreakStatementIf = (statement: es.IfStatement): boolean => {
   // Parser enforces that if/else have braces (block statement)
   hasBreak = hasBreak || hasBreakStatement(statement.consequent as es.BlockStatement)
   if (statement.alternate) {
-    if (statement.alternate.type === 'IfStatement') {
+    if (isIfStatement(statement.alternate)) {
       hasBreak = hasBreak || hasBreakStatementIf(statement.alternate as es.IfStatement)
-    } else if (statement.alternate.type === 'BlockStatement') {
+    } else if (isBlockStatement(statement.alternate)) {
       hasBreak = hasBreak || hasBreakStatement(statement.alternate as es.BlockStatement)
     }
   }
@@ -560,13 +560,13 @@ export const hasBreakStatement = (block: es.BlockStatement): boolean => {
   for (const statement of block.body) {
     if (statement.type === 'BreakStatement') {
       hasBreak = true
-    } else if (statement.type === 'IfStatement') {
+    } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
       hasBreak = hasBreak || hasBreakStatement(statement.consequent as es.BlockStatement)
       if (statement.alternate) {
-        if (statement.alternate.type === 'IfStatement') {
+        if (isIfStatement(statement.alternate)) {
           hasBreak = hasBreak || hasBreakStatementIf(statement.alternate as es.IfStatement)
-        } else if (statement.alternate.type === 'BlockStatement') {
+        } else if (isBlockStatement(statement.alternate)) {
           hasBreak = hasBreak || hasBreakStatement(statement.alternate as es.BlockStatement)
         }
       }
@@ -580,9 +580,9 @@ export const hasContinueStatementIf = (statement: es.IfStatement): boolean => {
   // Parser enforces that if/else have braces (block statement)
   hasContinue = hasContinue || hasContinueStatement(statement.consequent as es.BlockStatement)
   if (statement.alternate) {
-    if (statement.alternate.type === 'IfStatement') {
+    if (isIfStatement(statement.alternate)) {
       hasContinue = hasContinue || hasContinueStatementIf(statement.alternate as es.IfStatement)
-    } else if (statement.alternate.type === 'BlockStatement') {
+    } else if (isBlockStatement(statement.alternate)) {
       hasContinue = hasContinue || hasContinueStatement(statement.alternate as es.BlockStatement)
     }
   }
@@ -594,13 +594,13 @@ export const hasContinueStatement = (block: es.BlockStatement): boolean => {
   for (const statement of block.body) {
     if (statement.type === 'ContinueStatement') {
       hasContinue = true
-    } else if (statement.type === 'IfStatement') {
+    } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
       hasContinue = hasContinue || hasContinueStatement(statement.consequent as es.BlockStatement)
       if (statement.alternate) {
-        if (statement.alternate.type === 'IfStatement') {
+        if (isIfStatement(statement.alternate)) {
           hasContinue = hasContinue || hasContinueStatementIf(statement.alternate as es.IfStatement)
-        } else if (statement.alternate.type === 'BlockStatement') {
+        } else if (isBlockStatement(statement.alternate)) {
           hasContinue =
             hasContinue || hasContinueStatement(statement.alternate as es.BlockStatement)
         }

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -532,6 +532,10 @@ export const hasReturnStatement = (block: es.BlockStatement): boolean => {
           hasReturn = hasReturn || hasReturnStatement(statement.alternate as es.BlockStatement)
         }
       }
+    } else if (statement.type === 'ForStatement') {
+      hasReturn = hasReturn || hasReturnStatement(statement.body as es.BlockStatement)
+    } else if (statement.type === 'WhileStatement') {
+      hasReturn = hasReturn || hasReturnStatement(statement.body as es.BlockStatement)
     }
   }
   return hasReturn

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -503,20 +503,30 @@ export const checkStackOverFlow = (context: Context, control: Control) => {
   }
 }
 
+/**
+ * Checks whether an `if` statement returns in every possible branch.
+ * @param body The `if` statement to be checked
+ * @return `true` if every branch has a return statement, else `false`.
+ */
 export const hasReturnStatementIf = (statement: es.IfStatement): boolean => {
-  let hasReturn = false
+  let hasReturn = true
   // Parser enforces that if/else have braces (block statement)
-  hasReturn = hasReturn || hasReturnStatement(statement.consequent as es.BlockStatement)
+  hasReturn = hasReturn && hasReturnStatement(statement.consequent as es.BlockStatement)
   if (statement.alternate) {
     if (isIfStatement(statement.alternate)) {
-      hasReturn = hasReturn || hasReturnStatementIf(statement.alternate as es.IfStatement)
+      hasReturn = hasReturn && hasReturnStatementIf(statement.alternate as es.IfStatement)
     } else if (isBlockStatement(statement.alternate)) {
-      hasReturn = hasReturn || hasReturnStatement(statement.alternate as es.BlockStatement)
+      hasReturn = hasReturn && hasReturnStatement(statement.alternate as es.BlockStatement)
     }
   }
   return hasReturn
 }
 
+/**
+ * Checks whether a block returns in every possible branch.
+ * @param body The block to be checked
+ * @return `true` if every branch has a return statement, else `false`.
+ */
 export const hasReturnStatement = (block: es.BlockStatement): boolean => {
   let hasReturn = false
   for (const statement of block.body) {
@@ -524,18 +534,7 @@ export const hasReturnStatement = (block: es.BlockStatement): boolean => {
       hasReturn = true
     } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
-      hasReturn = hasReturn || hasReturnStatement(statement.consequent as es.BlockStatement)
-      if (statement.alternate) {
-        if (isIfStatement(statement.alternate)) {
-          hasReturn = hasReturn || hasReturnStatementIf(statement.alternate as es.IfStatement)
-        } else if (isBlockStatement(statement.alternate)) {
-          hasReturn = hasReturn || hasReturnStatement(statement.alternate as es.BlockStatement)
-        }
-      }
-    } else if (statement.type === 'ForStatement') {
-      hasReturn = hasReturn || hasReturnStatement(statement.body as es.BlockStatement)
-    } else if (statement.type === 'WhileStatement') {
-      hasReturn = hasReturn || hasReturnStatement(statement.body as es.BlockStatement)
+      hasReturn = hasReturn || hasReturnStatementIf(statement as es.IfStatement)
     }
   }
   return hasReturn
@@ -555,6 +554,11 @@ export const hasBreakStatementIf = (statement: es.IfStatement): boolean => {
   return hasBreak
 }
 
+/**
+ * Checks whether a block has a `break` statement.
+ * @param body The block to be checked
+ * @return `true` if there is a `break` statement, else `false`.
+ */
 export const hasBreakStatement = (block: es.BlockStatement): boolean => {
   let hasBreak = false
   for (const statement of block.body) {
@@ -562,14 +566,7 @@ export const hasBreakStatement = (block: es.BlockStatement): boolean => {
       hasBreak = true
     } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
-      hasBreak = hasBreak || hasBreakStatement(statement.consequent as es.BlockStatement)
-      if (statement.alternate) {
-        if (isIfStatement(statement.alternate)) {
-          hasBreak = hasBreak || hasBreakStatementIf(statement.alternate as es.IfStatement)
-        } else if (isBlockStatement(statement.alternate)) {
-          hasBreak = hasBreak || hasBreakStatement(statement.alternate as es.BlockStatement)
-        }
-      }
+      hasBreak = hasBreak || hasBreakStatementIf(statement as es.IfStatement)
     }
   }
   return hasBreak
@@ -589,6 +586,11 @@ export const hasContinueStatementIf = (statement: es.IfStatement): boolean => {
   return hasContinue
 }
 
+/**
+ * Checks whether a block has a `continue` statement.
+ * @param body The block to be checked
+ * @return `true` if there is a `continue` statement, else `false`.
+ */
 export const hasContinueStatement = (block: es.BlockStatement): boolean => {
   let hasContinue = false
   for (const statement of block.body) {
@@ -596,15 +598,7 @@ export const hasContinueStatement = (block: es.BlockStatement): boolean => {
       hasContinue = true
     } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
-      hasContinue = hasContinue || hasContinueStatement(statement.consequent as es.BlockStatement)
-      if (statement.alternate) {
-        if (isIfStatement(statement.alternate)) {
-          hasContinue = hasContinue || hasContinueStatementIf(statement.alternate as es.IfStatement)
-        } else if (isBlockStatement(statement.alternate)) {
-          hasContinue =
-            hasContinue || hasContinueStatement(statement.alternate as es.BlockStatement)
-        }
-      }
+      hasContinue = hasContinue || hasContinueStatementIf(statement as es.IfStatement)
     }
   }
   return hasContinue


### PR DESCRIPTION
# Description:

The functions `hasContinueStatement`, `hasReturnStatement` and `hasBreakStatement` are used to detect `continue`, `return` and `break` statements. These functions expect a block statement and recurse into `if` statements, meaning they fail on `else if` constructs since these constructs nest an `if` statement inside an `if` statement.

This PR adds variants of the above functions ( `hasContinueStatementIf`, `hasReturnStatementIf` and `hasBreakStatementIf`) so that `else if` constructs can now be properly recursed into.

# Changes:

- [X] Add `hasContinueStatementIf`, `hasReturnStatementIf` and `hasBreakStatementIf`
- [X] Fix `hasContinueStatement`, `hasReturnStatement` and `hasBreakStatement` to work with `else if` constructs