### PR TITLE
Remove special cases for environment instruction generator

### DIFF
--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -393,15 +393,8 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     }
     // Normal block statement: do environment setup
     // To restore environment after block ends
-    // If there is an env instruction on top of the stack, or if there are no declarations, or there is no next control item
-    // we do not need to push another one
-    // The no declarations case is handled by Control :: simplifyBlocksWithoutDeclarations, so no blockStatement node
-    // without declarations should end up here.
-    const next = control.peek()
-    // Push ENVIRONMENT instruction if needed
-    if (next && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)) {
-      control.push(instr.envInstr(currentEnvironment(context), command))
-    }
+    // Push ENVIRONMENT instruction
+    control.push(instr.envInstr(currentEnvironment(context), command))
 
     const environment = createBlockEnvironment(context, 'blockEnvironment')
     declareFunctionsAndVariables(context, command, environment)
@@ -913,16 +906,9 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
         })
       }
 
-      const next = control.peek()
-
-      // Push ENVIRONMENT instruction if needed
-      if (
-        next &&
-        !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) &&
-        !control.isEmpty()
-      ) {
-        control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
-      }
+      // Push ENVIRONMENT instruction regardless of whether the function is simple or
+      // a builtin.
+      control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
 
       // Create environment for function parameters if the function isn't nullary.
       // Name the environment if the function call expression is not anonymous

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -393,8 +393,15 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     }
     // Normal block statement: do environment setup
     // To restore environment after block ends
-    // Push ENVIRONMENT instruction
-    control.push(instr.envInstr(currentEnvironment(context), command))
+    // If there is an env instruction on top of the stack, or if there are no declarations
+    // we do not need to push another one
+    // The no declarations case is handled by Control :: simplifyBlocksWithoutDeclarations, so no blockStatement node
+    // without declarations should end up here.
+    const next = control.peek()
+    // Push ENVIRONMENT instruction if needed
+    if (!next || !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)) {
+      control.push(instr.envInstr(currentEnvironment(context), command))
+    }
 
     const environment = createBlockEnvironment(context, 'blockEnvironment')
     declareFunctionsAndVariables(context, command, environment)
@@ -906,9 +913,16 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
         })
       }
 
-      // Push ENVIRONMENT instruction regardless of whether the function is simple or
-      // a builtin.
-      control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
+      const next = control.peek()
+
+      // Push ENVIRONMENT instruction if needed - if next instruction
+      // is empty or not an environment instruction
+      if (
+        !next ||
+        (!(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) && !control.isEmpty())
+      ) {
+        control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
+      }
 
       // Create environment for function parameters if the function isn't nullary.
       // Name the environment if the function call expression is not anonymous


### PR DESCRIPTION
The CSE machine currently does not inject an environment instruction into the control when a function application or a block statement is the last item in a program. While this works for a single program, it breaks the REPL, where each submitted code snippet is treated as a singular program. The best way to deal with this issue is to force an environment instruction for any environment-producing statements at the end of the program to allow for newer REPL snippets to read from the correct environment.

Resolves #1576.