### PR TITLE
1562 stepper incorrect evaluation sequence in program

### DIFF
--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -19,16 +19,20 @@ a();
 (() => {})();
 \\"Gets returned by normal run\\";
 
-(() => {})();
-\\"Gets returned by normal run\\";
-
-(() => {})();
-\\"Gets returned by normal run\\";
-
+\\"other statement\\";
 {};
 \\"Gets returned by normal run\\";
 
+\\"other statement\\";
 {};
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+undefined;
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+undefined;
 \\"Gets returned by normal run\\";
 
 undefined;
@@ -62,16 +66,20 @@ a();
 a();
 \\"Gets returned by normal run\\";
 
-a();
-\\"Gets returned by normal run\\";
-
-a();
-\\"Gets returned by normal run\\";
-
+\\"other statement\\";
 {};
 \\"Gets returned by normal run\\";
 
+\\"other statement\\";
 {};
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+undefined;
+\\"Gets returned by normal run\\";
+
+\\"other statement\\";
+undefined;
 \\"Gets returned by normal run\\";
 
 undefined;
@@ -4105,6 +4113,113 @@ f();
 
 f();
 
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Irreducible second statement 1`] = `
+"'value';
+'also a value';
+
+'value';
+'also a value';
+
+'also a value';
+
+'also a value';
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Mix statements 1`] = `
+"'value';
+const x = 10;
+function f() {
+  20;
+}
+const z = 30;
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+const x = 10;
+function f() {
+  20;
+}
+const z = 30;
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+function f() {
+  20;
+}
+const z = 30;
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+function f() {
+  20;
+}
+const z = 30;
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+const z = 30;
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+const z = 30;
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+'also a value';
+'another value';
+const a = 40;
+
+'value';
+'also a value';
+'another value';
+const a = 40;
+
+'also a value';
+'another value';
+const a = 40;
+
+'also a value';
+'another value';
+const a = 40;
+
+'another value';
+const a = 40;
+
+'another value';
+const a = 40;
+
+'another value';
+
+'another value';
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Reducible second statement 1`] = `
+"'value';
+const x = 10;
+
+'value';
+const x = 10;
+
+'value';
+
+'value';
 "
 `;
 

--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -4116,7 +4116,73 @@ f();
 "
 `;
 
-exports[`Test correct evaluation sequence when first statement is a value Irreducible second statement 1`] = `
+exports[`Test correct evaluation sequence when first statement is a value Irreducible second statement in block 1`] = `
+"{
+  'value';
+  'also a value';
+}
+
+{
+  'value';
+  'also a value';
+}
+
+{
+  'also a value';
+}
+
+{
+  'also a value';
+}
+
+'also a value';
+
+'also a value';
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Irreducible second statement in functions 1`] = `
+"function f() {
+  'value';
+  'also a value';
+}
+f();
+
+function f() {
+  'value';
+  'also a value';
+}
+f();
+
+f();
+
+f();
+
+{
+  'value';
+  'also a value';
+};
+
+{
+  'value';
+  'also a value';
+};
+
+{
+  'also a value';
+};
+
+{
+  'also a value';
+};
+
+undefined;
+
+undefined;
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Irreducible second statement in program 1`] = `
 "'value';
 'also a value';
 
