### PR TITLE
Temporary fix to speed up `canAvoidInstr`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-slang",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "license": "Apache-2.0",
   "description": "Javascript-based implementations of Source, written in Typescript",
   "keywords": [

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine-heap.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine-heap.ts.snap
@@ -177,6 +177,7 @@ EnvTree {
                   "type": "Identifier",
                 },
                 "end": 101,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 12,
@@ -798,6 +799,7 @@ EnvTree {
                     "type": "Identifier",
                   },
                   "end": 101,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 12,
@@ -1443,6 +1445,7 @@ EnvTree {
                 "type": "Identifier",
               },
               "end": 101,
+              "isEnvDependent": true,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 12,
@@ -2109,6 +2112,7 @@ EnvTree {
                   "type": "Identifier",
                 },
                 "end": 101,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 12,
@@ -2500,6 +2504,7 @@ EnvTree {
           "type": "Identifier",
         },
         "end": 101,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 12,
@@ -2678,6 +2683,7 @@ EnvTree {
             "type": "Identifier",
           },
           "end": 101,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 12,

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine-heap.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine-heap.ts.snap
@@ -162,6 +162,7 @@ EnvTree {
                 ],
                 "callee": Node {
                   "end": 90,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 1,
@@ -784,6 +785,7 @@ EnvTree {
                   ],
                   "callee": Node {
                     "end": 90,
+                    "isEnvDependent": true,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 1,
@@ -1430,6 +1432,7 @@ EnvTree {
               ],
               "callee": Node {
                 "end": 90,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 1,
@@ -2097,6 +2100,7 @@ EnvTree {
                 ],
                 "callee": Node {
                   "end": 90,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 1,
@@ -2489,6 +2493,7 @@ EnvTree {
         ],
         "callee": Node {
           "end": 90,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -2668,6 +2673,7 @@ EnvTree {
           ],
           "callee": Node {
             "end": 90,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 1,
@@ -5606,6 +5612,7 @@ EnvTree {
                 ],
                 "callee": Node {
                   "end": 24,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 1,
@@ -5621,6 +5628,7 @@ EnvTree {
                   "type": "Identifier",
                 },
                 "end": 33,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 10,
@@ -6064,6 +6072,7 @@ EnvTree {
                   ],
                   "callee": Node {
                     "end": 24,
+                    "isEnvDependent": true,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 1,
@@ -6079,6 +6088,7 @@ EnvTree {
                     "type": "Identifier",
                   },
                   "end": 33,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 10,
@@ -6531,6 +6541,7 @@ EnvTree {
               ],
               "callee": Node {
                 "end": 24,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 1,
@@ -6546,6 +6557,7 @@ EnvTree {
                 "type": "Identifier",
               },
               "end": 33,
+              "isEnvDependent": true,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 10,
@@ -6897,6 +6909,7 @@ EnvTree {
         ],
         "callee": Node {
           "end": 24,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -6912,6 +6925,7 @@ EnvTree {
           "type": "Identifier",
         },
         "end": 33,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 10,
@@ -7066,6 +7080,7 @@ EnvTree {
           ],
           "callee": Node {
             "end": 24,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 1,
@@ -7081,6 +7096,7 @@ EnvTree {
             "type": "Identifier",
           },
           "end": 33,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 10,
@@ -7437,6 +7453,7 @@ EnvTree {
                       },
                     ],
                     "callee": Object {
+                      "isEnvDependent": false,
                       "loc": SourceLocation {
                         "end": Position {
                           "column": 1,
@@ -7450,6 +7467,7 @@ EnvTree {
                       "type": "Literal",
                       "value": [Function],
                     },
+                    "isEnvDependent": true,
                     "loc": undefined,
                     "optional": false,
                     "type": "CallExpression",
@@ -8281,6 +8299,7 @@ EnvTree {
                         },
                       ],
                       "callee": Object {
+                        "isEnvDependent": false,
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 1,
@@ -8294,6 +8313,7 @@ EnvTree {
                         "type": "Literal",
                         "value": [Function],
                       },
+                      "isEnvDependent": true,
                       "loc": undefined,
                       "optional": false,
                       "type": "CallExpression",
@@ -9224,6 +9244,7 @@ EnvTree {
                     },
                   ],
                   "callee": Object {
+                    "isEnvDependent": false,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 1,
@@ -9237,6 +9258,7 @@ EnvTree {
                     "type": "Literal",
                     "value": [Function],
                   },
+                  "isEnvDependent": true,
                   "loc": undefined,
                   "optional": false,
                   "type": "CallExpression",
@@ -10186,6 +10208,7 @@ EnvTree {
                 },
               ],
               "callee": Object {
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 1,
@@ -10199,6 +10222,7 @@ EnvTree {
                 "type": "Literal",
                 "value": [Function],
               },
+              "isEnvDependent": true,
               "loc": undefined,
               "optional": false,
               "type": "CallExpression",
@@ -10938,6 +10962,7 @@ EnvTree {
           },
         ],
         "callee": Object {
+          "isEnvDependent": false,
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -10951,6 +10976,7 @@ EnvTree {
           "type": "Literal",
           "value": [Function],
         },
+        "isEnvDependent": true,
         "loc": undefined,
         "optional": false,
         "type": "CallExpression",
@@ -11189,6 +11215,7 @@ EnvTree {
             },
           ],
           "callee": Object {
+            "isEnvDependent": false,
             "loc": SourceLocation {
               "end": Position {
                 "column": 1,
@@ -11202,6 +11229,7 @@ EnvTree {
             "type": "Literal",
             "value": [Function],
           },
+          "isEnvDependent": true,
           "loc": undefined,
           "optional": false,
           "type": "CallExpression",

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine-runtime-context.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine-runtime-context.ts.snap
@@ -1,5 +1,2805 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Avoid unnescessary environment instruction 1 1`] = `
+Control {
+  "storage": Array [
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 53,
+        "left": Node {
+          "arguments": Array [
+            Node {
+              "end": 48,
+              "left": Node {
+                "end": 46,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 6,
+                    "line": 4,
+                  },
+                },
+                "name": "n",
+                "start": 45,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 6,
+                  "line": 4,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 48,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 9,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 8,
+                    "line": 4,
+                  },
+                },
+                "raw": "1",
+                "start": 47,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 45,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 44,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 5,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 4,
+                "line": 4,
+              },
+            },
+            "name": "f",
+            "start": 43,
+            "type": "Identifier",
+          },
+          "end": 49,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 10,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 4,
+            },
+          },
+          "start": 43,
+          "type": "CallExpression",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 14,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 4,
+            "line": 4,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "end": 53,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 13,
+              "line": 4,
+            },
+          },
+          "raw": "2",
+          "start": 52,
+          "type": "Literal",
+          "value": 2,
+        },
+        "start": 43,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Node {
+      "end": 53,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "raw": "2",
+      "start": 52,
+      "type": "Literal",
+      "value": 2,
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 53,
+        "left": Node {
+          "arguments": Array [
+            Node {
+              "end": 48,
+              "left": Node {
+                "end": 46,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 6,
+                    "line": 4,
+                  },
+                },
+                "name": "n",
+                "start": 45,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 6,
+                  "line": 4,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 48,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 9,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 8,
+                    "line": 4,
+                  },
+                },
+                "raw": "1",
+                "start": 47,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 45,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 44,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 5,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 4,
+                "line": 4,
+              },
+            },
+            "name": "f",
+            "start": 43,
+            "type": "Identifier",
+          },
+          "end": 49,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 10,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 4,
+            },
+          },
+          "start": 43,
+          "type": "CallExpression",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 14,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 4,
+            "line": 4,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "end": 53,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 13,
+              "line": 4,
+            },
+          },
+          "raw": "2",
+          "start": 52,
+          "type": "Literal",
+          "value": 2,
+        },
+        "start": 43,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Node {
+      "end": 53,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Position {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "raw": "2",
+      "start": 52,
+      "type": "Literal",
+      "value": 2,
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 53,
+        "left": Node {
+          "arguments": Array [
+            Node {
+              "end": 48,
+              "left": Node {
+                "end": 46,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 6,
+                    "line": 4,
+                  },
+                },
+                "name": "n",
+                "start": 45,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 6,
+                  "line": 4,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 48,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 9,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 8,
+                    "line": 4,
+                  },
+                },
+                "raw": "1",
+                "start": 47,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 45,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 44,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 5,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 4,
+                "line": 4,
+              },
+            },
+            "name": "f",
+            "start": 43,
+            "type": "Identifier",
+          },
+          "end": 49,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 10,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 4,
+            },
+          },
+          "start": 43,
+          "type": "CallExpression",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 14,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 4,
+            "line": 4,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "end": 53,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 13,
+              "line": 4,
+            },
+          },
+          "raw": "2",
+          "start": 52,
+          "type": "Literal",
+          "value": 2,
+        },
+        "start": 43,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+  ],
+}
+`;
+
+exports[`Avoid unnescessary environment instruction 2 1`] = `
+Control {
+  "storage": Array [
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 53,
+        "left": Node {
+          "end": 44,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 5,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 4,
+            },
+          },
+          "name": "n",
+          "start": 43,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 14,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 4,
+            "line": 4,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "arguments": Array [
+            Node {
+              "end": 52,
+              "left": Node {
+                "end": 50,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 11,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 10,
+                    "line": 4,
+                  },
+                },
+                "name": "n",
+                "start": 49,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 10,
+                  "line": 4,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 52,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 13,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 12,
+                    "line": 4,
+                  },
+                },
+                "raw": "1",
+                "start": 51,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 49,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 48,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 8,
+                "line": 4,
+              },
+            },
+            "name": "f",
+            "start": 47,
+            "type": "Identifier",
+          },
+          "end": 53,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 8,
+              "line": 4,
+            },
+          },
+          "start": 47,
+          "type": "CallExpression",
+        },
+        "start": 43,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 53,
+        "left": Node {
+          "end": 44,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 5,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 4,
+            },
+          },
+          "name": "n",
+          "start": 43,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 14,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 4,
+            "line": 4,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "arguments": Array [
+            Node {
+              "end": 52,
+              "left": Node {
+                "end": 50,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 11,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 10,
+                    "line": 4,
+                  },
+                },
+                "name": "n",
+                "start": 49,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 10,
+                  "line": 4,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 52,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 13,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 12,
+                    "line": 4,
+                  },
+                },
+                "raw": "1",
+                "start": 51,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 49,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 48,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 8,
+                "line": 4,
+              },
+            },
+            "name": "f",
+            "start": 47,
+            "type": "Identifier",
+          },
+          "end": 53,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 8,
+              "line": 4,
+            },
+          },
+          "start": 47,
+          "type": "CallExpression",
+        },
+        "start": 43,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 53,
+        "left": Node {
+          "end": 44,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 5,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 4,
+            },
+          },
+          "name": "n",
+          "start": 43,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 14,
+            "line": 4,
+          },
+          "start": Position {
+            "column": 4,
+            "line": 4,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "arguments": Array [
+            Node {
+              "end": 52,
+              "left": Node {
+                "end": 50,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 11,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 10,
+                    "line": 4,
+                  },
+                },
+                "name": "n",
+                "start": 49,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 4,
+                },
+                "start": Position {
+                  "column": 10,
+                  "line": 4,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 52,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 13,
+                    "line": 4,
+                  },
+                  "start": Position {
+                    "column": 12,
+                    "line": 4,
+                  },
+                },
+                "raw": "1",
+                "start": 51,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 49,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 48,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 4,
+              },
+              "start": Position {
+                "column": 8,
+                "line": 4,
+              },
+            },
+            "name": "f",
+            "start": 47,
+            "type": "Identifier",
+          },
+          "end": 53,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Position {
+              "column": 8,
+              "line": 4,
+            },
+          },
+          "start": 47,
+          "type": "CallExpression",
+        },
+        "start": 43,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+  ],
+}
+`;
+
+exports[`Avoid unnescessary environment instruction 3 1`] = `
+Control {
+  "storage": Array [
+    Node {
+      "end": 86,
+      "expression": Node {
+        "end": 85,
+        "left": Node {
+          "end": 81,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 1,
+              "line": 8,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 8,
+            },
+          },
+          "name": "a",
+          "start": 80,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 5,
+            "line": 8,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 8,
+          },
+        },
+        "operator": "=",
+        "right": Node {
+          "end": 85,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 5,
+              "line": 8,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 8,
+            },
+          },
+          "raw": "2",
+          "start": 84,
+          "type": "Literal",
+          "value": 2,
+        },
+        "start": 80,
+        "type": "AssignmentExpression",
+      },
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 6,
+          "line": 8,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "start": 80,
+      "type": "ExpressionStatement",
+    },
+    Object {
+      "instrType": "Pop",
+      "srcNode": Node {
+        "end": 86,
+        "expression": Node {
+          "end": 85,
+          "left": Node {
+            "end": 81,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 1,
+                "line": 8,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 8,
+              },
+            },
+            "name": "a",
+            "start": 80,
+            "type": "Identifier",
+          },
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 5,
+              "line": 8,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 8,
+            },
+          },
+          "operator": "=",
+          "right": Node {
+            "end": 85,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 5,
+                "line": 8,
+              },
+              "start": Position {
+                "column": 4,
+                "line": 8,
+              },
+            },
+            "raw": "2",
+            "start": 84,
+            "type": "Literal",
+            "value": 2,
+          },
+          "start": 80,
+          "type": "AssignmentExpression",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 6,
+            "line": 8,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 8,
+          },
+        },
+        "start": 80,
+        "type": "ExpressionStatement",
+      },
+    },
+    Object {
+      "env": Object {
+        "head": Object {
+          "a": 1,
+          "f": [Function],
+        },
+        "heap": Heap {
+          "storage": Set {
+            [Function],
+          },
+        },
+        "id": "47",
+        "name": "programEnvironment",
+        "tail": Object {
+          "head": Object {
+            "$accumulate": [Function],
+            "$append": [Function],
+            "$build_list": [Function],
+            "$enum_list": [Function],
+            "$filter": [Function],
+            "$length": [Function],
+            "$list_to_string": [Function],
+            "$map": [Function],
+            "$remove": [Function],
+            "$remove_all": [Function],
+            "$reverse": [Function],
+            "__access_export__": [Function],
+            "__access_named_export__": [Function],
+            "accumulate": [Function],
+            "append": [Function],
+            "build_list": [Function],
+            "build_stream": [Function],
+            "enum_list": [Function],
+            "enum_stream": [Function],
+            "equal": [Function],
+            "eval_stream": [Function],
+            "filter": [Function],
+            "for_each": [Function],
+            "integers_from": [Function],
+            "is_stream": [Function],
+            "length": [Function],
+            "list_ref": [Function],
+            "list_to_stream": [Function],
+            "list_to_string": [Function],
+            "map": [Function],
+            "member": [Function],
+            "remove": [Function],
+            "remove_all": [Function],
+            "reverse": [Function],
+            "stream_append": [Function],
+            "stream_filter": [Function],
+            "stream_for_each": [Function],
+            "stream_length": [Function],
+            "stream_map": [Function],
+            "stream_member": [Function],
+            "stream_ref": [Function],
+            "stream_remove": [Function],
+            "stream_remove_all": [Function],
+            "stream_reverse": [Function],
+            "stream_tail": [Function],
+            "stream_to_list": [Function],
+          },
+          "heap": Heap {
+            "storage": Set {
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+              [Function],
+            },
+          },
+          "id": "0",
+          "name": "prelude",
+          "tail": Object {
+            "head": Object {
+              "Infinity": Infinity,
+              "NaN": NaN,
+              "apply_in_underlying_javascript": [Function],
+              "arity": [Function],
+              "array_length": [Function],
+              "call_cc": [Function],
+              "char_at": [Function],
+              "display": [Function],
+              "display_list": [Function],
+              "draw_data": [Function],
+              "error": [Function],
+              "get_time": [Function],
+              "head": [Function],
+              "is_array": [Function],
+              "is_boolean": [Function],
+              "is_function": [Function],
+              "is_list": [Function],
+              "is_null": [Function],
+              "is_number": [Function],
+              "is_pair": [Function],
+              "is_string": [Function],
+              "is_undefined": [Function],
+              "list": [Function],
+              "math_E": 2.718281828459045,
+              "math_LN10": 2.302585092994046,
+              "math_LN2": 0.6931471805599453,
+              "math_LOG10E": 0.4342944819032518,
+              "math_LOG2E": 1.4426950408889634,
+              "math_PI": 3.141592653589793,
+              "math_SQRT1_2": 0.7071067811865476,
+              "math_SQRT2": 1.4142135623730951,
+              "math_abs": [Function],
+              "math_acos": [Function],
+              "math_acosh": [Function],
+              "math_asin": [Function],
+              "math_asinh": [Function],
+              "math_atan": [Function],
+              "math_atan2": [Function],
+              "math_atanh": [Function],
+              "math_cbrt": [Function],
+              "math_ceil": [Function],
+              "math_clz32": [Function],
+              "math_cos": [Function],
+              "math_cosh": [Function],
+              "math_exp": [Function],
+              "math_expm1": [Function],
+              "math_floor": [Function],
+              "math_fround": [Function],
+              "math_hypot": [Function],
+              "math_imul": [Function],
+              "math_log": [Function],
+              "math_log10": [Function],
+              "math_log1p": [Function],
+              "math_log2": [Function],
+              "math_max": [Function],
+              "math_min": [Function],
+              "math_pow": [Function],
+              "math_random": [Function],
+              "math_round": [Function],
+              "math_sign": [Function],
+              "math_sin": [Function],
+              "math_sinh": [Function],
+              "math_sqrt": [Function],
+              "math_tan": [Function],
+              "math_tanh": [Function],
+              "math_trunc": [Function],
+              "pair": [Function],
+              "parse": [Function],
+              "parse_int": [Function],
+              "prompt": [Function],
+              "raw_display": [Function],
+              "set_head": [Function],
+              "set_tail": [Function],
+              "stream": [Function],
+              "stringify": [Function],
+              "tail": [Function],
+              "tokenize": [Function],
+              "undefined": undefined,
+            },
+            "heap": Heap {
+              "storage": null,
+            },
+            "id": "-1",
+            "name": "global",
+            "tail": null,
+          },
+        },
+      },
+      "instrType": "Environment",
+      "srcNode": Node {
+        "arguments": Array [
+          Node {
+            "end": 77,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 3,
+                "line": 7,
+              },
+              "start": Position {
+                "column": 2,
+                "line": 7,
+              },
+            },
+            "raw": "3",
+            "start": 76,
+            "type": "Literal",
+            "value": 3,
+          },
+        ],
+        "callee": Node {
+          "end": 75,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 1,
+              "line": 7,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 7,
+            },
+          },
+          "name": "f",
+          "start": 74,
+          "type": "Identifier",
+        },
+        "end": 78,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 4,
+            "line": 7,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 7,
+          },
+        },
+        "start": 74,
+        "type": "CallExpression",
+      },
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 70,
+        "left": Node {
+          "end": 61,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 7,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 6,
+              "line": 5,
+            },
+          },
+          "name": "n",
+          "start": 60,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 16,
+            "line": 5,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 5,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "arguments": Array [
+            Node {
+              "end": 69,
+              "left": Node {
+                "end": 67,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 13,
+                    "line": 5,
+                  },
+                  "start": Position {
+                    "column": 12,
+                    "line": 5,
+                  },
+                },
+                "name": "n",
+                "start": 66,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 12,
+                  "line": 5,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 69,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 15,
+                    "line": 5,
+                  },
+                  "start": Position {
+                    "column": 14,
+                    "line": 5,
+                  },
+                },
+                "raw": "1",
+                "start": 68,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 66,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 65,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 11,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 10,
+                "line": 5,
+              },
+            },
+            "name": "f",
+            "start": 64,
+            "type": "Identifier",
+          },
+          "end": 70,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 16,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "start": 64,
+          "type": "CallExpression",
+        },
+        "start": 60,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Object {
+      "env": Object {
+        "callExpression": Object {
+          "arguments": Array [
+            Object {
+              "loc": undefined,
+              "type": "Literal",
+              "value": 3,
+            },
+          ],
+          "callee": Node {
+            "end": 75,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 1,
+                "line": 7,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 7,
+              },
+            },
+            "name": "f",
+            "start": 74,
+            "type": "Identifier",
+          },
+          "end": 78,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 4,
+              "line": 7,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 7,
+            },
+          },
+          "start": 74,
+          "type": "CallExpression",
+        },
+        "head": Object {
+          "n": 3,
+        },
+        "heap": Heap {
+          "storage": null,
+        },
+        "id": "49",
+        "name": "f",
+        "tail": Object {
+          "head": Object {
+            "a": 1,
+            "f": [Function],
+          },
+          "heap": Heap {
+            "storage": Set {
+              [Function],
+            },
+          },
+          "id": "47",
+          "name": "programEnvironment",
+          "tail": Object {
+            "head": Object {
+              "$accumulate": [Function],
+              "$append": [Function],
+              "$build_list": [Function],
+              "$enum_list": [Function],
+              "$filter": [Function],
+              "$length": [Function],
+              "$list_to_string": [Function],
+              "$map": [Function],
+              "$remove": [Function],
+              "$remove_all": [Function],
+              "$reverse": [Function],
+              "__access_export__": [Function],
+              "__access_named_export__": [Function],
+              "accumulate": [Function],
+              "append": [Function],
+              "build_list": [Function],
+              "build_stream": [Function],
+              "enum_list": [Function],
+              "enum_stream": [Function],
+              "equal": [Function],
+              "eval_stream": [Function],
+              "filter": [Function],
+              "for_each": [Function],
+              "integers_from": [Function],
+              "is_stream": [Function],
+              "length": [Function],
+              "list_ref": [Function],
+              "list_to_stream": [Function],
+              "list_to_string": [Function],
+              "map": [Function],
+              "member": [Function],
+              "remove": [Function],
+              "remove_all": [Function],
+              "reverse": [Function],
+              "stream_append": [Function],
+              "stream_filter": [Function],
+              "stream_for_each": [Function],
+              "stream_length": [Function],
+              "stream_map": [Function],
+              "stream_member": [Function],
+              "stream_ref": [Function],
+              "stream_remove": [Function],
+              "stream_remove_all": [Function],
+              "stream_reverse": [Function],
+              "stream_tail": [Function],
+              "stream_to_list": [Function],
+            },
+            "heap": Heap {
+              "storage": Set {
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+              },
+            },
+            "id": "0",
+            "name": "prelude",
+            "tail": Object {
+              "head": Object {
+                "Infinity": Infinity,
+                "NaN": NaN,
+                "apply_in_underlying_javascript": [Function],
+                "arity": [Function],
+                "array_length": [Function],
+                "call_cc": [Function],
+                "char_at": [Function],
+                "display": [Function],
+                "display_list": [Function],
+                "draw_data": [Function],
+                "error": [Function],
+                "get_time": [Function],
+                "head": [Function],
+                "is_array": [Function],
+                "is_boolean": [Function],
+                "is_function": [Function],
+                "is_list": [Function],
+                "is_null": [Function],
+                "is_number": [Function],
+                "is_pair": [Function],
+                "is_string": [Function],
+                "is_undefined": [Function],
+                "list": [Function],
+                "math_E": 2.718281828459045,
+                "math_LN10": 2.302585092994046,
+                "math_LN2": 0.6931471805599453,
+                "math_LOG10E": 0.4342944819032518,
+                "math_LOG2E": 1.4426950408889634,
+                "math_PI": 3.141592653589793,
+                "math_SQRT1_2": 0.7071067811865476,
+                "math_SQRT2": 1.4142135623730951,
+                "math_abs": [Function],
+                "math_acos": [Function],
+                "math_acosh": [Function],
+                "math_asin": [Function],
+                "math_asinh": [Function],
+                "math_atan": [Function],
+                "math_atan2": [Function],
+                "math_atanh": [Function],
+                "math_cbrt": [Function],
+                "math_ceil": [Function],
+                "math_clz32": [Function],
+                "math_cos": [Function],
+                "math_cosh": [Function],
+                "math_exp": [Function],
+                "math_expm1": [Function],
+                "math_floor": [Function],
+                "math_fround": [Function],
+                "math_hypot": [Function],
+                "math_imul": [Function],
+                "math_log": [Function],
+                "math_log10": [Function],
+                "math_log1p": [Function],
+                "math_log2": [Function],
+                "math_max": [Function],
+                "math_min": [Function],
+                "math_pow": [Function],
+                "math_random": [Function],
+                "math_round": [Function],
+                "math_sign": [Function],
+                "math_sin": [Function],
+                "math_sinh": [Function],
+                "math_sqrt": [Function],
+                "math_tan": [Function],
+                "math_tanh": [Function],
+                "math_trunc": [Function],
+                "pair": [Function],
+                "parse": [Function],
+                "parse_int": [Function],
+                "prompt": [Function],
+                "raw_display": [Function],
+                "set_head": [Function],
+                "set_tail": [Function],
+                "stream": [Function],
+                "stringify": [Function],
+                "tail": [Function],
+                "tokenize": [Function],
+                "undefined": undefined,
+              },
+              "heap": Heap {
+                "storage": null,
+              },
+              "id": "-1",
+              "name": "global",
+              "tail": null,
+            },
+          },
+        },
+      },
+      "instrType": "Environment",
+      "srcNode": Node {
+        "arguments": Array [
+          Node {
+            "end": 69,
+            "left": Node {
+              "end": 67,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 12,
+                  "line": 5,
+                },
+              },
+              "name": "n",
+              "start": 66,
+              "type": "Identifier",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 15,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 12,
+                "line": 5,
+              },
+            },
+            "operator": "-",
+            "right": Node {
+              "end": 69,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 14,
+                  "line": 5,
+                },
+              },
+              "raw": "1",
+              "start": 68,
+              "type": "Literal",
+              "value": 1,
+            },
+            "start": 66,
+            "type": "BinaryExpression",
+          },
+        ],
+        "callee": Node {
+          "end": 65,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 11,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "name": "f",
+          "start": 64,
+          "type": "Identifier",
+        },
+        "end": 70,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 16,
+            "line": 5,
+          },
+          "start": Position {
+            "column": 10,
+            "line": 5,
+          },
+        },
+        "start": 64,
+        "type": "CallExpression",
+      },
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 70,
+        "left": Node {
+          "end": 61,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 7,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 6,
+              "line": 5,
+            },
+          },
+          "name": "n",
+          "start": 60,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 16,
+            "line": 5,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 5,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "arguments": Array [
+            Node {
+              "end": 69,
+              "left": Node {
+                "end": 67,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 13,
+                    "line": 5,
+                  },
+                  "start": Position {
+                    "column": 12,
+                    "line": 5,
+                  },
+                },
+                "name": "n",
+                "start": 66,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 12,
+                  "line": 5,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 69,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 15,
+                    "line": 5,
+                  },
+                  "start": Position {
+                    "column": 14,
+                    "line": 5,
+                  },
+                },
+                "raw": "1",
+                "start": 68,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 66,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 65,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 11,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 10,
+                "line": 5,
+              },
+            },
+            "name": "f",
+            "start": 64,
+            "type": "Identifier",
+          },
+          "end": 70,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 16,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "start": 64,
+          "type": "CallExpression",
+        },
+        "start": 60,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Object {
+      "env": Object {
+        "callExpression": Object {
+          "arguments": Array [
+            Object {
+              "loc": undefined,
+              "type": "Literal",
+              "value": 2,
+            },
+          ],
+          "callee": Node {
+            "end": 65,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 11,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 10,
+                "line": 5,
+              },
+            },
+            "name": "f",
+            "start": 64,
+            "type": "Identifier",
+          },
+          "end": 70,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 16,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "start": 64,
+          "type": "CallExpression",
+        },
+        "head": Object {
+          "n": 2,
+        },
+        "heap": Heap {
+          "storage": null,
+        },
+        "id": "50",
+        "name": "f",
+        "tail": Object {
+          "head": Object {
+            "a": 1,
+            "f": [Function],
+          },
+          "heap": Heap {
+            "storage": Set {
+              [Function],
+            },
+          },
+          "id": "47",
+          "name": "programEnvironment",
+          "tail": Object {
+            "head": Object {
+              "$accumulate": [Function],
+              "$append": [Function],
+              "$build_list": [Function],
+              "$enum_list": [Function],
+              "$filter": [Function],
+              "$length": [Function],
+              "$list_to_string": [Function],
+              "$map": [Function],
+              "$remove": [Function],
+              "$remove_all": [Function],
+              "$reverse": [Function],
+              "__access_export__": [Function],
+              "__access_named_export__": [Function],
+              "accumulate": [Function],
+              "append": [Function],
+              "build_list": [Function],
+              "build_stream": [Function],
+              "enum_list": [Function],
+              "enum_stream": [Function],
+              "equal": [Function],
+              "eval_stream": [Function],
+              "filter": [Function],
+              "for_each": [Function],
+              "integers_from": [Function],
+              "is_stream": [Function],
+              "length": [Function],
+              "list_ref": [Function],
+              "list_to_stream": [Function],
+              "list_to_string": [Function],
+              "map": [Function],
+              "member": [Function],
+              "remove": [Function],
+              "remove_all": [Function],
+              "reverse": [Function],
+              "stream_append": [Function],
+              "stream_filter": [Function],
+              "stream_for_each": [Function],
+              "stream_length": [Function],
+              "stream_map": [Function],
+              "stream_member": [Function],
+              "stream_ref": [Function],
+              "stream_remove": [Function],
+              "stream_remove_all": [Function],
+              "stream_reverse": [Function],
+              "stream_tail": [Function],
+              "stream_to_list": [Function],
+            },
+            "heap": Heap {
+              "storage": Set {
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+              },
+            },
+            "id": "0",
+            "name": "prelude",
+            "tail": Object {
+              "head": Object {
+                "Infinity": Infinity,
+                "NaN": NaN,
+                "apply_in_underlying_javascript": [Function],
+                "arity": [Function],
+                "array_length": [Function],
+                "call_cc": [Function],
+                "char_at": [Function],
+                "display": [Function],
+                "display_list": [Function],
+                "draw_data": [Function],
+                "error": [Function],
+                "get_time": [Function],
+                "head": [Function],
+                "is_array": [Function],
+                "is_boolean": [Function],
+                "is_function": [Function],
+                "is_list": [Function],
+                "is_null": [Function],
+                "is_number": [Function],
+                "is_pair": [Function],
+                "is_string": [Function],
+                "is_undefined": [Function],
+                "list": [Function],
+                "math_E": 2.718281828459045,
+                "math_LN10": 2.302585092994046,
+                "math_LN2": 0.6931471805599453,
+                "math_LOG10E": 0.4342944819032518,
+                "math_LOG2E": 1.4426950408889634,
+                "math_PI": 3.141592653589793,
+                "math_SQRT1_2": 0.7071067811865476,
+                "math_SQRT2": 1.4142135623730951,
+                "math_abs": [Function],
+                "math_acos": [Function],
+                "math_acosh": [Function],
+                "math_asin": [Function],
+                "math_asinh": [Function],
+                "math_atan": [Function],
+                "math_atan2": [Function],
+                "math_atanh": [Function],
+                "math_cbrt": [Function],
+                "math_ceil": [Function],
+                "math_clz32": [Function],
+                "math_cos": [Function],
+                "math_cosh": [Function],
+                "math_exp": [Function],
+                "math_expm1": [Function],
+                "math_floor": [Function],
+                "math_fround": [Function],
+                "math_hypot": [Function],
+                "math_imul": [Function],
+                "math_log": [Function],
+                "math_log10": [Function],
+                "math_log1p": [Function],
+                "math_log2": [Function],
+                "math_max": [Function],
+                "math_min": [Function],
+                "math_pow": [Function],
+                "math_random": [Function],
+                "math_round": [Function],
+                "math_sign": [Function],
+                "math_sin": [Function],
+                "math_sinh": [Function],
+                "math_sqrt": [Function],
+                "math_tan": [Function],
+                "math_tanh": [Function],
+                "math_trunc": [Function],
+                "pair": [Function],
+                "parse": [Function],
+                "parse_int": [Function],
+                "prompt": [Function],
+                "raw_display": [Function],
+                "set_head": [Function],
+                "set_tail": [Function],
+                "stream": [Function],
+                "stringify": [Function],
+                "tail": [Function],
+                "tokenize": [Function],
+                "undefined": undefined,
+              },
+              "heap": Heap {
+                "storage": null,
+              },
+              "id": "-1",
+              "name": "global",
+              "tail": null,
+            },
+          },
+        },
+      },
+      "instrType": "Environment",
+      "srcNode": Node {
+        "arguments": Array [
+          Node {
+            "end": 69,
+            "left": Node {
+              "end": 67,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 12,
+                  "line": 5,
+                },
+              },
+              "name": "n",
+              "start": 66,
+              "type": "Identifier",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 15,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 12,
+                "line": 5,
+              },
+            },
+            "operator": "-",
+            "right": Node {
+              "end": 69,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 14,
+                  "line": 5,
+                },
+              },
+              "raw": "1",
+              "start": 68,
+              "type": "Literal",
+              "value": 1,
+            },
+            "start": 66,
+            "type": "BinaryExpression",
+          },
+        ],
+        "callee": Node {
+          "end": 65,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 11,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "name": "f",
+          "start": 64,
+          "type": "Identifier",
+        },
+        "end": 70,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 16,
+            "line": 5,
+          },
+          "start": Position {
+            "column": 10,
+            "line": 5,
+          },
+        },
+        "start": 64,
+        "type": "CallExpression",
+      },
+    },
+    Object {
+      "instrType": "BinaryOperation",
+      "srcNode": Node {
+        "end": 70,
+        "left": Node {
+          "end": 61,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 7,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 6,
+              "line": 5,
+            },
+          },
+          "name": "n",
+          "start": 60,
+          "type": "Identifier",
+        },
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 16,
+            "line": 5,
+          },
+          "start": Position {
+            "column": 6,
+            "line": 5,
+          },
+        },
+        "operator": "*",
+        "right": Node {
+          "arguments": Array [
+            Node {
+              "end": 69,
+              "left": Node {
+                "end": 67,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 13,
+                    "line": 5,
+                  },
+                  "start": Position {
+                    "column": 12,
+                    "line": 5,
+                  },
+                },
+                "name": "n",
+                "start": 66,
+                "type": "Identifier",
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 12,
+                  "line": 5,
+                },
+              },
+              "operator": "-",
+              "right": Node {
+                "end": 69,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 15,
+                    "line": 5,
+                  },
+                  "start": Position {
+                    "column": 14,
+                    "line": 5,
+                  },
+                },
+                "raw": "1",
+                "start": 68,
+                "type": "Literal",
+                "value": 1,
+              },
+              "start": 66,
+              "type": "BinaryExpression",
+            },
+          ],
+          "callee": Node {
+            "end": 65,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 11,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 10,
+                "line": 5,
+              },
+            },
+            "name": "f",
+            "start": 64,
+            "type": "Identifier",
+          },
+          "end": 70,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 16,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "start": 64,
+          "type": "CallExpression",
+        },
+        "start": 60,
+        "type": "BinaryExpression",
+      },
+      "symbol": "*",
+    },
+    Object {
+      "env": Object {
+        "callExpression": Object {
+          "arguments": Array [
+            Object {
+              "loc": undefined,
+              "type": "Literal",
+              "value": 1,
+            },
+          ],
+          "callee": Node {
+            "end": 65,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 11,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 10,
+                "line": 5,
+              },
+            },
+            "name": "f",
+            "start": 64,
+            "type": "Identifier",
+          },
+          "end": 70,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 16,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "start": 64,
+          "type": "CallExpression",
+        },
+        "head": Object {
+          "n": 1,
+        },
+        "heap": Heap {
+          "storage": null,
+        },
+        "id": "51",
+        "name": "f",
+        "tail": Object {
+          "head": Object {
+            "a": 1,
+            "f": [Function],
+          },
+          "heap": Heap {
+            "storage": Set {
+              [Function],
+            },
+          },
+          "id": "47",
+          "name": "programEnvironment",
+          "tail": Object {
+            "head": Object {
+              "$accumulate": [Function],
+              "$append": [Function],
+              "$build_list": [Function],
+              "$enum_list": [Function],
+              "$filter": [Function],
+              "$length": [Function],
+              "$list_to_string": [Function],
+              "$map": [Function],
+              "$remove": [Function],
+              "$remove_all": [Function],
+              "$reverse": [Function],
+              "__access_export__": [Function],
+              "__access_named_export__": [Function],
+              "accumulate": [Function],
+              "append": [Function],
+              "build_list": [Function],
+              "build_stream": [Function],
+              "enum_list": [Function],
+              "enum_stream": [Function],
+              "equal": [Function],
+              "eval_stream": [Function],
+              "filter": [Function],
+              "for_each": [Function],
+              "integers_from": [Function],
+              "is_stream": [Function],
+              "length": [Function],
+              "list_ref": [Function],
+              "list_to_stream": [Function],
+              "list_to_string": [Function],
+              "map": [Function],
+              "member": [Function],
+              "remove": [Function],
+              "remove_all": [Function],
+              "reverse": [Function],
+              "stream_append": [Function],
+              "stream_filter": [Function],
+              "stream_for_each": [Function],
+              "stream_length": [Function],
+              "stream_map": [Function],
+              "stream_member": [Function],
+              "stream_ref": [Function],
+              "stream_remove": [Function],
+              "stream_remove_all": [Function],
+              "stream_reverse": [Function],
+              "stream_tail": [Function],
+              "stream_to_list": [Function],
+            },
+            "heap": Heap {
+              "storage": Set {
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+                [Function],
+              },
+            },
+            "id": "0",
+            "name": "prelude",
+            "tail": Object {
+              "head": Object {
+                "Infinity": Infinity,
+                "NaN": NaN,
+                "apply_in_underlying_javascript": [Function],
+                "arity": [Function],
+                "array_length": [Function],
+                "call_cc": [Function],
+                "char_at": [Function],
+                "display": [Function],
+                "display_list": [Function],
+                "draw_data": [Function],
+                "error": [Function],
+                "get_time": [Function],
+                "head": [Function],
+                "is_array": [Function],
+                "is_boolean": [Function],
+                "is_function": [Function],
+                "is_list": [Function],
+                "is_null": [Function],
+                "is_number": [Function],
+                "is_pair": [Function],
+                "is_string": [Function],
+                "is_undefined": [Function],
+                "list": [Function],
+                "math_E": 2.718281828459045,
+                "math_LN10": 2.302585092994046,
+                "math_LN2": 0.6931471805599453,
+                "math_LOG10E": 0.4342944819032518,
+                "math_LOG2E": 1.4426950408889634,
+                "math_PI": 3.141592653589793,
+                "math_SQRT1_2": 0.7071067811865476,
+                "math_SQRT2": 1.4142135623730951,
+                "math_abs": [Function],
+                "math_acos": [Function],
+                "math_acosh": [Function],
+                "math_asin": [Function],
+                "math_asinh": [Function],
+                "math_atan": [Function],
+                "math_atan2": [Function],
+                "math_atanh": [Function],
+                "math_cbrt": [Function],
+                "math_ceil": [Function],
+                "math_clz32": [Function],
+                "math_cos": [Function],
+                "math_cosh": [Function],
+                "math_exp": [Function],
+                "math_expm1": [Function],
+                "math_floor": [Function],
+                "math_fround": [Function],
+                "math_hypot": [Function],
+                "math_imul": [Function],
+                "math_log": [Function],
+                "math_log10": [Function],
+                "math_log1p": [Function],
+                "math_log2": [Function],
+                "math_max": [Function],
+                "math_min": [Function],
+                "math_pow": [Function],
+                "math_random": [Function],
+                "math_round": [Function],
+                "math_sign": [Function],
+                "math_sin": [Function],
+                "math_sinh": [Function],
+                "math_sqrt": [Function],
+                "math_tan": [Function],
+                "math_tanh": [Function],
+                "math_trunc": [Function],
+                "pair": [Function],
+                "parse": [Function],
+                "parse_int": [Function],
+                "prompt": [Function],
+                "raw_display": [Function],
+                "set_head": [Function],
+                "set_tail": [Function],
+                "stream": [Function],
+                "stringify": [Function],
+                "tail": [Function],
+                "tokenize": [Function],
+                "undefined": undefined,
+              },
+              "heap": Heap {
+                "storage": null,
+              },
+              "id": "-1",
+              "name": "global",
+              "tail": null,
+            },
+          },
+        },
+      },
+      "instrType": "Environment",
+      "srcNode": Node {
+        "arguments": Array [
+          Node {
+            "end": 69,
+            "left": Node {
+              "end": 67,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 13,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 12,
+                  "line": 5,
+                },
+              },
+              "name": "n",
+              "start": 66,
+              "type": "Identifier",
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 15,
+                "line": 5,
+              },
+              "start": Position {
+                "column": 12,
+                "line": 5,
+              },
+            },
+            "operator": "-",
+            "right": Node {
+              "end": 69,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 15,
+                  "line": 5,
+                },
+                "start": Position {
+                  "column": 14,
+                  "line": 5,
+                },
+              },
+              "raw": "1",
+              "start": 68,
+              "type": "Literal",
+              "value": 1,
+            },
+            "start": 66,
+            "type": "BinaryExpression",
+          },
+        ],
+        "callee": Node {
+          "end": 65,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 11,
+              "line": 5,
+            },
+            "start": Position {
+              "column": 10,
+              "line": 5,
+            },
+          },
+          "name": "f",
+          "start": 64,
+          "type": "Identifier",
+        },
+        "end": 70,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 16,
+            "line": 5,
+          },
+          "start": Position {
+            "column": 10,
+            "line": 5,
+          },
+        },
+        "start": 64,
+        "type": "CallExpression",
+      },
+    },
+    Node {
+      "end": 53,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 7,
+          "line": 4,
+        },
+        "start": Position {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "raw": "1",
+      "start": 52,
+      "type": "Literal",
+      "value": 1,
+    },
+  ],
+}
+`;
+
+exports[`Avoid unnescessary environment instruction 4 1`] = `
+Control {
+  "storage": Array [
+    Object {
+      "body": Array [
+        Node {
+          "end": 43,
+          "expression": Node {
+            "end": 42,
+            "left": Node {
+              "end": 38,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 5,
+                  "line": 7,
+                },
+                "start": Position {
+                  "column": 4,
+                  "line": 7,
+                },
+              },
+              "raw": "1",
+              "start": 37,
+              "type": "Literal",
+              "value": 1,
+            },
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 9,
+                "line": 7,
+              },
+              "start": Position {
+                "column": 4,
+                "line": 7,
+              },
+            },
+            "operator": "+",
+            "right": Node {
+              "end": 42,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 9,
+                  "line": 7,
+                },
+                "start": Position {
+                  "column": 8,
+                  "line": 7,
+                },
+              },
+              "raw": "2",
+              "start": 41,
+              "type": "Literal",
+              "value": 2,
+            },
+            "start": 37,
+            "type": "BinaryExpression",
+          },
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 10,
+              "line": 7,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 7,
+            },
+          },
+          "start": 37,
+          "type": "ExpressionStatement",
+        },
+        Node {
+          "end": 50,
+          "expression": Node {
+            "end": 49,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 5,
+                "line": 8,
+              },
+              "start": Position {
+                "column": 4,
+                "line": 8,
+              },
+            },
+            "raw": "3",
+            "start": 48,
+            "type": "Literal",
+            "value": 3,
+          },
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 6,
+              "line": 8,
+            },
+            "start": Position {
+              "column": 4,
+              "line": 8,
+            },
+          },
+          "start": 48,
+          "type": "ExpressionStatement",
+        },
+      ],
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 1,
+          "line": 9,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "type": "StatementSequence",
+    },
+    Object {
+      "body": Array [
+        Node {
+          "declarations": Array [
+            Node {
+              "end": 13,
+              "id": Node {
+                "end": 9,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 2,
+                  },
+                  "start": Position {
+                    "column": 6,
+                    "line": 2,
+                  },
+                },
+                "name": "a",
+                "start": 8,
+                "type": "Identifier",
+              },
+              "init": Node {
+                "end": 13,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 11,
+                    "line": 2,
+                  },
+                  "start": Position {
+                    "column": 10,
+                    "line": 2,
+                  },
+                },
+                "raw": "1",
+                "start": 12,
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 11,
+                  "line": 2,
+                },
+                "start": Position {
+                  "column": 6,
+                  "line": 2,
+                },
+              },
+              "start": 8,
+              "type": "VariableDeclarator",
+            },
+          ],
+          "end": 14,
+          "kind": "let",
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 12,
+              "line": 2,
+            },
+            "start": Position {
+              "column": 2,
+              "line": 2,
+            },
+          },
+          "start": 4,
+          "typability": "NotYetTyped",
+          "type": "VariableDeclaration",
+        },
+        Node {
+          "declarations": Array [
+            Node {
+              "end": 26,
+              "id": Node {
+                "end": 22,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 7,
+                    "line": 3,
+                  },
+                  "start": Position {
+                    "column": 6,
+                    "line": 3,
+                  },
+                },
+                "name": "b",
+                "start": 21,
+                "type": "Identifier",
+              },
+              "init": Node {
+                "end": 26,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 11,
+                    "line": 3,
+                  },
+                  "start": Position {
+                    "column": 10,
+                    "line": 3,
+                  },
+                },
+                "raw": "2",
+                "start": 25,
+                "type": "Literal",
+                "value": 2,
+              },
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 11,
+                  "line": 3,
+                },
+                "start": Position {
+                  "column": 6,
+                  "line": 3,
+                },
+              },
+              "start": 21,
+              "type": "VariableDeclarator",
+            },
+          ],
+          "end": 27,
+          "kind": "let",
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 12,
+              "line": 3,
+            },
+            "start": Position {
+              "column": 2,
+              "line": 3,
+            },
+          },
+          "start": 17,
+          "typability": "NotYetTyped",
+          "type": "VariableDeclaration",
+        },
+      ],
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 1,
+          "line": 4,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "type": "StatementSequence",
+    },
+  ],
+}
+`;
+
 exports[`Breakpoint steps match 1`] = `
 Array [
   7,

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine-runtime-context.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine-runtime-context.ts.snap
@@ -5,6 +5,7 @@ Control {
   "storage": Array [
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
         "left": Node {
@@ -102,6 +103,7 @@ Control {
         "operator": "*",
         "right": Node {
           "end": 53,
+          "isEnvDependent": false,
           "loc": SourceLocation {
             "end": Position {
               "column": 14,
@@ -124,6 +126,7 @@ Control {
     },
     Node {
       "end": 53,
+      "isEnvDependent": false,
       "loc": SourceLocation {
         "end": Position {
           "column": 14,
@@ -141,6 +144,7 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
         "left": Node {
@@ -238,6 +242,7 @@ Control {
         "operator": "*",
         "right": Node {
           "end": 53,
+          "isEnvDependent": false,
           "loc": SourceLocation {
             "end": Position {
               "column": 14,
@@ -260,6 +265,7 @@ Control {
     },
     Node {
       "end": 53,
+      "isEnvDependent": false,
       "loc": SourceLocation {
         "end": Position {
           "column": 14,
@@ -277,6 +283,7 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
         "left": Node {
@@ -374,6 +381,7 @@ Control {
         "operator": "*",
         "right": Node {
           "end": 53,
+          "isEnvDependent": false,
           "loc": SourceLocation {
             "end": Position {
               "column": 14,
@@ -403,6 +411,7 @@ Control {
   "storage": Array [
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
         "left": Node {
@@ -521,6 +530,7 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
         "left": Node {
@@ -639,6 +649,7 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
         "left": Node {
@@ -766,6 +777,7 @@ Control {
       "end": 86,
       "expression": Node {
         "end": 85,
+        "isEnvDependent": true,
         "left": Node {
           "end": 81,
           "loc": SourceLocation {
@@ -813,6 +825,7 @@ Control {
         "start": 80,
         "type": "AssignmentExpression",
       },
+      "isEnvDependent": true,
       "loc": SourceLocation {
         "end": Position {
           "column": 6,
@@ -832,6 +845,7 @@ Control {
         "end": 86,
         "expression": Node {
           "end": 85,
+          "isEnvDependent": true,
           "left": Node {
             "end": 81,
             "loc": SourceLocation {
@@ -879,6 +893,7 @@ Control {
           "start": 80,
           "type": "AssignmentExpression",
         },
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 6,
@@ -2541,8 +2556,10 @@ Control {
           "end": 43,
           "expression": Node {
             "end": 42,
+            "isEnvDependent": false,
             "left": Node {
               "end": 38,
+              "isEnvDependent": false,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 5,
@@ -2571,6 +2588,7 @@ Control {
             "operator": "+",
             "right": Node {
               "end": 42,
+              "isEnvDependent": false,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 9,
@@ -2589,6 +2607,7 @@ Control {
             "start": 37,
             "type": "BinaryExpression",
           },
+          "isEnvDependent": false,
           "loc": SourceLocation {
             "end": Position {
               "column": 10,
@@ -2606,6 +2625,7 @@ Control {
           "end": 50,
           "expression": Node {
             "end": 49,
+            "isEnvDependent": false,
             "loc": SourceLocation {
               "end": Position {
                 "column": 5,
@@ -2621,6 +2641,7 @@ Control {
             "type": "Literal",
             "value": 3,
           },
+          "isEnvDependent": false,
           "loc": SourceLocation {
             "end": Position {
               "column": 6,
@@ -2635,6 +2656,7 @@ Control {
           "type": "ExpressionStatement",
         },
       ],
+      "isEnvDependent": false,
       "loc": SourceLocation {
         "end": Position {
           "column": 1,

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine-runtime-context.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine-runtime-context.ts.snap
@@ -2,18 +2,22 @@
 
 exports[`Avoid unnescessary environment instruction 1 1`] = `
 Control {
+  "numEnvDependentItems": 0,
   "storage": Array [
     Object {
       "instrType": "BinaryOperation",
       "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
+        "isEnvDependent": true,
         "left": Node {
           "arguments": Array [
             Node {
               "end": 48,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 46,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 7,
@@ -41,6 +45,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 48,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 9,
@@ -62,6 +67,7 @@ Control {
           ],
           "callee": Node {
             "end": 44,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 5,
@@ -77,6 +83,7 @@ Control {
             "type": "Identifier",
           },
           "end": 49,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 10,
@@ -147,12 +154,15 @@ Control {
       "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
+        "isEnvDependent": true,
         "left": Node {
           "arguments": Array [
             Node {
               "end": 48,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 46,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 7,
@@ -180,6 +190,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 48,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 9,
@@ -201,6 +212,7 @@ Control {
           ],
           "callee": Node {
             "end": 44,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 5,
@@ -216,6 +228,7 @@ Control {
             "type": "Identifier",
           },
           "end": 49,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 10,
@@ -286,12 +299,15 @@ Control {
       "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
+        "isEnvDependent": true,
         "left": Node {
           "arguments": Array [
             Node {
               "end": 48,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 46,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 7,
@@ -319,6 +335,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 48,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 9,
@@ -340,6 +357,7 @@ Control {
           ],
           "callee": Node {
             "end": 44,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 5,
@@ -355,6 +373,7 @@ Control {
             "type": "Identifier",
           },
           "end": 49,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 10,
@@ -408,14 +427,17 @@ Control {
 
 exports[`Avoid unnescessary environment instruction 2 1`] = `
 Control {
+  "numEnvDependentItems": 0,
   "storage": Array [
     Object {
       "instrType": "BinaryOperation",
       "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
+        "isEnvDependent": true,
         "left": Node {
           "end": 44,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 5,
@@ -445,8 +467,10 @@ Control {
           "arguments": Array [
             Node {
               "end": 52,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 50,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 11,
@@ -474,6 +498,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 52,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 13,
@@ -495,6 +520,7 @@ Control {
           ],
           "callee": Node {
             "end": 48,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 9,
@@ -510,6 +536,7 @@ Control {
             "type": "Identifier",
           },
           "end": 53,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 14,
@@ -533,8 +560,10 @@ Control {
       "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
+        "isEnvDependent": true,
         "left": Node {
           "end": 44,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 5,
@@ -564,8 +593,10 @@ Control {
           "arguments": Array [
             Node {
               "end": 52,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 50,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 11,
@@ -593,6 +624,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 52,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 13,
@@ -614,6 +646,7 @@ Control {
           ],
           "callee": Node {
             "end": 48,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 9,
@@ -629,6 +662,7 @@ Control {
             "type": "Identifier",
           },
           "end": 53,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 14,
@@ -652,8 +686,10 @@ Control {
       "isEnvDependent": false,
       "srcNode": Node {
         "end": 53,
+        "isEnvDependent": true,
         "left": Node {
           "end": 44,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 5,
@@ -683,8 +719,10 @@ Control {
           "arguments": Array [
             Node {
               "end": 52,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 50,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 11,
@@ -712,6 +750,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 52,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 13,
@@ -733,6 +772,7 @@ Control {
           ],
           "callee": Node {
             "end": 48,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 9,
@@ -748,6 +788,7 @@ Control {
             "type": "Identifier",
           },
           "end": 53,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 14,
@@ -772,6 +813,7 @@ Control {
 
 exports[`Avoid unnescessary environment instruction 3 1`] = `
 Control {
+  "numEnvDependentItems": 5,
   "storage": Array [
     Node {
       "end": 86,
@@ -841,6 +883,7 @@ Control {
     },
     Object {
       "instrType": "Pop",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 86,
         "expression": Node {
@@ -1113,10 +1156,12 @@ Control {
         },
       },
       "instrType": "Environment",
+      "isEnvDependent": true,
       "srcNode": Node {
         "arguments": Array [
           Node {
             "end": 77,
+            "isEnvDependent": false,
             "loc": SourceLocation {
               "end": Position {
                 "column": 3,
@@ -1135,6 +1180,7 @@ Control {
         ],
         "callee": Node {
           "end": 75,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -1150,6 +1196,7 @@ Control {
           "type": "Identifier",
         },
         "end": 78,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 4,
@@ -1166,10 +1213,13 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 70,
+        "isEnvDependent": true,
         "left": Node {
           "end": 61,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 7,
@@ -1199,8 +1249,10 @@ Control {
           "arguments": Array [
             Node {
               "end": 69,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 67,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 13,
@@ -1228,6 +1280,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 69,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 15,
@@ -1249,6 +1302,7 @@ Control {
           ],
           "callee": Node {
             "end": 65,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 11,
@@ -1264,6 +1318,7 @@ Control {
             "type": "Identifier",
           },
           "end": 70,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 16,
@@ -1294,6 +1349,7 @@ Control {
           ],
           "callee": Node {
             "end": 75,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 1,
@@ -1309,6 +1365,7 @@ Control {
             "type": "Identifier",
           },
           "end": 78,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 4,
@@ -1535,12 +1592,15 @@ Control {
         },
       },
       "instrType": "Environment",
+      "isEnvDependent": true,
       "srcNode": Node {
         "arguments": Array [
           Node {
             "end": 69,
+            "isEnvDependent": true,
             "left": Node {
               "end": 67,
+              "isEnvDependent": true,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 13,
@@ -1568,6 +1628,7 @@ Control {
             "operator": "-",
             "right": Node {
               "end": 69,
+              "isEnvDependent": false,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 15,
@@ -1589,6 +1650,7 @@ Control {
         ],
         "callee": Node {
           "end": 65,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 11,
@@ -1604,6 +1666,7 @@ Control {
           "type": "Identifier",
         },
         "end": 70,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 16,
@@ -1620,10 +1683,13 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 70,
+        "isEnvDependent": true,
         "left": Node {
           "end": 61,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 7,
@@ -1653,8 +1719,10 @@ Control {
           "arguments": Array [
             Node {
               "end": 69,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 67,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 13,
@@ -1682,6 +1750,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 69,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 15,
@@ -1703,6 +1772,7 @@ Control {
           ],
           "callee": Node {
             "end": 65,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 11,
@@ -1718,6 +1788,7 @@ Control {
             "type": "Identifier",
           },
           "end": 70,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 16,
@@ -1748,6 +1819,7 @@ Control {
           ],
           "callee": Node {
             "end": 65,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 11,
@@ -1763,6 +1835,7 @@ Control {
             "type": "Identifier",
           },
           "end": 70,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 16,
@@ -1989,12 +2062,15 @@ Control {
         },
       },
       "instrType": "Environment",
+      "isEnvDependent": true,
       "srcNode": Node {
         "arguments": Array [
           Node {
             "end": 69,
+            "isEnvDependent": true,
             "left": Node {
               "end": 67,
+              "isEnvDependent": true,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 13,
@@ -2022,6 +2098,7 @@ Control {
             "operator": "-",
             "right": Node {
               "end": 69,
+              "isEnvDependent": false,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 15,
@@ -2043,6 +2120,7 @@ Control {
         ],
         "callee": Node {
           "end": 65,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 11,
@@ -2058,6 +2136,7 @@ Control {
           "type": "Identifier",
         },
         "end": 70,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 16,
@@ -2074,10 +2153,13 @@ Control {
     },
     Object {
       "instrType": "BinaryOperation",
+      "isEnvDependent": false,
       "srcNode": Node {
         "end": 70,
+        "isEnvDependent": true,
         "left": Node {
           "end": 61,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 7,
@@ -2107,8 +2189,10 @@ Control {
           "arguments": Array [
             Node {
               "end": 69,
+              "isEnvDependent": true,
               "left": Node {
                 "end": 67,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 13,
@@ -2136,6 +2220,7 @@ Control {
               "operator": "-",
               "right": Node {
                 "end": 69,
+                "isEnvDependent": false,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 15,
@@ -2157,6 +2242,7 @@ Control {
           ],
           "callee": Node {
             "end": 65,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 11,
@@ -2172,6 +2258,7 @@ Control {
             "type": "Identifier",
           },
           "end": 70,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 16,
@@ -2202,6 +2289,7 @@ Control {
           ],
           "callee": Node {
             "end": 65,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 11,
@@ -2217,6 +2305,7 @@ Control {
             "type": "Identifier",
           },
           "end": 70,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 16,
@@ -2443,12 +2532,15 @@ Control {
         },
       },
       "instrType": "Environment",
+      "isEnvDependent": true,
       "srcNode": Node {
         "arguments": Array [
           Node {
             "end": 69,
+            "isEnvDependent": true,
             "left": Node {
               "end": 67,
+              "isEnvDependent": true,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 13,
@@ -2476,6 +2568,7 @@ Control {
             "operator": "-",
             "right": Node {
               "end": 69,
+              "isEnvDependent": false,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 15,
@@ -2497,6 +2590,7 @@ Control {
         ],
         "callee": Node {
           "end": 65,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 11,
@@ -2512,6 +2606,7 @@ Control {
           "type": "Identifier",
         },
         "end": 70,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 16,
@@ -2528,6 +2623,7 @@ Control {
     },
     Node {
       "end": 53,
+      "isEnvDependent": false,
       "loc": SourceLocation {
         "end": Position {
           "column": 7,
@@ -2549,6 +2645,7 @@ Control {
 
 exports[`Avoid unnescessary environment instruction 4 1`] = `
 Control {
+  "numEnvDependentItems": 0,
   "storage": Array [
     Object {
       "body": Array [
@@ -2723,6 +2820,7 @@ Control {
             },
           ],
           "end": 14,
+          "isEnvDependent": true,
           "kind": "let",
           "loc": SourceLocation {
             "end": Position {
@@ -2806,6 +2904,7 @@ Control {
           "type": "VariableDeclaration",
         },
       ],
+      "isEnvDependent": false,
       "loc": SourceLocation {
         "end": Position {
           "column": 1,

--- a/src/cse-machine/__tests__/__snapshots__/cse-machine-unique-id.ts.snap
+++ b/src/cse-machine/__tests__/__snapshots__/cse-machine-unique-id.ts.snap
@@ -30,6 +30,7 @@ EnvTree {
                     ],
                     "callee": Node {
                       "end": 63,
+                      "isEnvDependent": true,
                       "loc": SourceLocation {
                         "end": Position {
                           "column": 1,
@@ -45,6 +46,7 @@ EnvTree {
                       "type": "Identifier",
                     },
                     "end": 78,
+                    "isEnvDependent": true,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 16,
@@ -1225,6 +1227,7 @@ EnvTree {
                       ],
                       "callee": Node {
                         "end": 63,
+                        "isEnvDependent": true,
                         "loc": SourceLocation {
                           "end": Position {
                             "column": 1,
@@ -1240,6 +1243,7 @@ EnvTree {
                         "type": "Identifier",
                       },
                       "end": 78,
+                      "isEnvDependent": true,
                       "loc": SourceLocation {
                         "end": Position {
                           "column": 16,
@@ -2519,6 +2523,7 @@ EnvTree {
                   ],
                   "callee": Node {
                     "end": 63,
+                    "isEnvDependent": true,
                     "loc": SourceLocation {
                       "end": Position {
                         "column": 1,
@@ -2534,6 +2539,7 @@ EnvTree {
                     "type": "Identifier",
                   },
                   "end": 78,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 16,
@@ -3863,6 +3869,7 @@ EnvTree {
               ],
               "callee": Node {
                 "end": 63,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 1,
@@ -3878,6 +3885,7 @@ EnvTree {
                 "type": "Identifier",
               },
               "end": 78,
+              "isEnvDependent": true,
               "loc": SourceLocation {
                 "end": Position {
                   "column": 16,
@@ -4966,6 +4974,7 @@ EnvTree {
         ],
         "callee": Node {
           "end": 63,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 1,
@@ -4981,6 +4990,7 @@ EnvTree {
           "type": "Identifier",
         },
         "end": 78,
+        "isEnvDependent": true,
         "loc": SourceLocation {
           "end": Position {
             "column": 16,
@@ -5273,6 +5283,7 @@ EnvTree {
           ],
           "callee": Node {
             "end": 63,
+            "isEnvDependent": true,
             "loc": SourceLocation {
               "end": Position {
                 "column": 1,
@@ -5288,6 +5299,7 @@ EnvTree {
             "type": "Identifier",
           },
           "end": 78,
+          "isEnvDependent": true,
           "loc": SourceLocation {
             "end": Position {
               "column": 16,
@@ -6903,6 +6915,7 @@ EnvTree {
                 ],
                 "callee": Node {
                   "end": 63,
+                  "isEnvDependent": true,
                   "loc": SourceLocation {
                     "end": Position {
                       "column": 1,
@@ -6918,6 +6931,7 @@ EnvTree {
                   "type": "Identifier",
                 },
                 "end": 78,
+                "isEnvDependent": true,
                 "loc": SourceLocation {
                   "end": Position {
                     "column": 16,

--- a/src/cse-machine/__tests__/cse-machine-runtime-context.ts
+++ b/src/cse-machine/__tests__/cse-machine-runtime-context.ts
@@ -6,9 +6,9 @@ import { stripIndent } from '../../utils/formatters'
 
 const getContextFrom = async (code: string, steps?: number) => {
   const context = mockContext(Chapter.SOURCE_4)
-  const options: RecursivePartial<IOptions> = { executionMethod: 'cse-machine' };
+  const options: RecursivePartial<IOptions> = { executionMethod: 'cse-machine' }
   if (steps !== undefined) {
-    options.steps = steps;
+    options.envSteps = steps
   }
   await runCodeInSource(code, context, options)
   return context
@@ -73,8 +73,9 @@ for (const context of contexts) {
   })
 }
 test('Avoid unnescessary environment instruction 1', async () => {
-  const context = getContextFrom(stripIndent(
-    `
+  const context = getContextFrom(
+    stripIndent(
+      `
       function f(n) {
         return n === 0
         ? 1
@@ -82,13 +83,16 @@ test('Avoid unnescessary environment instruction 1', async () => {
       }
       f(3);
     `
-  ), 61)
+    ),
+    61
+  )
   expect((await context).runtime.control).toMatchSnapshot()
 })
 
 test('Avoid unnescessary environment instruction 2', async () => {
-  const context = getContextFrom(stripIndent(
-    `
+  const context = getContextFrom(
+    stripIndent(
+      `
       function f(n) {
         return n === 0
         ? 1
@@ -96,13 +100,16 @@ test('Avoid unnescessary environment instruction 2', async () => {
       }
       f(3);
     `
-  ), 63)
+    ),
+    63
+  )
   expect((await context).runtime.control).toMatchSnapshot()
 })
 
 test('Avoid unnescessary environment instruction 3', async () => {
-  const context = getContextFrom(stripIndent(
-    `
+  const context = getContextFrom(
+    stripIndent(
+      `
       let a = 1;
       function f(n) {
           return n === 0
@@ -112,13 +119,16 @@ test('Avoid unnescessary environment instruction 3', async () => {
       f(3);
       a = 2;
     `
-  ), 66)
+    ),
+    66
+  )
   expect((await context).runtime.control).toMatchSnapshot()
 })
 
 test('Avoid unnescessary environment instruction 4', async () => {
-  const context = getContextFrom(stripIndent(
-    `
+  const context = getContextFrom(
+    stripIndent(
+      `
       {
         let a = 1;
         let b = 2;
@@ -129,6 +139,8 @@ test('Avoid unnescessary environment instruction 4', async () => {
           3;
       }
     `
-  ), 3)
+    ),
+    3
+  )
   expect((await context).runtime.control).toMatchSnapshot()
 })

--- a/src/cse-machine/__tests__/cse-machine-runtime-context.ts
+++ b/src/cse-machine/__tests__/cse-machine-runtime-context.ts
@@ -1,11 +1,16 @@
+import { IOptions } from '../..'
 import { mockContext } from '../../mocks/context'
 import { runCodeInSource } from '../../runner'
-import { Chapter } from '../../types'
+import { Chapter, RecursivePartial } from '../../types'
 import { stripIndent } from '../../utils/formatters'
 
-const getContextFrom = async (code: string) => {
+const getContextFrom = async (code: string, steps?: number) => {
   const context = mockContext(Chapter.SOURCE_4)
-  await runCodeInSource(code, context, { executionMethod: 'cse-machine' })
+  const options: RecursivePartial<IOptions> = { executionMethod: 'cse-machine' };
+  if (steps !== undefined) {
+    options.steps = steps;
+  }
+  await runCodeInSource(code, context, options)
   return context
 }
 
@@ -67,3 +72,63 @@ for (const context of contexts) {
     expect((await context).runtime.changepointSteps).toMatchSnapshot()
   })
 }
+test('Avoid unnescessary environment instruction 1', async () => {
+  const context = getContextFrom(stripIndent(
+    `
+      function f(n) {
+        return n === 0
+        ? 1
+        : f(n-1) * 2;
+      }
+      f(3);
+    `
+  ), 61)
+  expect((await context).runtime.control).toMatchSnapshot()
+})
+
+test('Avoid unnescessary environment instruction 2', async () => {
+  const context = getContextFrom(stripIndent(
+    `
+      function f(n) {
+        return n === 0
+        ? 1
+        : n * f(n-1);
+      }
+      f(3);
+    `
+  ), 63)
+  expect((await context).runtime.control).toMatchSnapshot()
+})
+
+test('Avoid unnescessary environment instruction 3', async () => {
+  const context = getContextFrom(stripIndent(
+    `
+      let a = 1;
+      function f(n) {
+          return n === 0
+          ? 1
+          : n * f(n-1);
+      }
+      f(3);
+      a = 2;
+    `
+  ), 66)
+  expect((await context).runtime.control).toMatchSnapshot()
+})
+
+test('Avoid unnescessary environment instruction 4', async () => {
+  const context = getContextFrom(stripIndent(
+    `
+      {
+        let a = 1;
+        let b = 2;
+      }
+      
+      {
+          1 + 2;
+          3;
+      }
+    `
+  ), 3)
+  expect((await context).runtime.control).toMatchSnapshot()
+})

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -442,9 +442,11 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     // Push ENVIRONMENT instruction if needed - if next control stack item
     // exists and is not an environment instruction, OR the control only contains
     // environment indepedent item
-    if (next 
-      && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)
-    && !canAvoidEnvInstr(control)) {
+    if (
+      next &&
+      !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) &&
+      !canAvoidEnvInstr(control)
+    ) {
       control.push(instr.envInstr(currentEnvironment(context), command))
     }
 
@@ -955,10 +957,12 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
 
       // Push ENVIRONMENT instruction if needed - if next control stack item
       // exists and is not an environment instruction, OR the control only contains
-    // environment indepedent item
-      if (next 
-        && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)
-      && !canAvoidEnvInstr(control)) {
+      // environment indepedent item
+      if (
+        next &&
+        !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT) &&
+        !canAvoidEnvInstr(control)
+      ) {
         control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
       }
 

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -75,6 +75,7 @@ import {
   isInstr,
   isNode,
   isSimpleFunction,
+  canAvoidEnvInstr,
   isStreamFn,
   popEnvironment,
   pushEnvironment,
@@ -439,8 +440,11 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     const next = control.peek()
 
     // Push ENVIRONMENT instruction if needed - if next control stack item
-    // exists and is not an environment instruction
-    if (next && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)) {
+    // exists and is not an environment instruction, OR the control only contains
+    // environment indepedent item
+    if (next 
+      && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)
+    && !canAvoidEnvInstr(control)) {
       control.push(instr.envInstr(currentEnvironment(context), command))
     }
 
@@ -950,8 +954,11 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       const next = control.peek()
 
       // Push ENVIRONMENT instruction if needed - if next control stack item
-      // exists and is not an environment instruction
-      if (next && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)) {
+      // exists and is not an environment instruction, OR the control only contains
+    // environment indepedent item
+      if (next 
+        && !(isInstr(next) && next.instrType === InstrType.ENVIRONMENT)
+      && !canAvoidEnvInstr(control)) {
         control.push(instr.envInstr(currentEnvironment(context), command.srcNode))
       }
 

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -113,7 +113,7 @@ export class Control extends Stack<ControlItem> {
   public pop(): ControlItem | undefined {
     const item = super.pop()
     if (item != undefined && isEnvDependent(item)) {
-      this.numEnvDependentItems --;
+      this.numEnvDependentItems--
     }
     return item
   }
@@ -123,7 +123,7 @@ export class Control extends Stack<ControlItem> {
     // testing
     itemsNew.forEach((item: ControlItem) => {
       if (isEnvDependent(item)) {
-        this.numEnvDependentItems++;
+        this.numEnvDependentItems++
       }
     })
     super.push(...itemsNew)

--- a/src/cse-machine/types.ts
+++ b/src/cse-machine/types.ts
@@ -93,7 +93,13 @@ export type Instr =
   | GenContInstr
   | ResumeContInstr
 
-export type ControlItem = Node | Instr
+export type ControlItem = (Node | Instr) & {
+  isEnvDependent?: boolean
+}
+// {
+//   body: Node | Instr
+//   isEnvDependent: boolean
+// }
 
 // Every array also has the properties `id` and `environment` for use in the frontend CSE Machine
 export type EnvArray = any[] & {

--- a/src/cse-machine/types.ts
+++ b/src/cse-machine/types.ts
@@ -96,10 +96,6 @@ export type Instr =
 export type ControlItem = (Node | Instr) & {
   isEnvDependent?: boolean
 }
-// {
-//   body: Node | Instr
-//   isEnvDependent: boolean
-// }
 
 // Every array also has the properties `id` and `environment` for use in the frontend CSE Machine
 export type EnvArray = any[] & {


### PR DESCRIPTION
Following the fact that the check `canAvoidInstr` implemented in previous PR #1687 is too slow, this PR implements a temporary fix by caching the result of `isEnvDependent` as a field for each `ControlItem`