### PR TITLE
Source Native: Fix imports not working from prelude

### DIFF
--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -588,6 +588,7 @@ async function transpileToFullJS(
     globalIds.native
   )
 
+  program.body = (importNodes as es.Program['body']).concat(otherNodes)
   getFunctionDeclarationNamesInProgram(program).forEach(id =>
     context.nativeStorage.previousProgramsIdentifiers.add(id)
   )


### PR DESCRIPTION
As mentioned in issues #1500 and #1495, when using Source (any chapter) Native variant, importing module functions and constants in prelude (for assessments) or when using those names in the REPL (after running the main code, shown below) fails to work correctly.

It appears that the exported functions do not get picked up by `getGloballyDeclaredIdentifiers` (in the `transpileToFullJS` function) and thus get lost when running in the native variant. This causes the transpiler unable to recognise that the symbol has been imported and hence throws an error that the name is undeclared.

During the debugging process for this, there are two more bugs to related to the native variant when using the REPL (more details will in the respective issues that will be created), but other than that, the code seems to work and tested to be working locally in both the example (as shown below) and in assessments with prelude.

Resolves #1500.

**Current Behaviour (in REPL):**
![Screenshot 2024-03-31 at 03-19-37 Source Academy](https://github.com/source-academy/js-slang/assets/26355099/82dd5cad-db2c-479c-938d-cc43de348102)

**Expected/Fixed Behaviour (in REPL):**
![Screenshot 2024-03-31 at 03-42-41 Source Academy](https://github.com/source-academy/js-slang/assets/26355099/3505e71b-b219-4785-9231-0de1ccd047b3)
