### PR TITLE
Fix faulty regex for syntax highlighter

### DIFF
--- a/src/__tests__/mode.ts
+++ b/src/__tests__/mode.ts
@@ -79,7 +79,7 @@ test('constants are not correctly loaded', () => {
 })
 
 test('operator syntax type error', () => {
-  const code = 'const num = 3; \nnum++; \nnum--; \nnum += 1;'
+  const code = 'const num = 3; \nnum++; \nnum--; \nnum += 1; \n5 + num |2;'
 
   setSession(Chapter.SOURCE_1, defaultVariant, defaultExternal, code)
 
@@ -91,6 +91,15 @@ test('operator syntax type error', () => {
 
   const token3 = session.getTokenAt(3, 5)
   expect(expectedBool(token3, CATEGORY.forbidden)).toBe(true)
+
+  const token4 = session.getTokenAt(4, 1)
+  expect(expectedBool(token4, CATEGORY.number)).toBe(true)
+
+  const token5 = session.getTokenAt(4, 9)
+  expect(expectedBool(token5, CATEGORY.forbidden)).toBe(true)
+
+  const token6 = session.getTokenAt(4, 10)
+  expect(expectedBool(token6, CATEGORY.number)).toBe(true)
 })
 
 test('forbidden keywords', () => {

--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -113,9 +113,9 @@ export function HighlightRulesSelector(
     const VariantForbiddenRegexSelector = () => {
       if (variant === Variant.TYPED) {
         // Removes the part of the regex that highlights singular |, since Typed variant uses union types
-        return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|[^&]*&[^&]/
+        return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)*&(?!&)/
       }
-      return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|[^&]*&[^&]|[^\|]*\|[^\|]/
+      return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)*&(?!&)|(?<!\|)\|(?!\|)/
     }
 
     // @ts-ignore

--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -113,9 +113,9 @@ export function HighlightRulesSelector(
     const VariantForbiddenRegexSelector = () => {
       if (variant === Variant.TYPED) {
         // Removes the part of the regex that highlights singular |, since Typed variant uses union types
-        return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)*&(?!&)/
+        return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)&(?!&)/
       }
-      return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)*&(?!&)|(?<!\|)\|(?!\|)/
+      return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)&(?!&)|(?<!\|)\|(?!\|)/
     }
 
     // @ts-ignore


### PR DESCRIPTION
### Description

When a single | or single & (not || or &&) is used, not as the final character in the line nor in a multiline comment (but a single line comment still has the bug), the syntax highlighting fails.

Starting from 
- the end of a single numeral literal at the start of the line o,
- or the latest occurrence of the character doubled (| => ||, & => &&),
- otherwise the start of the line,

it highlights the entire line up to the | and one character after in pink, the colour used for `new` and `with`.

Characters past one after the single | or & would be highlighted normally even if they are part of a comment.

We can observe this on the playground here: https://share.sourceacademy.nus.edu.sg/syntaxhighlightingbug

I identified the issue as a faulty regex here: https://github.com/source-academy/js-slang/blob/f6ea5712d578b02685120b484a2f3bbc3b78055a/src/editors/ace/modes/source.ts#L116-L118
The cases for '|' and '&' capture other parts of the string in the attempt to exclude '||' and '&&'.
This PR has a fix for this, using lookahead and lookbehind assertions.
This PR also includes a few lines in the test for this file to cover the case of '|'.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

I expanded the existing tests for this file to cover this change.
https://github.com/notmeegoreng/js-slang/blob/patch-1/src/__tests__/mode.ts#L82

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code
