### PR TITLE
CSE Machine: Fix environment reset instruction insertion

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,7 @@ jobs:
         exit 0
     - name: Install dependencies (apt)
       run: |
-        sudo apt-get update;
+        sudo apt-get update
         sudo apt-get install -y --no-install-recommends libxi-dev libgl1-mesa-dev
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,6 +28,7 @@ jobs:
         exit 0
     - name: Install dependencies (apt)
       run: |
+        sudo apt-get update;
         sudo apt-get install -y --no-install-recommends libxi-dev libgl1-mesa-dev
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
@@ -97,6 +97,19 @@ fact(5);",
 }
 `;
 
+exports[`Environment reset is inserted when only instructions are in control stack: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "const a = (v => v)(0);",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": undefined,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`Imports are properly handled: expectResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/cse-machine/__tests__/cse-machine.ts
+++ b/src/cse-machine/__tests__/cse-machine.ts
@@ -460,3 +460,12 @@ test('Breaks, continues and returns are detected properly inside loops', () => {
     optionEC3
   ).toMatchInlineSnapshot(`3`)
 })
+
+test('Environment reset is inserted when only instructions are in control stack', () => {
+  return expectResult(
+    stripIndent`
+    const a = (v => v)(0);
+    `,
+    optionEC3
+  ).toMatchInlineSnapshot(`undefined`)
+})

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -827,7 +827,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       if (
         next &&
         !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) &&
-        control.some(isNode)
+        !control.isEmpty()
       ) {
         control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
       }


### PR DESCRIPTION
# Description

This PR fixes the condition for inserting an environment reset instruction so that they are still inserted when the control stack has no nodes.

Resolves #1506, resolves #1520.

# Changes
- [X] fix condition for inserting environment reset instruction