### PR TITLE
Update dependency @types/estree to v1.0.9 (with type adaptations)

### DIFF
--- a/src/cse-machine/interpreter.ts
+++ b/src/cse-machine/interpreter.ts
@@ -24,6 +24,7 @@ import * as ast from '../utils/ast/astCreator';
 import {
   filterImportDeclarations,
   getSourceVariableDeclaration,
+  getSpecifierName,
   hasNoDeclarations,
   hasNoImportDeclarations,
 } from '../utils/ast/helpers';
@@ -237,7 +238,7 @@ function evaluateImports(program: es.Program, context: Context) {
 
           switch (spec.type) {
             case 'ImportSpecifier': {
-              obj = functions[spec.imported.name];
+              obj = functions[getSpecifierName(spec.imported)];
               break;
             }
             case 'ImportDefaultSpecifier': {

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -10,6 +10,7 @@ import type {
 } from 'estree';
 
 import type { Context, Node } from './types';
+import { getSpecifierName } from './utils/ast/helpers';
 import {
   ancestor,
   base,
@@ -90,7 +91,7 @@ export function findDeclarationNode(program: Node, identifier: Identifier): Node
         }
       },
       ImportSpecifier(node: ImportSpecifier, _state: any, _callback: WalkerCallback<any>) {
-        if (node.imported.name === identifier.name) {
+        if (getSpecifierName(node.imported) === identifier.name) {
           declarations.push(node.imported);
         }
       },

--- a/src/modules/preprocessor/analyzer.ts
+++ b/src/modules/preprocessor/analyzer.ts
@@ -7,6 +7,7 @@ import {
   getIdsFromDeclaration,
   getImportedName,
   getModuleDeclarationSource,
+  getSpecifierName,
 } from '../../utils/ast/helpers';
 import { isModuleDeclaration, isNamespaceSpecifier } from '../../utils/ast/typeGuards';
 import Dict, { ArrayMap } from '../../utils/dict';
@@ -87,7 +88,7 @@ export default function analyzeImportsAndExports(
         }
 
         for (const spec of node.specifiers) {
-          moduleDocs[sourceModule].add(spec.exported.name);
+          moduleDocs[sourceModule].add(getSpecifierName(spec.exported));
         }
 
         if (!node.source) continue;
@@ -103,7 +104,7 @@ export default function analyzeImportsAndExports(
           if (dstModuleDocs.size === 0) throw new UndefinedNamespaceImportError(dstModule, node);
 
           if (node.exported) {
-            moduleDocs[sourceModule].add(node.exported.name);
+            moduleDocs[sourceModule].add(getSpecifierName(node.exported));
           } else {
             for (const each of dstModuleDocs) {
               if (each === 'default') {

--- a/src/modules/preprocessor/constructors/contextSpecificConstructors.ts
+++ b/src/modules/preprocessor/constructors/contextSpecificConstructors.ts
@@ -2,6 +2,7 @@ import type es from 'estree';
 
 import { accessExportFunctionName } from '../../../stdlib/localImport.prelude';
 import * as create from '../../../utils/ast/astCreator';
+import { getSpecifierName } from '../../../utils/ast/helpers';
 
 /**
  * Constructs a call to the `pair` function.
@@ -78,7 +79,7 @@ export const cloneAndStripImportSpecifier = (
       return {
         type: 'ImportSpecifier',
         local: create.identifier(importSpecifier.local.name),
-        imported: create.identifier(importSpecifier.imported.name),
+        imported: create.identifier(getSpecifierName(importSpecifier.imported)),
       };
     case 'ImportDefaultSpecifier':
       return {

--- a/src/modules/preprocessor/transformers/hoistAndMergeImports.ts
+++ b/src/modules/preprocessor/transformers/hoistAndMergeImports.ts
@@ -2,7 +2,7 @@ import type es from 'estree';
 import { partition } from 'lodash';
 
 import * as create from '../../../utils/ast/astCreator';
-import { getModuleDeclarationSource } from '../../../utils/ast/helpers';
+import { getModuleDeclarationSource, getSpecifierName } from '../../../utils/ast/helpers';
 import { isImportDeclaration } from '../../../utils/ast/typeGuards';
 import Dict from '../../../utils/dict';
 import { isSourceModule } from '../../utils';
@@ -47,7 +47,7 @@ export default function hoistAndMergeImports(program: es.Program) {
           break;
         }
         case 'ImportSpecifier': {
-          const importedName = spec.imported.name;
+          const importedName = getSpecifierName(spec.imported);
           regularSpecifiers.setdefault(importedName, new Set()).add(declaredName);
           break;
         }

--- a/src/modules/preprocessor/transformers/transformProgramToFunctionDeclaration.ts
+++ b/src/modules/preprocessor/transformers/transformProgramToFunctionDeclaration.ts
@@ -4,7 +4,7 @@ import type es from 'estree';
 import { defaultExportLookupName } from '../../../stdlib/localImport.prelude';
 import assert from '../../../utils/assert';
 import * as create from '../../../utils/ast/astCreator';
-import { getModuleDeclarationSource } from '../../../utils/ast/helpers';
+import { getModuleDeclarationSource, getSpecifierName } from '../../../utils/ast/helpers';
 import {
   isDeclaration,
   isDirective,
@@ -130,8 +130,10 @@ const getExportedNameToIdentifierMap = (
       // Exported names can be renamed using the 'as' keyword. As such, the
       // exported names and their corresponding identifiers might be different.
       node.specifiers.forEach((node: es.ExportSpecifier): void => {
-        const exportedName = node.exported.name;
-        const identifier = node.local;
+        const exportedName = getSpecifierName(node.exported);
+        // Source only supports identifier locals (string-literal re-exports are
+        // not part of the language), so this is always an Identifier.
+        const identifier = node.local as es.Identifier;
         exportedNameToIdentifierMap[exportedName] = identifier;
       });
     }
@@ -200,7 +202,7 @@ export const createAccessImportStatements = (
           importDeclaration = createImportedNameDeclaration(
             invokedFunctionResultVariableName,
             importSpecifier.local,
-            importSpecifier.imported.name,
+            getSpecifierName(importSpecifier.imported),
           );
           break;
         case 'ImportDefaultSpecifier':

--- a/src/parser/source/rules/noExportNamedDeclarationWithDefault.ts
+++ b/src/parser/source/rules/noExportNamedDeclarationWithDefault.ts
@@ -1,5 +1,6 @@
 import type { ExportNamedDeclaration } from 'estree';
 import { defaultExportLookupName } from '../../../stdlib/localImport.prelude';
+import { getSpecifierName } from '../../../utils/ast/helpers';
 import { mapAndFilter } from '../../../utils/misc';
 import { RuleError } from '../../errors';
 import { defineRule } from '../../types';
@@ -20,7 +21,7 @@ export default defineRule(
   {
     ExportNamedDeclaration(node) {
       return mapAndFilter(node.specifiers, specifier =>
-        specifier.exported.name === defaultExportLookupName
+        getSpecifierName(specifier.exported) === defaultExportLookupName
           ? new NoExportNamedDeclarationWithDefaultError(node)
           : undefined,
       );

--- a/src/parser/source/rules/noExportNamedDeclarationWithSource.ts
+++ b/src/parser/source/rules/noExportNamedDeclarationWithSource.ts
@@ -1,5 +1,5 @@
 import type { ExportNamedDeclaration } from 'estree';
-import { specifierToString } from '../../../utils/ast/helpers';
+import { getSpecifierName, specifierToString } from '../../../utils/ast/helpers';
 import { RuleError } from '../../errors';
 import { defineRule } from '../../types';
 
@@ -11,7 +11,7 @@ export class NoExportNamedDeclarationWithSourceError extends RuleError<ExportNam
   public override elaborate() {
     const [imports, exps] = this.node.specifiers.reduce(
       ([ins, outs], spec) => [
-        [...ins, spec.local.name],
+        [...ins, getSpecifierName(spec.local)],
         [...outs, specifierToString(spec)],
       ],
       [[], []] as [string[], string[]],

--- a/src/parser/source/rules/noImportSpecifierWithDefault.ts
+++ b/src/parser/source/rules/noImportSpecifierWithDefault.ts
@@ -1,5 +1,6 @@
 import type { ImportSpecifier } from 'estree';
 import { defaultExportLookupName } from '../../../stdlib/localImport.prelude';
+import { getSpecifierName } from '../../../utils/ast/helpers';
 import { RuleError } from '../../errors';
 import { defineRule } from '../../types';
 import syntaxBlacklist from '../syntax';
@@ -18,7 +19,7 @@ export default defineRule(
   'no-import-with-default',
   {
     ImportSpecifier(node) {
-      if (node.imported.name === defaultExportLookupName) {
+      if (getSpecifierName(node.imported) === defaultExportLookupName) {
         return [new NoImportSpecifierWithDefaultError(node)];
       }
       return [];

--- a/src/stdlib/parser.ts
+++ b/src/stdlib/parser.ts
@@ -4,7 +4,7 @@ import { parse as sourceParse } from '../parser/parser';
 import { SourceParser } from '../parser/source';
 import { libraryParserLanguage } from '../parser/source/syntax';
 import type { Context, ContiguousArrayElements, Node, NodeTypeToNode, Value } from '../types';
-import { getSourceVariableDeclaration } from '../utils/ast/helpers';
+import { getSourceVariableDeclaration, getSpecifierName } from '../utils/ast/helpers';
 import { isDeclaration } from '../utils/ast/typeGuards';
 import { oneLine } from '../utils/formatters';
 import { RuntimeSourceError } from '../errors/base';
@@ -135,7 +135,7 @@ const transformers: ASTTransformers = {
       declaration ? this.transform(declaration) : specifiers.map(this.transform),
     ]);
   },
-  ExportSpecifier: node => vector_to_list(['name', node.exported.name]),
+  ExportSpecifier: node => vector_to_list(['name', getSpecifierName(node.exported)]),
   ExpressionStatement({ expression }) {
     return this.transform(expression);
   },
@@ -180,7 +180,7 @@ const transformers: ASTTransformers = {
     ]);
   },
   ImportDefaultSpecifier: () => vector_to_list(['default']),
-  ImportSpecifier: node => vector_to_list(['name', node.imported.name]),
+  ImportSpecifier: node => vector_to_list(['name', getSpecifierName(node.imported)]),
   Literal: ({ value }) => vector_to_list(['literal', value]),
   LogicalExpression(node) {
     return vector_to_list([

--- a/src/stepper/nodes/Expression/BinaryExpression.ts
+++ b/src/stepper/nodes/Expression/BinaryExpression.ts
@@ -1,4 +1,4 @@
-import type { BinaryExpression, BinaryOperator, Comment, SourceLocation } from 'estree';
+import type { BinaryExpression, BinaryOperator, Comment, Expression, SourceLocation } from 'estree';
 import type { StepperExpression, StepperPattern } from '..';
 import { convert } from '../../generator';
 import { StepperBaseNode } from '../../interface';
@@ -28,7 +28,9 @@ export class StepperBinaryExpression
   static create(node: BinaryExpression) {
     return new StepperBinaryExpression(
       node.operator,
-      convert(node.left),
+      // `left` is `Expression | PrivateIdentifier`; private-in expressions are
+      // not valid in Source, so the operand is always an Expression.
+      convert(node.left as Expression),
       convert(node.right),
       node.leadingComments,
       node.trailingComments,

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -293,7 +293,9 @@ function transformUnaryAndBinaryOperationsToFunctionCalls(
       create.mutateToCallExpression(node, globalIds.binaryOp, [
         create.literal(operator),
         create.literal(chapter),
-        left,
+        // `left` is `Expression | PrivateIdentifier`; private-in expressions are
+        // not valid in Source, so the operand is always an Expression.
+        left as es.Expression,
         right,
         create.literal(line),
         create.literal(column),

--- a/src/utils/ast/astCreator.ts
+++ b/src/utils/ast/astCreator.ts
@@ -24,6 +24,7 @@ export const importDeclaration = (
   type: 'ImportDeclaration',
   source: literal(source),
   specifiers,
+  attributes: [],
   loc,
 });
 

--- a/src/utils/ast/helpers.ts
+++ b/src/utils/ast/helpers.ts
@@ -101,6 +101,14 @@ export function getSourceVariableDeclaration(decl: es.VariableDeclaration) {
   };
 }
 
+/**
+ * Get the name of an import/export specifier endpoint. ES2022 allows these to be
+ * string literals (e.g. `export { x as "y" }`); Source only supports identifier
+ * names, so fall back to the literal's stringified value.
+ */
+export const getSpecifierName = (node: es.Identifier | es.Literal): string =>
+  node.type === 'Identifier' ? node.name : `${node.value}`;
+
 export const getImportedName = (
   spec: es.ImportSpecifier | es.ImportDefaultSpecifier | es.ExportSpecifier,
 ) => {
@@ -108,9 +116,9 @@ export const getImportedName = (
     case 'ImportDefaultSpecifier':
       return 'default';
     case 'ImportSpecifier':
-      return spec.imported.name;
+      return getSpecifierName(spec.imported);
     case 'ExportSpecifier':
-      return spec.local.name;
+      return getSpecifierName(spec.local);
   }
 };
 
@@ -119,18 +127,18 @@ export const specifierToString = (
 ) => {
   switch (spec.type) {
     case 'ImportSpecifier': {
-      if (spec.imported.name === spec.local.name) {
-        return spec.imported.name;
+      if (getSpecifierName(spec.imported) === spec.local.name) {
+        return getSpecifierName(spec.imported);
       }
-      return `${spec.imported.name} as ${spec.local.name}`;
+      return `${getSpecifierName(spec.imported)} as ${spec.local.name}`;
     }
     case 'ImportDefaultSpecifier':
       return `default as ${spec.local.name}`;
     case 'ExportSpecifier': {
-      if (spec.local.name === spec.exported.name) {
-        return spec.local.name;
+      if (getSpecifierName(spec.local) === getSpecifierName(spec.exported)) {
+        return getSpecifierName(spec.local);
       }
-      return `${spec.local.name} as ${spec.exported.name}`;
+      return `${getSpecifierName(spec.local)} as ${getSpecifierName(spec.exported)}`;
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,17 +722,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
-  version: 1.0.8
-  resolution: "@types/estree@npm:1.0.8"
-  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@types/estree@npm:1.0.5"
-  checksum: 10c0/b3b0e334288ddb407c7b3357ca67dbee75ee22db242ca7c56fe27db4e1a31989cb8af48a84dd401deb787fe10cc6b2ab1ee82dc4783be87ededbe3d53c79c70d
+"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates `@types/estree` to **1.0.9**. Unlike a normal Renovate lockfile bump, this version's updated ESTree types model newer ECMAScript constructs, which broke compilation in 28 places. This PR includes the source adaptations so the build passes.

### Changes
- **Import/export specifier endpoints are now `Identifier | Literal`** — ES2022 allows arbitrary module namespace names (e.g. `export { x as "y" }`). Added a `getSpecifierName` helper in `utils/ast/helpers.ts` and routed `.name` accesses through it. Source only supports identifier names, so it falls back to the literal's value.
- **`ImportDeclaration` now requires `attributes`** (import attributes) — set to `[]` in the `importDeclaration` AST constructor.
- **`BinaryExpression.left` is now `Expression | PrivateIdentifier`** (private-in expressions) — narrowed with casts in the transpiler and stepper, since private fields are not valid in Source.

### Verification
- `yarn build` passes (0 type errors)
- eslint clean on changed files
- 885 tests pass across preprocessor / transpiler / stepper / stdlib / parser / cse-machine / finder / utils-ast

### Note
Supersedes the lockfile-only Renovate PR #1766, which fails CI on its own because it lacks these source changes. That PR can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)