### PR TITLE
Update git submodules to use relative paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/alt-langs/scheme/scm-slang"]
 	path = src/alt-langs/scheme/scm-slang
-	url = https://github.com/source-academy/scm-slang
+	url = ../../source-academy/scm-slang.git
 [submodule "src/py-slang"]
 	path = src/py-slang
-	url = https://github.com/source-academy/py-slang
+	url = ../../source-academy/py-slang.git


### PR DESCRIPTION
As mentioned in the discussion group, ssh users who clones the `js-slang` repo may face issues when checking out submodules (i.e. `py-slang` and `scm-slang`) if their https credentials are not yet properly set up. Thus, to better cater to both demographics (users cloning via the `https://` protocol and users cloning via the `ssh://` protocol), it would be better to use relative paths instead.

The reason why the relative path is set to traverse 2 level up (and then back with the `source-academy` prefix) is so that user forks will not be affected (as only going 1 level up will result in git trying to find a fork of the two repos `py-slang` and `scm-slang` under users' own account, which may or may not exist, and could be not the most updated version either).