### PR TITLE
Fix readme for running js-slang without adding to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ cd dist
 $ npm link
 ```
 
-If you do not wish to add \"js-slang\" to your PATH, replace \"js-slang\" with \"node dist/repl/repl.js\" in the following examples.
+If you do not wish to add \"js-slang\" to your PATH, replace \"js-slang\" with \"node dist/repl\" in the following examples.
 
 To try out _Source_ in a REPL, run
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the changes proposed, and include relevant motivation and context. List issues/pull requests that are related for this change (if any). -->

Following instructions on README for running the REPL without adding js-slang to PATH does not work as the command `node dist/repl/repl.js` quits immediately. This was due to https://github.com/source-academy/js-slang/pull/1672 refactored runner execution and changed the entry point to the REPL from `src/repl/repl.ts` to `src/repl/index.ts`.

This is a minor issue since anyone who follows the documentation to link js-slang to PATH using `npm link` will not be affected by the readme bug.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have tested this code
- [ ] I have updated the documentation