@@ -4134,9 +4200,17 @@ exports[`Test correct evaluation sequence when first statement is a value Mix st
 const x = 10;
 function f() {
   20;
+  function p() {
+    22;
+  }
 }
 const z = 30;
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
@@ -4144,57 +4218,159 @@ const a = 40;
 const x = 10;
 function f() {
   20;
+  function p() {
+    22;
+  }
 }
 const z = 30;
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'value';
 function f() {
   20;
+  function p() {
+    22;
+  }
 }
 const z = 30;
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'value';
 function f() {
   20;
+  function p() {
+    22;
+  }
 }
 const z = 30;
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'value';
 const z = 30;
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'value';
 const z = 30;
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'value';
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'value';
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
 'another value';
 const a = 40;
 
 'also a value';
+{
+  'another value';
+  const a = 40;
+  a;
+}
+'another value';
+const a = 40;
+
+'also a value';
+{
+  'another value';
+  40;
+}
+'another value';
+const a = 40;
+
+'also a value';
+{
+  'another value';
+  40;
+}
+'another value';
+const a = 40;
+
+'also a value';
+{
+  40;
+}
+'another value';
+const a = 40;
+
+'also a value';
+{
+  40;
+}
+'another value';
+const a = 40;
+
+'also a value';
+40;
+'another value';
+const a = 40;
+
+'also a value';
+40;
+'another value';
+const a = 40;
+
+40;
+'another value';
+const a = 40;
+
+40;
 'another value';
 const a = 40;
 
@@ -4210,7 +4386,73 @@ const a = 40;
 "
 `;
 
-exports[`Test correct evaluation sequence when first statement is a value Reducible second statement 1`] = `
+exports[`Test correct evaluation sequence when first statement is a value Reducible second statement in block 1`] = `
+"{
+  'value';
+  const x = 10;
+}
+
+{
+  'value';
+  const x = 10;
+}
+
+{
+  'value';
+}
+
+{
+  'value';
+}
+
+'value';
+
+'value';
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Reducible second statement in function 1`] = `
+"function f() {
+  'value';
+  const x = 10;
+}
+f();
+
+function f() {
+  'value';
+  const x = 10;
+}
+f();
+
+f();
+
+f();
+
+{
+  'value';
+  const x = 10;
+};
+
+{
+  'value';
+  const x = 10;
+};
+
+{
+  'value';
+};
+
+{
+  'value';
+};
+
+undefined;
+
+undefined;
+"
+`;
+
+exports[`Test correct evaluation sequence when first statement is a value Reducible second statement in program 1`] = `
 "'value';
 const x = 10;
 

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -77,6 +77,43 @@ const testEvalSteps = (programStr: string, context?: Context) => {
   return getEvaluationSteps(program, context, options)
 }
 
