### PR TITLE
Docs deploy: keep_files instead of force_orphan

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,5 +38,8 @@ jobs:
           publish_dir: docs/source
           external_repository: source-academy/docs.sourceacademy.org
           publish_branch: master
-          force_orphan: true
+          # Do not wipe the branch: keep files published by other sources
+          # (e.g. py-slang's Python docs under /python). Previously this used
+          # force_orphan: true, which replaced the whole branch on every deploy.
+          keep_files: true
           cname: docs.sourceacademy.org


### PR DESCRIPTION
## What

Change the docs deploy step to use \`keep_files: true\` instead of \`force_orphan: true\` when publishing to the \`master\` branch of \`source-academy/docs.sourceacademy.org\`.

## Why

\`force_orphan: true\` replaces the **entire** \`master\` branch on every deploy, so anything published there by another source is wiped. We want the Python docs generated by [py-slang](https://github.com/source-academy/py-slang) to live alongside the Source docs at \`docs.sourceacademy.org/python/\`.

With \`keep_files: true\`:
- The Source docs are still written to the branch root, exactly as before (same URLs, same content).
- The \`/python\` subfolder (published by py-slang) is left intact across js-slang deploys.

This is the js-slang half of the change; the companion PR is [source-academy/py-slang#deploy-docs-to-python-subfolder](https://github.com/source-academy/py-slang/pull/new/deploy-docs-to-python-subfolder), which switches py-slang to publish into \`master/python/\`.

## Trade-off

Without \`force_orphan\`, deleted/renamed Source doc files are no longer auto-pruned from the branch (they linger until overwritten). This is an accepted cost for keeping both doc sets on one branch.