### PR TITLE
fix: reduce firstStatement if secondStatement is a return statement

### DIFF
--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -4145,12 +4145,14 @@ exports[`Test correct evaluation sequence when first statement is a value Irredu
 "function f() {
   'value';
   'also a value';
+  return 'another value';
 }
 f();
 
 function f() {
   'value';
   'also a value';
+  return 'another value';
 }
 f();
 
@@ -4161,24 +4163,36 @@ f();
 {
   'value';
   'also a value';
+  return 'another value';
 };
 
 {
   'value';
   'also a value';
+  return 'another value';
 };
 
 {
   'also a value';
+  return 'another value';
 };
 
 {
   'also a value';
+  return 'another value';
 };
 
-undefined;
+{
+  return 'another value';
+};
 
-undefined;
+{
+  return 'another value';
+};
+
+'another value';
+
+'another value';
 "
 `;
 
@@ -4415,12 +4429,14 @@ exports[`Test correct evaluation sequence when first statement is a value Reduci
 "function f() {
   'value';
   const x = 10;
+  return 'another value';
 }
 f();
 
 function f() {
   'value';
   const x = 10;
+  return 'another value';
 }
 f();
 
@@ -4431,24 +4447,36 @@ f();
 {
   'value';
   const x = 10;
+  return 'another value';
 };
 
 {
   'value';
   const x = 10;
+  return 'another value';
 };
 
 {
   'value';
+  return 'another value';
 };
 
 {
   'value';
+  return 'another value';
 };
 
-undefined;
+{
+  return 'another value';
+};
 
-undefined;
+{
+  return 'another value';
+};
+
+'another value';
+
+'another value';
 "
 `;
 

--- a/src/stepper/__tests__/stepper.ts
+++ b/src/stepper/__tests__/stepper.ts
@@ -127,6 +127,7 @@ describe('Test correct evaluation sequence when first statement is a value', () 
     function f () {
       'value';
       const x = 10;
+      return 'another value';
     }
     f();
     `
@@ -139,6 +140,7 @@ describe('Test correct evaluation sequence when first statement is a value', () 
     function f () {
       'value';
       'also a value';
+      return 'another value';
     }
     f();
     `

--- a/src/stepper/stepper.ts
+++ b/src/stepper/stepper.ts
@@ -2215,8 +2215,9 @@ function reduceMain(
             const stmt = ast.identifier('undefined')
             return [stmt, context, paths, explain(node)]
           } else if (
-            secondStatement.type == 'ExpressionStatement' &&
-            isIrreducible(secondStatement.expression, context)
+            (secondStatement.type == 'ExpressionStatement' &&
+              isIrreducible(secondStatement.expression, context)) ||
+            secondStatement.type === 'ReturnStatement'
           ) {
             paths[0].push('body[0]')
             paths.push([])


### PR DESCRIPTION
Stepper was crashing because it was trying to reduce a return statement due to the first statement being a value. Fixed the evaluation sequence in accordance to the specs. 

<img width="705" alt="image" src="https://github.com/source-academy/js-slang/assets/43413899/c8f9de4b-9b2b-44b6-82ff-1ff5c8a9ccc7">

Reduce value if the next statement is a return statement