### PR TITLE
Fix Source Academy REPL

### DIFF
--- a/src/repl/index.ts
+++ b/src/repl/index.ts
@@ -1,4 +1,4 @@
-#!/bin/env/node
+#!/usr/bin/env node
 import { getMainCommand } from './main'
 
 getMainCommand().parseAsync()


### PR DESCRIPTION
### Description

The current version of js-slang is not usable as a command line tool due to a malformed shebang. This is the first of several fixes to investigate the stability of js-slang as a headless tool

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### How to test

- build `js-slang`
- attempt to run it as a CLI tool

### Checklist

- [X] I have tested this code
