### PR TITLE
Streamline CSE machine

### DIFF
--- a/src/cse-machine/__tests__/continuations.ts
+++ b/src/cse-machine/__tests__/continuations.ts
@@ -1,5 +1,20 @@
-import { Call_cc } from '../continuations'
+import { Call_cc, Continuation, isCallWithCurrentContinuation } from '../continuations'
+import { Control, Stash } from '../interpreter'
 
-test('Call/cc is a singleton', () => {
+test('call/cc is a singleton', () => {
   expect(Call_cc.get()).toBe(Call_cc.get())
+})
+
+test('call/cc toString', () => {
+  expect(Call_cc.get().toString()).toBe('call/cc')
+})
+
+test('isCallWithCurrentContinuation works on call/cc only', () => {
+  expect(isCallWithCurrentContinuation(Call_cc.get())).toBe(true)
+  expect(isCallWithCurrentContinuation(1)).toBe(false)
+})
+
+test('Continuation toString', () => {
+  const cont = new Continuation(new Control(), new Stash(), [])
+  expect(cont.toString()).toBe('continuation')
 })

--- a/src/cse-machine/__tests__/continuations.ts
+++ b/src/cse-machine/__tests__/continuations.ts
@@ -1,0 +1,5 @@
+import { Call_cc } from '../continuations'
+
+test('Call/cc is a singleton', () => {
+  expect(Call_cc.get()).toBe(Call_cc.get())
+})

--- a/src/cse-machine/continuations.ts
+++ b/src/cse-machine/continuations.ts
@@ -8,16 +8,26 @@ import { Control, Stash } from './interpreter'
  * If the interpreter sees this specific function, a continuation at the current
  * point of evaluation is executed instead of a regular function call.
  */
+export class Call_cc extends Function {
+  private static instance: Call_cc = new Call_cc()
 
-export function call_with_current_continuation(f: Function): any {
-  return 'SHOULD NOT BE CALLED!'
+  private constructor() {
+    super()
+  }
+
+  public static get(): Call_cc {
+    return Call_cc.instance
+  }
+
+  public toString(): string {
+    return 'call/cc'
+  }
 }
 
-/**
- * Checks if the function refers to the designated function object call/cc.
- */
-export function isCallWithCurrentContinuation(f: Function): boolean {
-  return f === call_with_current_continuation
+export const call_with_current_continuation = Call_cc.get()
+
+export function isCallWithCurrentContinuation(value: any): boolean {
+  return value === call_with_current_continuation
 }
 
 /**

--- a/src/cse-machine/continuations.ts
+++ b/src/cse-machine/continuations.ts
@@ -75,7 +75,7 @@ export function isContinuation(f: Function): f is Continuation {
 /**
  * Provides an adequate representation of what calling
  * call/cc or continuations looks like, to give to the
- * GENERATE_CONT and RESUME_CONT instructions.
+ * APPLICATION instruction.
  */
 export function makeDummyContCallExpression(callee: string, argument: string): es.CallExpression {
   return {

--- a/src/cse-machine/continuations.ts
+++ b/src/cse-machine/continuations.ts
@@ -9,8 +9,8 @@ import { Control, Stash } from './interpreter'
  * point of evaluation is executed instead of a regular function call.
  */
 
-export function call_with_current_continuation(f: any): any {
-  return f()
+export function call_with_current_continuation(f: Function): any {
+  return 'SHOULD NOT BE CALLED!'
 }
 
 /**
@@ -28,48 +28,35 @@ export function isCallWithCurrentContinuation(f: Function): boolean {
  * Continuations and functions are treated as the same by
  * the typechecker so that they can be first-class values.
  */
-export interface Continuation extends Function {
-  control: Control
-  stash: Stash
-  env: Environment[]
-}
+export class Continuation extends Function {
+  private control: Control
+  private stash: Stash
+  private env: Environment[]
 
-// As the continuation needs to be immutable (we can call it several times)
-// we need to copy its elements whenever we access them
-export function getContinuationControl(cn: Continuation): Control {
-  return cn.control.copy()
-}
+  constructor(control: Control, stash: Stash, env: Environment[]) {
+    super()
+    this.control = control.copy()
+    this.stash = stash.copy()
+    this.env = [...env]
+  }
 
-export function getContinuationStash(cn: Continuation): Stash {
-  return cn.stash.copy()
-}
+  // As the continuation needs to be immutable (we can call it several times)
+  // we need to copy its elements whenever we access them
+  public getControl(): Control {
+    return this.control.copy()
+  }
 
-export function getContinuationEnv(cn: Continuation): Environment[] {
-  return [...cn.env]
-}
+  public getStash(): Stash {
+    return this.stash.copy()
+  }
 
-export function makeContinuation(control: Control, stash: Stash, env: Environment[]): Function {
-  // Cast a function into a continuation
-  // a continuation may take any amount of arguments
-  const fn: Function = (...x: any[]) => x
-  const cn: Continuation = fn as Continuation
+  public getEnv(): Environment[] {
+    return [...this.env]
+  }
 
-  // Set the control, stash and environment
-  // as shallow copies of the given program equivalents
-  cn.control = control.copy()
-  cn.stash = stash.copy()
-  cn.env = [...env]
-
-  // Return the continuation as a function so that
-  // the type checker allows it to be called
-  return cn as Function
-}
-
-/**
- * Checks whether a given function is actually a continuation.
- */
-export function isContinuation(f: Function): f is Continuation {
-  return 'control' in f && 'stash' in f && 'env' in f
+  public toString(): string {
+    return 'continuation'
+  }
 }
 
 /**

--- a/src/cse-machine/instrCreator.ts
+++ b/src/cse-machine/instrCreator.ts
@@ -13,10 +13,8 @@ import {
   BranchInstr,
   EnvInstr,
   ForInstr,
-  GenContInstr,
   Instr,
   InstrType,
-  ResumeContInstr,
   UnOpInstr,
   WhileInstr
 } from './types'
@@ -136,16 +134,5 @@ export const breakInstr = (srcNode: Node): Instr => ({
 
 export const breakMarkerInstr = (srcNode: Node): Instr => ({
   instrType: InstrType.BREAK_MARKER,
-  srcNode
-})
-
-export const genContInstr = (srcNode: Node): GenContInstr => ({
-  instrType: InstrType.GENERATE_CONT,
-  srcNode
-})
-
-export const resumeContInstr = (numOfArgs: number, srcNode: es.Node): ResumeContInstr => ({
-  numOfArgs: numOfArgs,
-  instrType: InstrType.RESUME_CONT,
   srcNode
 })

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -1195,56 +1195,5 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     }
   },
 
-  [InstrType.BREAK_MARKER]: function () {},
-
-  [InstrType.GENERATE_CONT]: function (
-    _command: GenContInstr,
-    context: Context,
-    control: Control,
-    stash: Stash
-  ) {
-    throw new Error('This should never be called!')
-    const contControl = control.copy()
-    const contStash = stash.copy()
-    const contEnv = context.runtime.environments
-
-    // Remove all data related to the continuation-consuming function
-    contControl.pop()
-    contStash.pop()
-
-    // Now this will accurately represent the slice of the
-    // program execution at the time of the call/cc call
-    const continuation = makeContinuation(contControl, contStash, contEnv)
-
-    stash.push(continuation)
-  },
-
-  [InstrType.RESUME_CONT]: function (
-    command: ResumeContInstr,
-    context: Context,
-    control: Control,
-    stash: Stash
-  ) {
-    throw new Error('This should never be called!')
-    // pop the arguments
-    const args: Value[] = []
-    for (let i = 0; i < command.numOfArgs; i++) {
-      args.unshift(stash.pop())
-    }
-    const cn: Continuation = stash.pop() as Continuation
-
-    const contControl = getContinuationControl(cn)
-    const contStash = getContinuationStash(cn)
-    const contEnv = getContinuationEnv(cn)
-
-    // Set the control and stash to the continuation's control and stash
-    control.setTo(contControl)
-    stash.setTo(contStash)
-
-    // Push the arguments given to the continuation back onto the stash
-    stash.push(...args)
-
-    // Restore the environment pointer to that of the continuation's environment
-    context.runtime.environments = contEnv
-  }
+  [InstrType.BREAK_MARKER]: function () {}
 }

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -954,16 +954,29 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       // Check for number of arguments mismatch error
       checkNumberOfArguments(context, func, args, command.srcNode)
 
-      const dummyContCallExpression = makeDummyContCallExpression('f', 'cont')
+      // const dummyContCallExpression = makeDummyContCallExpression('f', 'cont')
 
-      // Restore the state of the stash,
-      // but replace the function application instruction with
-      // a resume continuation instruction
-      stash.push(func)
-      // we need to push the arguments back onto the stash
-      // as well
+      // // Restore the state of the stash,
+      // // but replace the function application instruction with
+      // // a resume continuation instruction
+      // stash.push(func)
+      // // we need to push the arguments back onto the stash
+      // // as well
+      // stash.push(...args)
+      // control.push(instr.resumeContInstr(command.numOfArgs, dummyContCallExpression))
+
+      // get the C, S, E from the continuation
+      const contControl = getContinuationControl(func)
+      const contStash = getContinuationStash(func)
+      const contEnv = getContinuationEnv(func)
+
+      // update the C, S, E of the current context
+      control.setTo(contControl)
+      stash.setTo(contStash)
+      context.runtime.environments = contEnv
+
+      // push the arguments back onto the stash
       stash.push(...args)
-      control.push(instr.resumeContInstr(command.numOfArgs, dummyContCallExpression))
       return
     }
 
@@ -1192,6 +1205,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
     control: Control,
     stash: Stash
   ) {
+    throw new Error('This should never be called!')
     // pop the arguments
     const args: Value[] = []
     for (let i = 0; i < command.numOfArgs; i++) {

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -23,12 +23,8 @@ import * as seq from '../utils/statementSeqTransform'
 import { checkProgramForUndefinedVariables } from '../validator/validator'
 import Closure from './closure'
 import {
-  getContinuationControl,
-  getContinuationEnv,
-  getContinuationStash,
+  Continuation,
   isCallWithCurrentContinuation,
-  isContinuation,
-  makeContinuation,
   makeDummyContCallExpression
 } from './continuations'
 import * as instr from './instrCreator'
@@ -948,7 +944,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       // as such, there is no further need to modify the
       // copied C, S and E!
 
-      const continuation = makeContinuation(contControl, contStash, contEnv)
+      const continuation = new Continuation(contControl, contStash, contEnv)
 
       // Get the callee
       const cont_callee: Value = args[0]
@@ -966,7 +962,7 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       return
     }
 
-    if (isContinuation(func)) {
+    if (func instanceof Continuation) {
       // Check for number of arguments mismatch error
       checkNumberOfArguments(context, func, args, command.srcNode)
 
@@ -982,9 +978,9 @@ const cmdEvaluators: { [type: string]: CmdEvaluator } = {
       // control.push(instr.resumeContInstr(command.numOfArgs, dummyContCallExpression))
 
       // get the C, S, E from the continuation
-      const contControl = getContinuationControl(func)
-      const contStash = getContinuationStash(func)
-      const contEnv = getContinuationEnv(func)
+      const contControl = func.getControl()
+      const contStash = func.getStash()
+      const contEnv = func.getEnv()
 
       // update the C, S, E of the current context
       control.setTo(contControl)

--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -23,7 +23,6 @@ import * as seq from '../utils/statementSeqTransform'
 import { checkProgramForUndefinedVariables } from '../validator/validator'
 import Closure from './closure'
 import {
-  Continuation,
   getContinuationControl,
   getContinuationEnv,
   getContinuationStash,
@@ -45,10 +44,8 @@ import {
   CseError,
   EnvInstr,
   ForInstr,
-  GenContInstr,
   Instr,
   InstrType,
-  ResumeContInstr,
   UnOpInstr,
   WhileInstr
 } from './types'

--- a/src/cse-machine/types.ts
+++ b/src/cse-machine/types.ts
@@ -74,12 +74,6 @@ export interface ArrLitInstr extends BaseInstr {
   arity: number
 }
 
-export type GenContInstr = BaseInstr
-
-export interface ResumeContInstr extends BaseInstr {
-  numOfArgs: number
-}
-
 export type Instr =
   | BaseInstr
   | WhileInstr

--- a/src/cse-machine/types.ts
+++ b/src/cse-machine/types.ts
@@ -22,9 +22,7 @@ export enum InstrType {
   CONTINUE = 'Continue',
   CONTINUE_MARKER = 'ContinueMarker',
   BREAK = 'Break',
-  BREAK_MARKER = 'BreakMarker',
-  GENERATE_CONT = 'GenerateContinuation',
-  RESUME_CONT = 'ResumeContinuation'
+  BREAK_MARKER = 'BreakMarker'
 }
 
 interface BaseInstr {
@@ -90,8 +88,6 @@ export type Instr =
   | BranchInstr
   | EnvInstr
   | ArrLitInstr
-  | GenContInstr
-  | ResumeContInstr
 
 export type ControlItem = (Node | Instr) & {
   isEnvDependent?: boolean

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -6,12 +6,12 @@ import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import type { Environment, Node, StatementSequence, Value } from '../types'
 import * as ast from '../utils/ast/astCreator'
-import { isContinuation } from './continuations'
 import Heap from './heap'
 import * as instr from './instrCreator'
 import { Control } from './interpreter'
 import { AppInstr, EnvArray, ControlItem, Instr, InstrType } from './types'
 import Closure from './closure'
+import { Continuation } from './continuations'
 
 /**
  * Typeguard for Instr to distinguish between program statements and instructions.
@@ -505,7 +505,7 @@ export const checkNumberOfArguments = (
         )
       )
     }
-  } else if (isContinuation(callee)) {
+  } else if (callee instanceof Continuation) {
     // Continuations have variadic arguments,
     // and so we can let it pass
     // TODO: in future, if we can somehow check the number of arguments

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -11,7 +11,7 @@ import * as instr from './instrCreator'
 import { Control } from './interpreter'
 import { AppInstr, EnvArray, ControlItem, Instr, InstrType } from './types'
 import Closure from './closure'
-import { Continuation } from './continuations'
+import { Continuation, isCallWithCurrentContinuation } from './continuations'
 
 /**
  * Typeguard for Instr to distinguish between program statements and instructions.
@@ -505,6 +505,15 @@ export const checkNumberOfArguments = (
         )
       )
     }
+  } else if (isCallWithCurrentContinuation(callee)) {
+    // call/cc should have a single argument
+    if (args.length !== 1) {
+      return handleRuntimeError(
+        context,
+        new errors.InvalidNumberOfArguments(exp, 1, args.length, false)
+      )
+    }
+    return undefined
   } else if (callee instanceof Continuation) {
     // Continuations have variadic arguments,
     // and so we can let it pass

--- a/src/cse-machine/utils.ts
+++ b/src/cse-machine/utils.ts
@@ -508,7 +508,7 @@ export const checkNumberOfArguments = (
   } else if (isContinuation(callee)) {
     // Continuations have variadic arguments,
     // and so we can let it pass
-    // in future, if we can somehow check the number of arguments
+    // TODO: in future, if we can somehow check the number of arguments
     // expected by the continuation, we can add a check here.
     return undefined
   } else {


### PR DESCRIPTION
### Description

Streamlines the logic behind continuations, removing GENERATE_CONT and RESUME_CONT instructions. Instead, continuations are now generated immediately upon calling call/cc, and continuations are applied immediately upon being called, without need for other instructions. All logic has been moved to CALL.

Also changes the continuation implementation to be less hacky. Instead of appending continuation data (C, S and E) to a function, continuations now have their own class representation.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code quality improvements

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
