### PR TITLE
CSE Machine: Changes to step count

### DIFF
--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -305,7 +305,9 @@ export function* generateCSEMachineStateStream(
 ) {
   context.runtime.break = false
   context.runtime.nodes = []
-  let steps = 1
+
+  // steps: number of steps completed
+  let steps = 0
 
   let command = control.peek()
 

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -357,11 +357,11 @@ export function* generateCSEMachineStateStream(
     command = control.peek()
 
     steps += 1
-    yield { stash, control, steps }
-  }
+    if (!isPrelude) {
+      context.runtime.envStepsTotal = steps
+    }
 
-  if (!isPrelude) {
-    context.runtime.envStepsTotal = steps
+    yield { stash, control, steps }
   }
 }
 


### PR DESCRIPTION
# Description
This PR makes some changes to how step count is updated, so that `context.runtime.envStepsTotal` represents the number of steps completed by the machine before the program finishes/runs into an error.

This is needed to implement source-academy/frontend#2847.
# Changes
- [X] `context.runtime.envStepsTotal` is updated during evaluation
- [X] Step count now starts from 0 and represents the number of steps completed