### PR TITLE
Update docs deployment workflow runner version

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
           yarn run jsdoc prepare
           find docs/source -name .gitignore -delete -print
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_SSH_KEY }}
           publish_dir: docs/source


### PR DESCRIPTION
Currently, we are using `peaceiris/actions-gh-ages@v3` to deploy the documentation for js-slang, however this workflow action uses Node 16 under the hood, which is already EOL.

A new version update for the workflow action has been released, and uses Node 20 instead. As such, this PR bumps the version of the workflow action used to the latest version.

More information about the newer workflow action here:
https://github.com/peaceiris/actions-gh-pages/blob/v4.0.0/CHANGELOG.md