### PR TITLE
Revert "Fix faulty regex for syntax highlighter"

### DIFF
--- a/src/__tests__/mode.ts
+++ b/src/__tests__/mode.ts
@@ -79,7 +79,7 @@ test('constants are not correctly loaded', () => {
 })
 
 test('operator syntax type error', () => {
-  const code = 'const num = 3; \nnum++; \nnum--; \nnum += 1; \n5 + num |2;'
+  const code = 'const num = 3; \nnum++; \nnum--; \nnum += 1;'
 
   setSession(Chapter.SOURCE_1, defaultVariant, defaultExternal, code)
 
@@ -91,15 +91,6 @@ test('operator syntax type error', () => {
 
   const token3 = session.getTokenAt(3, 5)
   expect(expectedBool(token3, CATEGORY.forbidden)).toBe(true)
-
-  const token4 = session.getTokenAt(4, 1)
-  expect(expectedBool(token4, CATEGORY.number)).toBe(true)
-
-  const token5 = session.getTokenAt(4, 9)
-  expect(expectedBool(token5, CATEGORY.forbidden)).toBe(true)
-
-  const token6 = session.getTokenAt(4, 10)
-  expect(expectedBool(token6, CATEGORY.number)).toBe(true)
 })
 
 test('forbidden keywords', () => {

--- a/src/editors/ace/modes/source.ts
+++ b/src/editors/ace/modes/source.ts
@@ -113,9 +113,9 @@ export function HighlightRulesSelector(
     const VariantForbiddenRegexSelector = () => {
       if (variant === Variant.TYPED) {
         // Removes the part of the regex that highlights singular |, since Typed variant uses union types
-        return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)&(?!&)/
+        return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|[^&]*&[^&]/
       }
-      return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|(?<!&)&(?!&)|(?<!\|)\|(?!\|)/
+      return /\.{3}|--+|\+\++|\^|(==|!=)[^=]|[$%&*+\-~\/^]=+|[^&]*&[^&]|[^\|]*\|[^\|]/
     }
 
     // @ts-ignore


### PR DESCRIPTION
Reverts source-academy/js-slang#1723, accidentally merged, my apologies.