### PR TITLE
CSE Machine: Documentation fixes for Explicit-Control and Continuations

### DIFF
--- a/docs/md/README_4_EXPLICIT-CONTROL.md
+++ b/docs/md/README_4_EXPLICIT-CONTROL.md
@@ -43,8 +43,8 @@ order. Click on a name to see how it is defined and used. They come in these gro
 
 You can use all features of
 <a href="../source_4/">Source §4</a> and 
-the facilities supporting continuation,
-given in  <a href="../MCE/index.html">MCE</a>.
+the facilities supporting continuations,
+given in  <a href="../CONTINUATION/index.html">CONTINUATION</a>.
 
 ## You want the definitive specs?
 

--- a/docs/md/README_CONTINUATION.md
+++ b/docs/md/README_CONTINUATION.md
@@ -1,4 +1,4 @@
 CONTINUATION provides the function `call_cc` for generating and consuming continuations.
 Click on a name on the right to see how they are defined and used.
 
-Continuations in Source work similar to the <a href="https://en.wikipedia.org/wiki/Call-with-current-continuation">call-with-current-continuation</a> functin in Scheme.
+Continuations in Source work similar to the <a href="https://en.wikipedia.org/wiki/Call-with-current-continuation">call-with-current-continuation</a> function in Scheme.


### PR DESCRIPTION
### Description

This PR provides some documentation fixes for Explicit-Control and Continuations.

### Changes

- [X] fix typo `functin` in Continuations
- [X] fix link to Continuations in Explicit-Control