### PR TITLE
Stepper evaluation of toplevel statement sequences

### DIFF
--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -4465,6 +4465,47 @@ const x = 10;
 "
 `;
 
+exports[`Test reducing of empty block into epsilon Empty block in function 1`] = `
+"function f() {
+  3;
+  {}
+}
+f();
+
+function f() {
+  3;
+  {}
+}
+f();
+
+f();
+
+f();
+
+{
+  3;
+  {}
+};
+
+{
+  3;
+  {}
+};
+
+{
+  3;
+};
+
+{
+  3;
+};
+
+undefined;
+
+undefined;
+"
+`;
+
 exports[`Test reducing of empty block into epsilon Empty block in program 1`] = `
 "3;
 {}

--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -4465,6 +4465,74 @@ const x = 10;
 "
 `;
 
+exports[`Test reducing of empty block into epsilon Empty block in program 1`] = `
+"3;
+{}
+
+3;
+{}
+
+3;
+
+3;
+"
+`;
+
+exports[`Test reducing of empty block into epsilon Empty blocks in block 1`] = `
+"{
+  3;
+  {
+    {}
+    {}
+  }
+}
+
+{
+  3;
+  {
+    {}
+    {}
+  }
+}
+
+{
+  3;
+  {
+    {}
+  }
+}
+
+{
+  3;
+  {
+    {}
+  }
+}
+
+{
+  3;
+  {}
+}
+
+{
+  3;
+  {}
+}
+
+{
+  3;
+}
+
+{
+  3;
+}
+
+3;
+
+3;
+"
+`;
+
 exports[`const declarations in blocks subst into call expressions 1`] = `
 "const z = 1;
 function f(g) {

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -77,6 +77,33 @@ const testEvalSteps = (programStr: string, context?: Context) => {
   return getEvaluationSteps(program, context, options)
 }
 
+describe('Test reducing of empty block into epsilon', () => {
+  test('Empty block in program', async () => {
+    const code = `
+    3;
+    {}
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('3;')
+  })
+
+  test('Empty blocks in block', async () => {
+    const code = `
+    {
+      3;
+      {
+        {}
+        {}
+      }
+    }
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+    expect(getLastStepAsString(steps)).toEqual('3;')
+  })
+})
+
 describe('Test correct evaluation sequence when first statement is a value', () => {
   test('Reducible second statement in program', async () => {
     const code = `

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -102,6 +102,18 @@ describe('Test reducing of empty block into epsilon', () => {
     expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
     expect(getLastStepAsString(steps)).toEqual('3;')
   })
+
+  test('Empty block in function', async () => {
+    const code = `
+    function f() {
+      3;
+      {}
+    }
+    f();
+    `
+    const steps = await testEvalSteps(code)
+    expect(steps.map(x => codify(x[0])).join('\n')).toMatchSnapshot()
+  })
 })
 
 describe('Test correct evaluation sequence when first statement is a value', () => {

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -2214,6 +2214,11 @@ function reduceMain(
               str
             ]
           }
+        } else if (firstStatement.type === 'BlockStatement' && firstStatement.body.length === 0) {
+          paths[0].push('body[0]')
+          paths.push([])
+          const stmt = ast.blockExpression(otherStatements as es.Statement[])
+          return [stmt, context, paths, explain(firstStatement)]
         } else if (
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -1791,6 +1791,11 @@ function reduceMain(
               str
             ]
           }
+        } else if (firstStatement.type === 'BlockStatement' && firstStatement.body.length === 0) {
+          paths[0].push('body[0]')
+          paths.push([])
+          const stmt = ast.program(otherStatements as es.Statement[])
+          return [stmt, context, paths, explain(firstStatement)]
         } else if (
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)
@@ -1997,6 +2002,11 @@ function reduceMain(
               str
             ]
           }
+        } else if (firstStatement.type === 'BlockStatement' && firstStatement.body.length === 0) {
+          paths[0].push('body[0]')
+          paths.push([])
+          const stmt = ast.blockStatement(otherStatements as es.Statement[])
+          return [stmt, context, paths, explain(firstStatement)]
         } else if (
           firstStatement.type === 'ExpressionStatement' &&
           isIrreducible(firstStatement.expression, context)


### PR DESCRIPTION
Bug fix for issue #539 

Reduces empty block statements in the program, block statements and block expressions into epsilon. 

Added tests for all 3 contexts too