### PR TITLE
Nested break/continue statement detection fixes

### DIFF
--- a/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine.ts.snap
@@ -317,6 +317,66 @@ f(5000, 5000);",
 }
 `;
 
+exports[`breaks, continues are properly detected in child blocks 1: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "let i = 0;
+for (i = 1; i < 5; i = i + 1) {
+    {
+        const a = i;
+        if (i === 1) {
+            continue;
+        }
+    }
+    
+    {
+        const a = i;
+        if (i === 2) {
+            break;
+        }
+    }
+}
+i;",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 2,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
+exports[`breaks, continues are properly detected in child blocks 2: expectResult 1`] = `
+Object {
+  "alertResult": Array [],
+  "code": "let a = 0;
+for (let i = 1; i < 5; i = i + 1) {
+    {
+        const x = 0;
+        a = i;
+        if (i === 1) {
+            continue;
+        }
+    }
+    
+    {
+        const x = 0;
+        a = i;
+        if (i === 2) {
+            break;
+        }
+    }
+}
+a;",
+  "displayResult": Array [],
+  "numErrors": 0,
+  "parsedErrors": "",
+  "result": 2,
+  "resultStatus": "finished",
+  "visualiseListResult": Array [],
+}
+`;
+
 exports[`const uses block scoping instead of function scoping: expectResult 1`] = `
 Object {
   "alertResult": Array [],

--- a/src/cse-machine/__tests__/cse-machine.ts
+++ b/src/cse-machine/__tests__/cse-machine.ts
@@ -460,3 +460,55 @@ test('Breaks, continues and returns are detected properly inside loops', () => {
     optionEC3
   ).toMatchInlineSnapshot(`3`)
 })
+
+test('breaks, continues are properly detected in child blocks 1', () => {
+  return expectResult(
+    stripIndent`
+    let i = 0;
+    for (i = 1; i < 5; i = i + 1) {
+        {
+            const a = i;
+            if (i === 1) {
+                continue;
+            }
+        }
+        
+        {
+            const a = i;
+            if (i === 2) {
+                break;
+            }
+        }
+    }
+    i;
+    `,
+    optionEC3
+  ).toMatchInlineSnapshot(`2`)
+})
+
+test('breaks, continues are properly detected in child blocks 2', () => {
+  return expectResult(
+    stripIndent`
+    let a = 0;
+    for (let i = 1; i < 5; i = i + 1) {
+        {
+            const x = 0;
+            a = i;
+            if (i === 1) {
+                continue;
+            }
+        }
+        
+        {
+            const x = 0;
+            a = i;
+            if (i === 2) {
+                break;
+            }
+        }
+    }
+    a;
+    `,
+    optionEC3
+  ).toMatchInlineSnapshot(`2`)
+})

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -572,7 +572,7 @@ export const hasBreakStatementIf = (statement: es.IfStatement): boolean => {
 }
 
 /**
- * Checks whether a block has a `break` statement.
+ * Checks whether a block OR any of its child blocks has a `break` statement.
  * @param body The block to be checked
  * @return `true` if there is a `break` statement, else `false`.
  */
@@ -584,6 +584,8 @@ export const hasBreakStatement = (block: es.BlockStatement): boolean => {
     } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
       hasBreak = hasBreak || hasBreakStatementIf(statement as es.IfStatement)
+    } else if (isBlockStatement(statement)) {
+      hasBreak = hasBreak || hasBreakStatement(statement as es.BlockStatement)
     }
   }
   return hasBreak
@@ -604,7 +606,7 @@ export const hasContinueStatementIf = (statement: es.IfStatement): boolean => {
 }
 
 /**
- * Checks whether a block has a `continue` statement.
+ * Checks whether a block OR any of its child blocks has a `continue` statement.
  * @param body The block to be checked
  * @return `true` if there is a `continue` statement, else `false`.
  */
@@ -616,6 +618,8 @@ export const hasContinueStatement = (block: es.BlockStatement): boolean => {
     } else if (isIfStatement(statement)) {
       // Parser enforces that if/else have braces (block statement)
       hasContinue = hasContinue || hasContinueStatementIf(statement as es.IfStatement)
+    } else if (isBlockStatement(statement)) {
+      hasContinue = hasContinue || hasContinueStatement(statement as es.BlockStatement)
     }
   }
   return hasContinue


### PR DESCRIPTION
### Description
The current implementation of `hasBreakStatement`/ `hasContinueStatement` on a `blockStatement` only detects break/continue statements inside its own block and disregards any occurrences in its child blocks. This behavior leads to issue #1505, where nested break and continue statements are not properly accounted for.
This PR aims to resolve #1505 