+describe('Test correct evaluation sequence when first statement is a value', () => {
+  test('Reducible second statement', async () => {
+    const code = `
+    'value';
+    const x = 10;
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual("'value';")
+  })
+
+  test('Irreducible second statement', async () => {
+    const code = `
+    'value';
+    'also a value';
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual("'also a value';")
+  })
+
+  test('Mix statements', async () => {
+    const code = `
+    'value';
+    const x = 10;
+    function f() {20;}
+    const z = 30;
+    'also a value';
+    'another value';
+    const a = 40;
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual("'another value';")
+  })
+})
+
 describe('Test single line of code is evaluated', () => {
   test('Constants Declaration', async () => {
     const code = `
@@ -185,9 +222,11 @@ test('Test two statement substitution', async () => {
     21;
     3 * 5;
 
-    3 * 5;
+    21;
+    15;
 
-    3 * 5;
+    21;
+    15;
 
     15;
 
@@ -800,21 +839,25 @@ test('triple equals work on function', async () => {
     g === g;
     f === g;
 
-    g === g;
+    true;
+    true;
     f === g;
 
-    g === g;
-    f === g;
-
+    true;
     true;
     f === g;
 
     true;
     f === g;
 
+    true;
     f === g;
 
-    f === g;
+    true;
+    false;
+
+    true;
+    false;
 
     false;
 

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -78,7 +78,7 @@ const testEvalSteps = (programStr: string, context?: Context) => {
 }
 
 describe('Test correct evaluation sequence when first statement is a value', () => {
-  test('Reducible second statement', async () => {
+  test('Reducible second statement in program', async () => {
     const code = `
     'value';
     const x = 10;
@@ -88,7 +88,7 @@ describe('Test correct evaluation sequence when first statement is a value', () 
     expect(getLastStepAsString(steps)).toEqual("'value';")
   })
 
-  test('Irreducible second statement', async () => {
+  test('Irreducible second statement in program', async () => {
     const code = `
     'value';
     'also a value';
@@ -98,13 +98,71 @@ describe('Test correct evaluation sequence when first statement is a value', () 
     expect(getLastStepAsString(steps)).toEqual("'also a value';")
   })
 
+  test('Reducible second statement in block', async () => {
+    const code = `
+    {
+      'value';
+      const x = 10;
+    }
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual("'value';")
+  })
+
+  test('Irreducible second statement in block', async () => {
+    const code = `
+    {
+      'value';
+      'also a value';
+    }
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual("'also a value';")
+  })
+
+  test('Reducible second statement in function', async () => {
+    const code = `
+    function f () {
+      'value';
+      const x = 10;
+    }
+    f();
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+  })
+
+  test('Irreducible second statement in functions', async () => {
+    const code = `
+    function f () {
+      'value';
+      'also a value';
+    }
+    f();
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+  })
+
   test('Mix statements', async () => {
     const code = `
     'value';
     const x = 10;
-    function f() {20;}
+    function f() {
+      20;
+      function p() {
+        22;
+      }
+    }
     const z = 30;
     'also a value';
+    {
+      'another value';
+      const a = 40;
+      a;
+    }
     'another value';
     const a = 40;
     `

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1796,8 +1796,6 @@ function reduceMain(
           isIrreducible(firstStatement.expression, context)
         ) {
           const [secondStatement] = otherStatements
-          // if the first statement is irreducible, reduce second statement if it's reducible
-          // else reduce the first statement
           if (
             secondStatement !== undefined &&
             secondStatement.type == 'ExpressionStatement' &&

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -2010,7 +2010,7 @@ function reduceMain(
           ) {
             paths[0].push('body[0]')
             paths.push([])
-            let stmt = ast.blockStatement(otherStatements as es.Statement[])
+            const stmt = ast.blockStatement(otherStatements as es.Statement[])
             return [stmt, context, paths, explain(node)]
           } else {
             // Reduce the second statement and preserve the first statement
@@ -2216,7 +2216,7 @@ function reduceMain(
           ) {
             paths[0].push('body[0]')
             paths.push([])
-            let stmt = ast.blockExpression(otherStatements as es.Statement[])
+            const stmt = ast.blockExpression(otherStatements as es.Statement[])
             return [stmt, context, paths, explain(node)]
           } else {
             // Reduce the second statement and preserve the first statement

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1807,18 +1807,23 @@ function reduceMain(
             return [stmt, context, paths, explain(node)]
           } else {
             // Reduce the second statement and preserve the first statement
+            // Pass in a new path to avoid modifying the original path
+            const newPath = [[]]
             const [reduced, cont, path, str] = reducers['Program'](
               ast.program(otherStatements as es.Statement[]),
               context,
-              paths
+              newPath
             )
 
             // Fix path highlighting after preserving first statement
             path.forEach(pathStep => {
               pathStep.forEach((_, i) => {
-                pathStep[i] = pathStep[i].replace(/\d+/g, match => String(Number(match) + 1))
+                if (i == 0) {
+                  pathStep[i] = pathStep[i].replace(/\d+/g, match => String(Number(match) + 1))
+                }
               })
             })
+            paths[0].push(...path[0])
 
             const stmt = ast.program([
               firstStatement,
@@ -1994,15 +1999,45 @@ function reduceMain(
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)
         ) {
-          let stmt
-          if (otherStatements.length > 0) {
+          const [secondStatement] = otherStatements
+
+          if (secondStatement == undefined) {
+            const stmt = ast.expressionStatement(firstStatement.expression)
+            return [stmt, context, paths, explain(node)]
+          } else if (
+            secondStatement.type == 'ExpressionStatement' &&
+            isIrreducible(secondStatement.expression, context)
+          ) {
             paths[0].push('body[0]')
             paths.push([])
-            stmt = ast.blockStatement(otherStatements as es.Statement[])
+            let stmt = ast.blockStatement(otherStatements as es.Statement[])
+            return [stmt, context, paths, explain(node)]
           } else {
-            stmt = ast.expressionStatement(firstStatement.expression)
+            // Reduce the second statement and preserve the first statement
+            // Pass in a new path to avoid modifying the original path
+            const newPath = [[]]
+            const [reduced, cont, path, str] = reducers['BlockStatement'](
+              ast.blockStatement(otherStatements as es.Statement[]),
+              context,
+              newPath
+            )
+
+            // Fix path highlighting after preserving first statement
+            path.forEach(pathStep => {
+              pathStep.forEach((_, i) => {
+                if (i == 0) {
+                  pathStep[i] = pathStep[i].replace(/\d+/g, match => String(Number(match) + 1))
+                }
+              })
+            })
+            paths[0].push(...path[0])
+
+            const stmt = ast.blockStatement([
+              firstStatement,
+              ...((reduced as es.BlockStatement).body as es.Statement[])
+            ])
+            return [stmt, cont, paths, str]
           }
-          return [stmt, context, paths, explain(node)]
         } else if (firstStatement.type === 'FunctionDeclaration') {
           let funDecExp = ast.functionDeclarationExpression(
             firstStatement.id!,
@@ -2170,15 +2205,45 @@ function reduceMain(
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)
         ) {
-          let stmt
-          if (otherStatements.length > 0) {
+          const [secondStatement] = otherStatements
+
+          if (secondStatement == undefined) {
+            const stmt = ast.identifier('undefined')
+            return [stmt, context, paths, explain(node)]
+          } else if (
+            secondStatement.type == 'ExpressionStatement' &&
+            isIrreducible(secondStatement.expression, context)
+          ) {
             paths[0].push('body[0]')
             paths.push([])
-            stmt = ast.blockExpression(otherStatements as es.Statement[])
+            let stmt = ast.blockExpression(otherStatements as es.Statement[])
+            return [stmt, context, paths, explain(node)]
           } else {
-            stmt = ast.identifier('undefined')
+            // Reduce the second statement and preserve the first statement
+            // Pass in a new path to avoid modifying the original path
+            const newPath = [[]]
+            const [reduced, cont, path, str] = reducers['BlockExpression'](
+              ast.blockExpression(otherStatements as es.Statement[]),
+              context,
+              newPath
+            )
+
+            // Fix path highlighting after preserving first statement
+            path.forEach(pathStep => {
+              pathStep.forEach((_, i) => {
+                if (i == 0) {
+                  pathStep[i] = pathStep[i].replace(/\d+/g, match => String(Number(match) + 1))
+                }
+              })
+            })
+            paths[0].push(...path[0])
+
+            const stmt = ast.blockExpression([
+              firstStatement,
+              ...((reduced as es.BlockStatement).body as es.Statement[])
+            ])
+            return [stmt, cont, paths, str]
           }
-          return [stmt, context, paths, explain(node)]
         } else if (firstStatement.type === 'FunctionDeclaration') {
           let funDecExp = ast.functionDeclarationExpression(
             firstStatement.id!,

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1795,7 +1795,9 @@ function reduceMain(
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)
         ) {
+          // Intentionally ignore the remaining statements
           const [secondStatement] = otherStatements
+
           if (
             secondStatement !== undefined &&
             secondStatement.type == 'ExpressionStatement' &&
@@ -1999,6 +2001,7 @@ function reduceMain(
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)
         ) {
+          // Intentionally ignore the remaining statements
           const [secondStatement] = otherStatements
 
           if (secondStatement == undefined) {
@@ -2205,6 +2208,7 @@ function reduceMain(
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)
         ) {
+          // Intentionally ignore the remaining statements
           const [secondStatement] = otherStatements
 
           if (secondStatement == undefined) {


### PR DESCRIPTION
Added checks for reducible second statements in accordance to the stepper specs.

Reduce second statements if it is reducible, keeping the first statement on the buffer. 

Fix code highlighting due to shifting of statements

Added tests and updated old tests to reflect new changes. 