### PR TITLE
Add auto-publish workflow for npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,94 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Verify NPM_TOKEN is available
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_TOKEN secret is not reachable from this repo."
+            echo "If it is set as an organization secret, confirm this repo is in its allowed-repos list."
+            exit 1
+          fi
+          echo "NPM_TOKEN is present."
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Read package.json version
+        id: pkg
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "package.json version: $VERSION"
+
+      - name: Check whether version is already on npm
+        id: check
+        run: |
+          PUBLISHED=$(npm view js-slang@${{ steps.pkg.outputs.version }} version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "js-slang@${{ steps.pkg.outputs.version }} is already published — nothing to do."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "js-slang@${{ steps.pkg.outputs.version }} is not yet on npm — will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install system dependencies for docs
+        if: steps.check.outputs.should_publish == 'true'
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y --no-install-recommends \
+          texlive texlive-fonts-extra texlive-lang-cjk latexmk latex-cjk-all
+
+      - name: Enable corepack for Yarn
+        if: steps.check.outputs.should_publish == 'true'
+        run: corepack enable
+
+      - name: Setup Node
+        if: steps.check.outputs.should_publish == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        if: steps.check.outputs.should_publish == 'true'
+        run: yarn install --immutable
+
+      - name: Build
+        if: steps.check.outputs.should_publish == 'true'
+        run: yarn build
+
+      - name: Publish to npm
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag the release
+        if: steps.check.outputs.should_publish == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          TAG="v${{ steps.pkg.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally — skipping."
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` that auto-publishes `js-slang` to npm when `package.json` version changes on `master`.
- On every push to `master`, it reads the version from `package.json` and asks npm whether `js-slang@<version>` already exists. If yes, it exits cleanly; if no, it builds and publishes.
- After a successful publish, it pushes a `v<version>` tag so git tags track released versions.
- Fails fast with a clear message if `NPM_TOKEN` is not reachable from this repo (useful the first time we run it, since the token lives at the org level and needs the repo in its allowed-repos list).

## How releasing works after this
1. Bump `package.json` version in a PR (same flow as the existing `bumping version` commits).
2. Merge to `master`.
3. The workflow publishes to npm and pushes the matching tag. No manual `npm publish` needed.

If a push to `master` does not bump the version, the workflow is a no-op — duplicate version detection is based on what is already on npm, so re-running is safe.

## Notes
- `NODE_AUTH_TOKEN` is wired via `actions/setup-node`'s `registry-url` — the standard pattern for npm publishes from Actions.
- `permissions: contents: write` is scoped to this workflow so it can push the release tag.
- No changes to the existing `nodejs.yml` CI; that still runs on every PR and push and continues to gate merges.

## Test plan
- [ ] First push to `master` after merge: confirm the `Verify NPM_TOKEN is available` step passes (i.e. the org secret is scoped to this repo). If it fails, add `js-slang` to the org secret's allowed repos.
- [ ] Next version bump (1.0.93): confirm the workflow publishes to npm and that a `v1.0.93` tag appears on the repo.
- [ ] Subsequent unrelated push to `master` with no version change: confirm the workflow runs and exits cleanly without republishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)