### PR TITLE
CSE Machine: Fix condition for pushing environment instruction during function application

### DIFF
--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -974,12 +974,9 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
 
       const next = control.peek()
 
-      // Push ENVIRONMENT instruction if needed - if next instruction
-      // is empty or not an environment instruction
-      if (
-        !next ||
-        (!(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) && !control.isEmpty())
-      ) {
+      // Push ENVIRONMENT instruction if needed - if next control stack item
+      // exists and is not an environment instruction
+      if (next && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)) {
         control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
       }
 


### PR DESCRIPTION
### Description

For some reason, the code handling function application has been pushing environment instructions even when the control stack is empty.

This PR rectifies that.

Fixes #1635.

### Changes

- [X] environment instruction is no longer pushed when control stack is empty
