### PR TITLE
Typed Source: Enable autocompletion for standard Source functions

### DIFF
--- a/scripts/updateAutocompleteDocs.js
+++ b/scripts/updateAutocompleteDocs.js
@@ -11,14 +11,18 @@ const SRC_FILENAME = "global.html"
 const OUT_DIR = "src/editors/ace/docTooltip"
 
 const TARGETS = [
-  "source_1",
-  "source_1_wasm",
-  "source_2",
-  "source_3",
-  "source_3_concurrent",
-  "source_3_non-det",
-  "source_4",
-  "External libraries",
+  'source_1',
+  'source_1_wasm',
+  'source_1_typed',
+  'source_2',
+  'source_2_typed',
+  'source_3',
+  'source_3_concurrent',
+  'source_3_non-det',
+  'source_3_typed',
+  'source_4',
+  'source_4_typed',
+  'External libraries'
 ]
 
 function newTitleNode(title, document) {

--- a/scripts/updateAutocompleteDocs.js
+++ b/scripts/updateAutocompleteDocs.js
@@ -11,18 +11,18 @@ const SRC_FILENAME = "global.html"
 const OUT_DIR = "src/editors/ace/docTooltip"
 
 const TARGETS = [
-  'source_1',
-  'source_1_wasm',
-  'source_1_typed',
-  'source_2',
-  'source_2_typed',
-  'source_3',
-  'source_3_concurrent',
-  'source_3_non-det',
-  'source_3_typed',
-  'source_4',
-  'source_4_typed',
-  'External libraries'
+  "source_1",
+  "source_1_wasm",
+  "source_1_typed",
+  "source_2",
+  "source_2_typed",
+  "source_3",
+  "source_3_concurrent",
+  "source_3_non-det",
+  "source_3_typed",
+  "source_4",
+  "source_4_typed",
+  "External libraries"
 ]
 
 function newTitleNode(title, document) {

--- a/src/editors/ace/docTooltip/index.ts
+++ b/src/editors/ace/docTooltip/index.ts
@@ -1,10 +1,14 @@
 import * as ext_lib from './External libraries.json'
 import * as source_1 from './source_1.json'
+import * as source_1_typed from './source_1_typed.json'
 import * as source_2 from './source_2.json'
+import * as source_2_typed from './source_2_typed.json'
 import * as source_3 from './source_3.json'
 import * as source_3_concurrent from './source_3_concurrent.json'
 import * as source_3_non_det from './source_3_non-det.json'
+import * as source_3_typed from './source_3_typed.json'
 import * as source_4 from './source_4.json'
+import * as source_4_typed from './source_4_typed.json'
 
 // (18 March 2022)
 // Problem to be fixed in the future:
@@ -38,12 +42,16 @@ export const SourceDocumentation = {
   builtins: {
     '1': resolveImportInconsistency(source_1),
     '1_lazy': resolveImportInconsistency(source_1),
+    '1_typed': resolveImportInconsistency(source_1_typed),
     '2': resolveImportInconsistency(source_2),
     '2_lazy': resolveImportInconsistency(source_2),
+    '2_typed': resolveImportInconsistency(source_2_typed),
     '3': resolveImportInconsistency(source_3),
     '3_concurrent': resolveImportInconsistency(source_3_concurrent),
     '3_non-det': resolveImportInconsistency(source_3_non_det),
-    '4': resolveImportInconsistency(source_4)
+    '3_typed': resolveImportInconsistency(source_3_typed),
+    '4': resolveImportInconsistency(source_4),
+    '4_typed': resolveImportInconsistency(source_4_typed),
   },
   ext_lib
 }

--- a/src/editors/ace/docTooltip/index.ts
+++ b/src/editors/ace/docTooltip/index.ts
@@ -51,7 +51,7 @@ export const SourceDocumentation = {
     '3_non-det': resolveImportInconsistency(source_3_non_det),
     '3_typed': resolveImportInconsistency(source_3_typed),
     '4': resolveImportInconsistency(source_4),
-    '4_typed': resolveImportInconsistency(source_4_typed),
+    '4_typed': resolveImportInconsistency(source_4_typed)
   },
   ext_lib
 }


### PR DESCRIPTION
This PR enables the autocompletion of the standard Source functions for the Typed Variant of Source. It does so by including the autocomplete documentation for Typed Source.

Closes #1529 