### PR TITLE
Line num range error

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -113,7 +113,9 @@ test('Simple arrow function infinite recursion represents CallExpression well', 
 */
 
 test('Simple function infinite recursion represents CallExpression well', () => {
-  return expectParsedError('function f(x) {return x(x)(x);} f(f);').toMatchInlineSnapshot(`"Line 1: RangeError: Maximum call stack size exceeded"`)
+  return expectParsedError('function f(x) {return x(x)(x);} f(f);').toMatchInlineSnapshot(
+    `"Line 1: RangeError: Maximum call stack size exceeded"`
+  )
 }, 30000)
 
 test('Cannot overwrite consts even when assignment is allowed', () => {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -113,9 +113,7 @@ test('Simple arrow function infinite recursion represents CallExpression well', 
 */
 
 test('Simple function infinite recursion represents CallExpression well', () => {
-  return expectParsedError('function f(x) {return x(x)(x);} f(f);').toMatchInlineSnapshot(
-    `"RangeError: Maximum call stack size exceeded"`
-  )
+  return expectParsedError('function f(x) {return x(x)(x);} f(f);').toMatchInlineSnapshot(`"Line 1: RangeError: Maximum call stack size exceeded"`)
 }, 30000)
 
 test('Cannot overwrite consts even when assignment is allowed', () => {


### PR DESCRIPTION
Fixes an issue that crept up recently: local testing and CI were inconsistent: local tests passed, but CI tripped up. This seems to be fixed. Maybe there was an update in some library? In any case: This seems ok now, with this fix.