### PR TITLE
Fix for JSON imports not working

### DIFF
--- a/src/__tests__/mode.ts
+++ b/src/__tests__/mode.ts
@@ -22,9 +22,9 @@ const CATEGORY = {
   types: /\bstorage.type\b/,
   forbidden: /\bvariable.language\b/,
   keywords: /\bkeyword\b/,
+  consts: /\bbuiltinconsts\b/,
   number: /\bconstant.numeric\b/,
-  bool: /\bconstant.language.boolean\b/,
-  identifier: /\bidentifier\b/
+  bool: /\bconstant.language.boolean\b/
 }
 
 const setSession = (chapter: Chapter, variant: Variant, external: string, code: string): void => {
@@ -49,15 +49,15 @@ test('function token type error', () => {
   const token2 = session.getTokenAt(1, 3)
 
   // at source 2, pair is function but set_tail is not
-  expect(expectedBool(token1, CATEGORY.identifier)).toBe(true)
+  expect(expectedBool(token1, CATEGORY.functions)).toBe(true)
   expect(expectedBool(token2, CATEGORY.functions)).toBe(false)
 
   // at source 4, set_tail is function as well
   setSession(Chapter.SOURCE_4, defaultVariant, defaultExternal, code)
   const newToken1 = session.getTokenAt(0, 11)
   const newToken2 = session.getTokenAt(1, 3)
-  expect(expectedBool(newToken1, CATEGORY.identifier)).toBe(true)
-  expect(expectedBool(newToken2, CATEGORY.identifier)).toBe(true)
+  expect(expectedBool(newToken1, CATEGORY.functions)).toBe(true)
+  expect(expectedBool(newToken2, CATEGORY.functions)).toBe(true)
 })
 
 test('constants are not correctly loaded', () => {
@@ -72,7 +72,7 @@ test('constants are not correctly loaded', () => {
   expect(expectedBool(token2, CATEGORY.number)).toBe(true)
 
   const token3 = session.getTokenAt(2, 1)
-  expect(expectedBool(token3, CATEGORY.identifier)).toBe(true)
+  expect(expectedBool(token3, CATEGORY.consts)).toBe(true)
 })
 
 test('operator syntax type error', () => {

--- a/src/editors/ace/docTooltip/index.ts
+++ b/src/editors/ace/docTooltip/index.ts
@@ -1,27 +1,55 @@
-import ext_lib from './External libraries.json'
-import source_1 from './source_1.json'
-import source_1_typed from './source_1_typed.json'
-import source_2 from './source_2.json'
-import source_2_typed from './source_2_typed.json'
-import source_3 from './source_3.json'
-import source_3_concurrent from './source_3_concurrent.json'
-import source_3_typed from './source_3_typed.json'
-import source_4 from './source_4.json'
-import source_4_explicit_control from './source_4_explicit-control.json'
-import source_4_typed from './source_4_typed.json'
+import * as ext_lib from './External libraries.json'
+import * as source_1 from './source_1.json'
+import * as source_1_typed from './source_1_typed.json'
+import * as source_2 from './source_2.json'
+import * as source_2_typed from './source_2_typed.json'
+import * as source_3 from './source_3.json'
+import * as source_3_concurrent from './source_3_concurrent.json'
+import * as source_3_typed from './source_3_typed.json'
+import * as source_4 from './source_4.json'
+import * as source_4_typed from './source_4_typed.json'
+import * as source_4_explicit_control from './source_4_explicit-control.json'
+
+// (18 March 2022)
+// Problem to be fixed in the future:
+//
+// There seems to be an inconsistency between how jest and how typescript
+// behaves when encountering imports of the form `import * as x from 'x.json'`
+// jest will set x = jsonobject,
+// but typescript will instead set x = { default: jsonobject }
+//
+// This means that under typescript, we want `import x from 'x.json'`,
+// while under jest, we want `import * as x from 'x.json'`
+//
+// This problem was hidden when transpiling to CommonJS modules before, which
+// behaves similarly to jest. But now that we are transpiling to es6,
+// typescript projects that depend on js-slang may now be exposed to this
+// inconsistency.
+//
+// For now, we use brute force until the landscape changes or someone thinks of
+// a proper solution.
+function resolveImportInconsistency(json: any) {
+  // `json` doesn't inherit from `Object`?
+  // Can't use hasOwnProperty for some reason.
+  if ('default' in json) {
+    return json.default
+  } else {
+    return json
+  }
+}
 
 export const SourceDocumentation = {
   builtins: {
-    '1': source_1,
-    '1_typed': source_1_typed,
-    '2': source_2,
-    '2_typed': source_2_typed,
-    '3': source_3,
-    '3_concurrent': source_3_concurrent,
-    '3_typed': source_3_typed,
-    '4': source_4,
-    '4_typed': source_4_typed,
-    '4_explicit-control': source_4_explicit_control
+    '1': resolveImportInconsistency(source_1),
+    '1_typed': resolveImportInconsistency(source_1_typed),
+    '2': resolveImportInconsistency(source_2),
+    '2_typed': resolveImportInconsistency(source_2_typed),
+    '3': resolveImportInconsistency(source_3),
+    '3_concurrent': resolveImportInconsistency(source_3_concurrent),
+    '3_typed': resolveImportInconsistency(source_3_typed),
+    '4': resolveImportInconsistency(source_4),
+    '4_typed': resolveImportInconsistency(source_4_typed),
+    '4_explicit-control': resolveImportInconsistency(source_4_explicit_control)
   },
   ext_lib
-} as const
+}


### PR DESCRIPTION
### Description

As per the original comment in the commit 80341a9, the 3 year long issue still holds right now as described by the comment itself. It appears that the compiled version (using `yarn build`) will append the `default` key to the imported JSON files, which does not exist and hence giving an error when used by other project (i.e. frontend). However, it does work correctly in testing/jest which appears to use `ts-jest` instead to transpile the typescript files.

This PR reverts the commit added here: https://github.com/source-academy/js-slang/pull/1741/commits/bca24234e63eccb3413f8185d154981cf95e74de

Some other possible fixes for this that can be considered (but more testing and discussion required):
1. Not using a JSON file (could be in a ts file instead, but since it is autogenerated there would be more steps to properly transform this)
2. Standardising the build procedure to be same as Jest (would be complicated to switch to a different packaging tool entirely)
3. Making jest use `tsc` instead of `ts-jest` (mentioned briefly on the jest docs, but this may affect coverage reporting/results)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have tested this code

