### PR TITLE
Fix broken Source specification PDF on documentation website

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           sudo apt-get update && \
           sudo apt-get install -y --no-install-recommends \
-          texlive texlive-fonts-extra texlive-lang-cjk latexmk \
+          texlive texlive-fonts-extra texlive-lang-cjk latexmk latex-cjk-all \
           libxi-dev libgl1-mesa-dev
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/scripts/jsdoc.sh
+++ b/scripts/jsdoc.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -e
+
 JSDOC="node_modules/.bin/jsdoc"
 TMPL="docs/jsdoc/templates/template"
 DST="docs/source"


### PR DESCRIPTION
There appears to be a regression introduced in #1544 related to the modification to the way how system packages are installed (as recommended packages are longer installed).

Upon checking the documentation deployment action, we can see that the build task fails at creating the PDF (but however the error is silently ignored and the deploy still proceeded), and that the error is related to CJK fonts not being found. From there, checking the system packages installed reveals that the `texlive-lang-cjk` package actually installs the `latex-cjk-all` package as a recommended package, and without the package it seems that the PDFs could not be generated.

This PR adds back the `latex-cjk-all` package explicitly, and at the same time also enables errors for the documentation building script to terminate if any of the generation command fails (which previously lead to such issues not being caught). However, I am unable to test whether the deployment will work out correctly (i.e. any other dependents related to the recommended packages) as the current deployment environment/runner setup differs from my local setup.