### PR TITLE
1718 stepper built in function errors not caught and crashing the frontend

### DIFF
--- a/src/errors/errors.ts
+++ b/src/errors/errors.ts
@@ -10,8 +10,8 @@ import { RuntimeSourceError } from './runtimeSourceError'
 
 //Wrap build-in function error in SourceError
 export class BuiltInFunctionError extends RuntimeSourceError {
-  constructor(node: Node, private explanation: String) {
-    super(node)
+  constructor(private explanation: String) {
+    super(undefined)
     this.explanation = explanation
   }
 

--- a/src/stepper/__tests__/__snapshots__/stepper.ts.snap
+++ b/src/stepper/__tests__/__snapshots__/stepper.ts.snap
@@ -5507,12 +5507,12 @@ math_abs(-1);
 
 exports[`Test catching errors from built in function Incorrect number of arguments 1`] = `
 "Start of evaluation
-"
+Expected 2 arguments, but got 1"
 `;
 
 exports[`Test catching errors from built in function Incorrect type of argument for math function 1`] = `
 "Start of evaluation
-"
+Math functions must be called with number arguments"
 `;
 
 exports[`Test catching errors from built in function Incorrect type of arguments for module function 1`] = `

--- a/src/stepper/util.ts
+++ b/src/stepper/util.ts
@@ -4,10 +4,13 @@ import { Context } from '..'
 import * as errors from '../errors/errors'
 import { RuntimeSourceError } from '../errors/runtimeSourceError'
 import { BlockExpression, Environment, Node, substituterNodes, Value } from '../types'
+import { UNKNOWN_LOCATION } from '../constants'
 import * as builtin from './lib'
 
 export function prettyPrintError(error: RuntimeSourceError): string {
-  return `Line ${error.location.start.line}: ${error.explain()}`
+  return error.location == UNKNOWN_LOCATION
+    ? error.explain()
+    : `Line ${error.location.start.line}: ${error.explain()}`
 }
 
 export function isBuiltinFunction(node: substituterNodes): boolean {


### PR DESCRIPTION
### Description

Built In Function's Error handling throws Errors that the stepper cannot handle. Changed the errors to SourceErrors instead. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

### How to test

Test exists, wrong expected answers

### Note

`BuiltInFunctionError` changed to only take in explanation without node to handle all built in function error. These errors without a node should be handled by the parser instead. 

### Checklist

- [x] I have tested this code
- [ ] I have updated the documentation
