### PR TITLE
Minimal change to expose steppable functionality from runCSEMachine()

### DIFF
--- a/src/modules/requireProvider.ts
+++ b/src/modules/requireProvider.ts
@@ -33,7 +33,7 @@ export const getRequireProvider = (context: Context) => (x: string) => {
         parser: {
           parser
         },
-        'ec-evaluator': {
+        'cse-machine': {
           interpreter
         }
       },

--- a/src/modules/requireProvider.ts
+++ b/src/modules/requireProvider.ts
@@ -1,4 +1,6 @@
 import * as jsslang from '..'
+import * as interpreter from '../cse-machine/interpreter'
+import * as parser from '../parser/parser'
 import * as stdlib from '../stdlib'
 import type { Context } from '../types'
 import * as types from '../types'
@@ -27,6 +29,12 @@ export const getRequireProvider = (context: Context) => (x: string) => {
         types,
         utils: {
           stringify
+        },
+        parser: {
+          parser
+        },
+        'ec-evaluator': {
+          interpreter
         }
       },
       context


### PR DESCRIPTION
Previously, the runCSEMachine function runs until the Control is empty or until the step limit is reached. 

It would be useful to extract each step in a generator function and export this functionality. This allows modules to run their own internal "steppable" CSE machine. 

The functionality of the runCSEMachine function is unchanged. 

```
// Example use case for generateCSEMachineStateStream

const code = context.unTypecheckedCode[0];
const context = createContext(...)

const program = parse(code, context);

context.runtime.isRunning = true;
context.runtime.control = new Control(program);
context.runtime.stash = new Stash();

const options = ... // Create options

const iterator = generateCSEMachineStateStream(
      context,
      context.runtime.control,
      context.runtime.stash,
      options.envSteps,
      options.stepLimit,
      options.isPrelude,
)

// Use a for loop to access the state at each step. For more control, use iterator.next()
for (const {stash, control, steps} of iterator) {
    // Do something with the state
}

```

