### PR TITLE
Use fetch for docs loading exclusively

### DIFF
--- a/src/modules/moduleTypes.ts
+++ b/src/modules/moduleTypes.ts
@@ -11,7 +11,7 @@ export type ModuleManifest = {
 export type ModuleBundle = (require: RequireProvider) => ModuleFunctions
 
 export type ModuleFunctions = {
-  [functionName: string]: Function
+  [name: string]: any
 }
 
 export interface FunctionDocumentation {
@@ -35,7 +35,9 @@ export const unknownDocs: UnknownDocumentation = { kind: 'unknown' }
 
 export type ModuleDocsEntry = FunctionDocumentation | VariableDocumentation | UnknownDocumentation
 
-export type ModuleDocumentation = Record<string, ModuleDocsEntry>
+export type ModuleDocumentation = {
+  [name: string]: ModuleDocsEntry
+}
 
 export type ImportOptions = {
   loadTabs: boolean


### PR DESCRIPTION
Import attributes don't really have as much support across browsers as we'd like. This PR removes the `import()` loader and simply uses `fetch()` for loading module documentation